### PR TITLE
Give homestead ownership of log directory when it already exists

### DIFF
--- a/debian/homestead.postinst
+++ b/debian/homestead.postinst
@@ -76,8 +76,8 @@ setup_user() {
 setup_logging() {
     if [ ! -d "$log_directory" ]; then
         mkdir -p $log_directory
-        chown $NAME $log_directory
     fi
+    chown $NAME $log_directory
 }
 
 case "$1" in


### PR DESCRIPTION
Matt,

Can you review this fix to the homestead log directory ownership? I'll open an issue for this in a minute (and close it again if this is fine).

I think this fix is needed for upgrade scenarios from old homestead. Old homestead did logging differently so didn't need ownership of the log directory. Does that sound right?

It feels like a fairly logical fix to me anyway.
