### PR TITLE
[Reviewer: Rob] Implement hss_mar_lowercase_unknown interop function

### DIFF
--- a/debian/homestead.init.d
+++ b/debian/homestead.init.d
@@ -101,6 +101,8 @@ get_settings()
             [ -r $file ] && . $file
           done
         fi
+
+        [ "$hss_mar_lowercase_unknown" != "Y" ] || scheme_unknown_arg="--scheme-unknown unknown"
 }
 
 #
@@ -131,6 +133,7 @@ do_start()
                      --server-name sip:$sprout_hostname:5054
                      --impu-cache-ttl $impu_cache_ttl 
                      --ims-sub-cache-ttl $ims_sub_cache_ttl
+                     $scheme_unknown_arg
                      -a $log_directory
                      -F $log_directory
                      -L $log_level"

--- a/include/handlers.h
+++ b/include/handlers.h
@@ -197,9 +197,22 @@ class ImpiHandler : public HssCacheHandler
 public:
   struct Config
   {
-    Config(bool _hss_configured = true, int _impu_cache_ttl = 0) : query_cache_av(!_hss_configured), impu_cache_ttl(_impu_cache_ttl) {}
+    Config(bool _hss_configured = true,
+           int _impu_cache_ttl = 0,
+           std::string _scheme_unknown = "Unknown",
+           std::string _scheme_digest = "SIP Digest",
+           std::string _scheme_aka = "Digest-AKAv1-MD5") :
+    query_cache_av(!_hss_configured),
+    impu_cache_ttl(_impu_cache_ttl),
+    scheme_unknown(_scheme_unknown),
+    scheme_digest(_scheme_digest),
+    scheme_aka(_scheme_aka) {}
+
     bool query_cache_av;
     int impu_cache_ttl;
+    std::string scheme_unknown;
+    std::string scheme_digest;
+    std::string scheme_aka;
   };
 
   ImpiHandler(HttpStack::Request& req, const Config* cfg) :
@@ -223,10 +236,6 @@ public:
   typedef HssCacheHandler::DiameterTransaction<ImpiHandler> DiameterTransaction;
 
 protected:
-  static const std::string SCHEME_UNKNOWN;
-  static const std::string SCHEME_SIP_DIGEST;
-  static const std::string SCHEME_DIGEST_AKAV1_MD5;
-
   const Config* _cfg;
   std::string _impi;
   std::string _impu;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -57,6 +57,9 @@ struct options
   std::string server_name;
   int impu_cache_ttl;
   int ims_sub_cache_ttl;
+  std::string scheme_unknown;
+  std::string scheme_digest;
+  std::string scheme_aka;
   bool access_log_enabled;
   std::string access_log_directory;
   bool log_to_file;
@@ -79,6 +82,12 @@ void usage(void)
        "                            IMPU cache time-to-live in seconds (default: 0)\n"
        " -I, --ims-sub-cache-ttl <secs>\n"
        "                            IMS subscription cache time-to-live in seconds (default: 0)\n"
+       "     --scheme-unknown <string>\n"
+       "                            String to use to specify unknown SIP-Auth-Scheme (default: Unknown)\n"
+       "     --scheme-digest <string>\n"
+       "                            String to use to specify digest SIP-Auth-Scheme (default: SIP Digest)\n"
+       "     --scheme-aka <string>\n"
+       "                            String to use to specify AKA SIP-Auth-Scheme (default: Digest-AKAv1-MD5)\n"
        " -a, --access-log <directory>\n"
        "                            Generate access logs in specified directory\n"
        " -F, --log-file <directory>\n"
@@ -87,6 +96,14 @@ void usage(void)
        " -d, --daemon               Run as daemon\n"
        " -h, --help                 Show this help screen\n");
 }
+
+// Enum for option types not assigned short-forms
+enum OptionTypes
+{
+  SCHEME_UNKNOWN = 128, // start after the ASCII set ends to avoid conflicts
+  SCHEME_DIGEST,
+  SCHEME_AKA
+};
 
 int init_options(int argc, char**argv, struct options& options)
 {
@@ -100,6 +117,9 @@ int init_options(int argc, char**argv, struct options& options)
     {"server-name",       required_argument, NULL, 's'},
     {"impu-cache-ttl",    required_argument, NULL, 'i'},
     {"ims-sub-cache-ttl", required_argument, NULL, 'I'},
+    {"scheme-unknown",    required_argument, NULL, SCHEME_UNKNOWN},
+    {"scheme-digest",     required_argument, NULL, SCHEME_DIGEST},
+    {"scheme-aka",        required_argument, NULL, SCHEME_AKA},
     {"access-log",        required_argument, NULL, 'a'},
     {"log-file",          required_argument, NULL, 'F'},
     {"log-level",         required_argument, NULL, 'L'},
@@ -144,6 +164,18 @@ int init_options(int argc, char**argv, struct options& options)
 
     case 'I':
       options.ims_sub_cache_ttl = atoi(optarg);
+      break;
+
+    case SCHEME_UNKNOWN:
+      options.scheme_unknown = std::string(optarg);
+      break;
+
+    case SCHEME_DIGEST:
+      options.scheme_digest = std::string(optarg);
+      break;
+
+    case SCHEME_AKA:
+      options.scheme_aka = std::string(optarg);
       break;
 
     case 'a':
@@ -212,6 +244,9 @@ int main(int argc, char**argv)
   options.dest_realm = "dest-realm.unknown";
   options.dest_host = "dest-host.unknown";
   options.server_name = "sip:server-name.unknown";
+  options.scheme_unknown = "Unknown";
+  options.scheme_digest = "SIP Digest";
+  options.scheme_aka = "Digest-AKAv1-MD5";
   options.access_log_enabled = false;
   options.impu_cache_ttl = 0;
   options.ims_sub_cache_ttl = 0;
@@ -295,7 +330,11 @@ int main(int argc, char**argv)
   // should always hit it.  If there is not, the AV information must have been provisioned in the
   // "cache" (which becomes persistent).
   bool hss_configured = !(options.dest_host.empty() || (options.dest_host == "0.0.0.0"));
-  ImpiHandler::Config impi_handler_config(hss_configured, options.impu_cache_ttl);
+  ImpiHandler::Config impi_handler_config(hss_configured,
+                                          options.impu_cache_ttl,
+                                          options.scheme_unknown,
+                                          options.scheme_digest,
+                                          options.scheme_aka);
   ImpiRegistrationStatusHandler::Config registration_status_handler_config(hss_configured);
   ImpuLocationInfoHandler::Config location_info_handler_config(hss_configured);
   ImpuIMSSubscriptionHandler::Config impu_handler_config(hss_configured, options.ims_sub_cache_ttl);


### PR DESCRIPTION
Rob,

Please can you review my fix to new homestead to implement the hss_mar_lowercase_unknown interop function that was provided by the old homestead?  I've tested this live and confirmed that UTs still run, but not added any new UT because main.cpp isn't UT-ed.

Thanks,

Matt
