### PR TITLE
[Reviewer: Ellie] Track code coverage for cpp-common too

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -107,8 +107,8 @@ GTEST_SRCS_ := $(GTEST_DIR)/src/*.cc $(GTEST_DIR)/src/*.h $(GTEST_HEADERS)
 GMOCK_SRCS_ := $(GMOCK_DIR)/src/*.cc $(GMOCK_HEADERS)
 # End of boilerplate
 
-COVERAGEFLAGS = $(OBJ_DIR_TEST) --object-directory=$(shell pwd) \
-                --root=$(shell pwd) --exclude=^ut/ \
+COVERAGEFLAGS = $(OBJ_DIR_TEST) --object-directory=$(shell pwd) --root=${ROOT} \
+                --exclude='(^include/|^modules/gmock/|^modules/rapidjson/|^modules/cpp-common/include/|^src/ut/|^usr/)' \
                 --sort-percentage --exclude-lines
 
 VGFLAGS = --suppressions=$(VG_SUPPRESS) \


### PR DESCRIPTION
Ellie,

Please can you review my change to track code coverage for cpp-common?

The key change is to set the root to the root of the code tree and then exclude those modules that we don't want to track.

If you're happy with this, I'll apply the same change to sprout.

Thanks,

Matt
