### PR TITLE
Reviewer Ellie: Fixes for when no HSS is configured.

### DIFF
--- a/include/handlers.h
+++ b/include/handlers.h
@@ -305,7 +305,8 @@ class ImpuIMSSubscriptionHandler : public HssCacheHandler
 public:
   struct Config
   {
-    Config(int _ims_sub_cache_ttl = 3600) : ims_sub_cache_ttl(_ims_sub_cache_ttl) {}
+    Config(bool _hss_configured = true, int _ims_sub_cache_ttl = 3600) : hss_configured(_hss_configured), ims_sub_cache_ttl(_ims_sub_cache_ttl) {}
+    bool hss_configured;
     int ims_sub_cache_ttl;
   };
 

--- a/src/handlers.cpp
+++ b/src/handlers.cpp
@@ -127,15 +127,8 @@ void ImpiHandler::on_get_av_success(Cache::Request* request)
 
 void ImpiHandler::on_get_av_failure(Cache::Request* request, Cache::ResultCode error, std::string& text)
 {
-  if (error == Cache::NOT_FOUND)
-  {
-    get_av();
-  }
-  else
-  {
-    _req.send_reply(502);
-    delete this;
-  }
+  _req.send_reply(502);
+  delete this;
 }
 
 void ImpiHandler::get_av()
@@ -596,7 +589,7 @@ void ImpuIMSSubscriptionHandler::on_get_ims_subscription_success(Cache::Request*
 
 void ImpuIMSSubscriptionHandler::on_get_ims_subscription_failure(Cache::Request* request, Cache::ResultCode error, std::string& text)
 {
-  if (error == Cache::NOT_FOUND)
+  if ((error == Cache::NOT_FOUND) && (_cfg->hss_configured))
   {
     Cx::ServerAssignmentRequest* sar =
       new Cx::ServerAssignmentRequest(_dict,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -285,7 +285,7 @@ int main(int argc, char**argv)
   ImpiHandler::Config impi_handler_config(hss_configured, options.impu_cache_ttl);
   ImpiRegistrationStatusHandler::Config registration_status_handler_config(hss_configured);
   ImpuLocationInfoHandler::Config location_info_handler_config(hss_configured);
-  ImpuIMSSubscriptionHandler::Config impu_handler_config(options.ims_sub_cache_ttl);
+  ImpuIMSSubscriptionHandler::Config impu_handler_config(hss_configured, options.ims_sub_cache_ttl);
   HttpStack::HandlerFactory<PingHandler> ping_handler_factory;
   HttpStack::ConfiguredHandlerFactory<ImpiDigestHandler, ImpiHandler::Config> impi_digest_handler_factory(&impi_handler_config);
   HttpStack::ConfiguredHandlerFactory<ImpiAvHandler, ImpiHandler::Config> impi_av_handler_factory(&impi_handler_config);


### PR DESCRIPTION
Plumb through hss_configured option to the IMS Subscription handler, so that we don't send SARs when we don't have an HSS.

In other news, we only query the AV cache when we don't have an HSS configured. Previously, we were then trying to send an MAR to the HSS by calling get_av() if the cache didn't return an AV. This obviously wasn't working.
