### PR TITLE
[Reviewer: Mike] Bracket IPv6 addresses in Server-Name field

### DIFF
--- a/debian/homestead.init.d
+++ b/debian/homestead.init.d
@@ -92,6 +92,8 @@ get_settings()
         log_level=2
         impu_cache_ttl=0
         ims_sub_cache_ttl=$((24 * 60 * 60))
+        server_name=sip:$(python /usr/share/clearwater/bin/bracket_ipv6_address.py $sprout_hostname):$scscf
+
         [ -r /etc/clearwater/user_settings ] && . /etc/clearwater/user_settings
 
         # Work out which features are enabled.
@@ -131,7 +133,7 @@ do_start()
                      --http-threads $num_http_threads
                      --dest-realm $home_domain
                      --dest-host $hss_hostname
-                     --server-name sip:$sprout_hostname:$scscf
+                     --server-name $server_name
                      --impu-cache-ttl $impu_cache_ttl
                      --ims-sub-cache-ttl $ims_sub_cache_ttl
                      $scheme_unknown_arg


### PR DESCRIPTION
Mike,

Please can you quickly review this fix to homestead to add square brackets around `$sprout hostname` if it contains an IPv6 address?  I've live-tested.

Thanks

Matt
