### PR TITLE
[Reviewer: Matt] Handle corrupt cert.pem or ca.pem files correctly

### DIFF
--- a/homestead.root/usr/share/clearwater/infrastructure/scripts/homestead
+++ b/homestead.root/usr/share/clearwater/infrastructure/scripts/homestead
@@ -65,10 +65,11 @@ then
     cert_current_name=$(certtool --certificate-info --infile /var/lib/homestead/cert.pem | egrep -e 'Subject: CN=' | sed 's/.*Subject: CN=//g')
     cert_issuer=$(certtool --certificate-info --infile /var/lib/homestead/cert.pem | egrep -e 'Issuer: CN=' | sed 's/.*Issuer: CN=//g')
 
-    if [ -f /var/lib/homestead/ca.pem ]
-    then
-        ca_name=$(certtool --certificate-info --infile /var/lib/homestead/ca.pem | egrep -e 'Subject: CN=' | sed 's/.*Subject: CN=//g')
-    fi
+fi
+
+if [ -f /var/lib/homestead/ca.pem ]
+then
+    ca_name=$(certtool --certificate-info --infile /var/lib/homestead/ca.pem | egrep -e 'Subject: CN=' | sed 's/.*Subject: CN=//g')
 fi
 
 if [ "$cert_current_name" != "$identity" ] ||


### PR DESCRIPTION
Mitigates https://github.com/Metaswitch/homestead/issues/73 - this fix means that just running the homestead script (or 'sudo service clearwater-infrastructure restart') will recover from invalid certificate files. However, I still don't know what corrupts them in the first place.

I've tested by:
- blanking both files
- blanking just cert.pem
- blanking just ca.pem
- removing both files

and ensuring that 'sudo service clearwater-infrastructure restart' regenerates both keys in each of the four cases.
