### PR TITLE
[Reviewer: Matt] Honour /etc/clearwater/config settings for Sprout's S-CSCF port

### DIFF
--- a/debian/homestead.init.d
+++ b/debian/homestead.init.d
@@ -84,6 +84,7 @@ get_settings()
         sas_server=0.0.0.0
         hss_hostname=0.0.0.0
         hss_port=3868
+        scscf=5054
         . /etc/clearwater/config
 
         # Set up defaults for user settings then pull in any overrides.
@@ -130,8 +131,8 @@ do_start()
                      --http-threads $num_http_threads
                      --dest-realm $home_domain
                      --dest-host $hss_hostname
-                     --server-name sip:$sprout_hostname:5054
-                     --impu-cache-ttl $impu_cache_ttl 
+                     --server-name sip:$sprout_hostname:$scscf
+                     --impu-cache-ttl $impu_cache_ttl
                      --ims-sub-cache-ttl $ims_sub_cache_ttl
                      $scheme_unknown_arg
                      -a $log_directory


### PR DESCRIPTION
Matt,

Sprout's S-CSCF port is configurable with "scscf=..." in .etc/clearwater/config (see https://github.com/Metaswitch/sprout/blob/dev/debian/sprout.init.d). However, Homestead's init.d file hardcodes 5054, and so may be incompatible.

This change keeps the default as 5054, but honours the scscf setting if it is different.
