### PR TITLE
[Reviewer: Graeme] Add check for server-name in capabilities AVP

### DIFF
--- a/include/servercapabilities.h
+++ b/include/servercapabilities.h
@@ -51,10 +51,13 @@ const std::string JSON_OPT_CAP = "optional-capabilities";
 struct ServerCapabilities
 {
   inline ServerCapabilities(std::vector<int32_t> man_caps,
-                            std::vector<int32_t> opt_caps) : mandatory_capabilities(man_caps), optional_capabilities(opt_caps) {}
+                            std::vector<int32_t> opt_caps,
+                            std::string server_name)
+    : mandatory_capabilities(man_caps), optional_capabilities(opt_caps), server_name(server_name) {}
 
   std::vector<int32_t> mandatory_capabilities;
   std::vector<int32_t> optional_capabilities;
+  std::string server_name;
 
   // Write the server capabilities contained in this structure into a JSON object.
   // The 2 sets of capabilities are added in 2 arrays. If either set of capabilities

--- a/src/cx.cpp
+++ b/src/cx.cpp
@@ -158,6 +158,10 @@ UserAuthorizationAnswer::UserAuthorizationAnswer(const Dictionary* dict,
   }
 
   Diameter::AVP server_capabilities(dict->SERVER_CAPABILITIES);
+  if (!capabs.server_name.empty())
+  {
+    server_capabilities.add(Diameter::AVP(dict->SERVER_NAME).val_str(capabs.server_name));
+  }
   if (!capabs.mandatory_capabilities.empty())
   {
     for (std::vector<int32_t>::const_iterator it = capabs.mandatory_capabilities.begin();
@@ -181,7 +185,7 @@ UserAuthorizationAnswer::UserAuthorizationAnswer(const Dictionary* dict,
 
 ServerCapabilities UserAuthorizationAnswer::server_capabilities() const
 {
-  ServerCapabilities server_capabilities({}, {});
+  ServerCapabilities server_capabilities({}, {}, "");
 
   // Server capabilities are grouped into mandatory capabilities and optional capabilities
   // underneath the SERVER_CAPABILITIES AVP.
@@ -203,7 +207,14 @@ ServerCapabilities UserAuthorizationAnswer::server_capabilities() const
       server_capabilities.optional_capabilities.push_back(avps2->val_i32());
       avps2++;
     }
+    avps2 = avps->begin(((Cx::Dictionary*)dict())->SERVER_NAME);
+    if (avps2 != avps->end())
+    {
+      LOG_DEBUG("Found server name %s", avps2->val_str().c_str());
+      server_capabilities.server_name = avps2->val_str();
+    }
   }
+
   return server_capabilities;
 }
 
@@ -269,6 +280,12 @@ LocationInfoAnswer::LocationInfoAnswer(const Dictionary* dict,
   }
 
   Diameter::AVP server_capabilities(dict->SERVER_CAPABILITIES);
+
+  if (!capabs.server_name.empty())
+  {
+    server_capabilities.add(Diameter::AVP(dict->SERVER_NAME).val_str(capabs.server_name));
+  }
+
   if (!capabs.mandatory_capabilities.empty())
   {
     for (std::vector<int32_t>::const_iterator it = capabs.mandatory_capabilities.begin();
@@ -292,7 +309,7 @@ LocationInfoAnswer::LocationInfoAnswer(const Dictionary* dict,
 
 ServerCapabilities LocationInfoAnswer::server_capabilities() const
 {
-  ServerCapabilities server_capabilities({}, {});
+  ServerCapabilities server_capabilities({}, {}, "");
 
   // Server capabilities are grouped into mandatory capabilities and optional capabilities
   // underneath the SERVER_CAPABILITIES AVP.
@@ -314,7 +331,14 @@ ServerCapabilities LocationInfoAnswer::server_capabilities() const
       server_capabilities.optional_capabilities.push_back(avps2->val_i32());
       avps2++;
     }
+    avps2 = avps->begin(((Cx::Dictionary*)dict())->SERVER_NAME);
+    if (avps2 != avps->end())
+    {
+      LOG_DEBUG("Found server name %s", avps2->val_str().c_str());
+      server_capabilities.server_name = avps2->val_str();
+    }
   }
+
   return server_capabilities;
 }
 

--- a/src/handlers.cpp
+++ b/src/handlers.cpp
@@ -537,6 +537,14 @@ void ImpiRegistrationStatusHandler::on_uar_response(Diameter::Message& rsp)
     {
       LOG_DEBUG("Got Server-Capabilities");
       ServerCapabilities server_capabilities = uaa.server_capabilities();
+
+      if (!server_capabilities.server_name.empty())
+      {
+        LOG_DEBUG("Got Server-Name %s from Capabilities AVP", server_capabilities.server_name.c_str());
+        writer.String(JSON_SCSCF.c_str());
+        writer.String(server_capabilities.server_name.c_str());
+      }
+
       server_capabilities.write_capabilities(&writer);
     }
     writer.EndObject();
@@ -657,6 +665,14 @@ void ImpuLocationInfoHandler::on_lir_response(Diameter::Message& rsp)
     {
       LOG_DEBUG("Got Server-Capabilities");
       ServerCapabilities server_capabilities = lia.server_capabilities();
+
+      if (!server_capabilities.server_name.empty())
+      {
+        LOG_DEBUG("Got Server-Name %s from Capabilities AVP", server_capabilities.server_name.c_str());
+        writer.String(JSON_SCSCF.c_str());
+        writer.String(server_capabilities.server_name.c_str());
+      }
+
       server_capabilities.write_capabilities(&writer);
     }
     writer.EndObject();

--- a/src/ut/cx_test.cpp
+++ b/src/ut/cx_test.cpp
@@ -54,6 +54,7 @@ public:
   static const std::string IMPI;
   static const std::string IMPU;
   static const std::string SERVER_NAME;
+  static const std::string SERVER_NAME_IN_CAPAB;
   static const std::string SIP_AUTH_SCHEME_DIGEST;
   static const std::string SIP_AUTH_SCHEME_AKA;
   static const std::string SIP_AUTHORIZATION;
@@ -76,6 +77,7 @@ public:
   static std::vector<std::string> ASSOCIATED_IDENTITIES;
   static const ServerCapabilities CAPABILITIES;
   static const ServerCapabilities NO_CAPABILITIES;
+  static const ServerCapabilities CAPABILITIES_WITH_SERVER_NAME;
 
   static Diameter::Stack* _real_stack;
   static MockDiameterStack* _mock_stack;
@@ -175,6 +177,7 @@ const std::string CxTest::DEST_HOST = "dest-host";
 const std::string CxTest::IMPI = "impi@example.com";
 const std::string CxTest::IMPU = "sip:impu@example.com";
 const std::string CxTest::SERVER_NAME = "sip:example.com";
+const std::string CxTest::SERVER_NAME_IN_CAPAB = "sip:example2.com";
 const std::string CxTest::SIP_AUTH_SCHEME_DIGEST = "SIP Digest";
 const std::string CxTest::SIP_AUTH_SCHEME_AKA = "Digest-AKAv1-MD5";
 const std::string CxTest::SIP_AUTHORIZATION = "authorization";
@@ -198,8 +201,9 @@ std::vector<std::string> CxTest::ASSOCIATED_IDENTITIES {"associated_id1", "assoc
 const std::vector<int32_t> mandatory_capabilities = {1, 3};
 const std::vector<int32_t> optional_capabilities = {2, 4};
 const std::vector<int32_t> no_capabilities = {};
-const ServerCapabilities CxTest::CAPABILITIES(mandatory_capabilities, optional_capabilities);
-const ServerCapabilities CxTest::NO_CAPABILITIES(no_capabilities, no_capabilities);
+const ServerCapabilities CxTest::CAPABILITIES(mandatory_capabilities, optional_capabilities, EMPTY_STRING);
+const ServerCapabilities CxTest::NO_CAPABILITIES(no_capabilities, no_capabilities, EMPTY_STRING);
+const ServerCapabilities CxTest::CAPABILITIES_WITH_SERVER_NAME(no_capabilities, no_capabilities, SERVER_NAME_IN_CAPAB);
 
 Diameter::Stack* CxTest::_real_stack = NULL;
 MockDiameterStack* CxTest::_mock_stack = NULL;
@@ -532,6 +536,27 @@ TEST_F(CxTest, UAATestNoCapabilities)
             capabilities.optional_capabilities);
 }
 
+TEST_F(CxTest, UAATestCapabilitiesWithServerName)
+{
+  Cx::LocationInfoAnswer uaa(_cx_dict,
+                             _mock_stack,
+                             RESULT_CODE_SUCCESS,
+                             0,
+                             EMPTY_STRING,
+                             CAPABILITIES_WITH_SERVER_NAME);
+  launder_message(uaa);
+  EXPECT_TRUE(uaa.result_code(test_i32));
+  EXPECT_EQ(RESULT_CODE_SUCCESS, test_i32);
+  EXPECT_FALSE(uaa.experimental_result_code());
+  EXPECT_FALSE(uaa.server_name(test_str));
+  ServerCapabilities capabilities = uaa.server_capabilities();
+  EXPECT_EQ(SERVER_NAME_IN_CAPAB, capabilities.server_name);
+  EXPECT_EQ(CAPABILITIES_WITH_SERVER_NAME.mandatory_capabilities,
+            capabilities.mandatory_capabilities);
+  EXPECT_EQ(CAPABILITIES_WITH_SERVER_NAME.optional_capabilities,
+            capabilities.optional_capabilities);
+}
+
 //
 // Location Info Requests
 //
@@ -669,6 +694,27 @@ TEST_F(CxTest, LIATestNoCapabilities)
   EXPECT_EQ(NO_CAPABILITIES.mandatory_capabilities,
             capabilities.mandatory_capabilities);
   EXPECT_EQ(NO_CAPABILITIES.optional_capabilities,
+            capabilities.optional_capabilities);
+}
+
+TEST_F(CxTest, LIATestCapabilitiesWithServerName)
+{
+  Cx::LocationInfoAnswer lia(_cx_dict,
+                             _mock_stack,
+                             RESULT_CODE_SUCCESS,
+                             0,
+                             EMPTY_STRING,
+                             CAPABILITIES_WITH_SERVER_NAME);
+  launder_message(lia);
+  EXPECT_TRUE(lia.result_code(test_i32));
+  EXPECT_EQ(RESULT_CODE_SUCCESS, test_i32);
+  EXPECT_FALSE(lia.experimental_result_code());
+  EXPECT_FALSE(lia.server_name(test_str));
+  ServerCapabilities capabilities = lia.server_capabilities();
+  EXPECT_EQ(SERVER_NAME_IN_CAPAB, capabilities.server_name);
+  EXPECT_EQ(CAPABILITIES_WITH_SERVER_NAME.mandatory_capabilities,
+            capabilities.mandatory_capabilities);
+  EXPECT_EQ(CAPABILITIES_WITH_SERVER_NAME.optional_capabilities,
             capabilities.optional_capabilities);
 }
 

--- a/src/ut/handlers_test.cpp
+++ b/src/ut/handlers_test.cpp
@@ -102,6 +102,7 @@ public:
   static const std::string AUTH_TYPE_CAPAB;
   static const ServerCapabilities CAPABILITIES;
   static const ServerCapabilities NO_CAPABILITIES;
+  static const ServerCapabilities CAPABILITIES_WITH_SERVER_NAME;
   static const int32_t AUTH_SESSION_STATE;
   static const std::string ASSOCIATED_IDENTITY1;
   static const std::string ASSOCIATED_IDENTITY2;
@@ -288,6 +289,11 @@ public:
     }
     else
     {
+      if (!capabs.server_name.empty())
+      {
+        writer.String(JSON_SCSCF.c_str());
+        writer.String(capabs.server_name.c_str());
+      }
       writer.String(JSON_MAN_CAP.c_str());
       writer.StartArray();
       if (!capabs.mandatory_capabilities.empty())
@@ -1081,8 +1087,9 @@ const std::string HandlersTest::AUTH_TYPE_CAPAB = "CAPAB";
 const std::vector<int32_t> mandatory_capabilities = {1, 3};
 const std::vector<int32_t> optional_capabilities = {2, 4};
 const std::vector<int32_t> no_capabilities = {};
-const ServerCapabilities HandlersTest::CAPABILITIES(mandatory_capabilities, optional_capabilities);
-const ServerCapabilities HandlersTest::NO_CAPABILITIES(no_capabilities, no_capabilities);
+const ServerCapabilities HandlersTest::CAPABILITIES(mandatory_capabilities, optional_capabilities, "");
+const ServerCapabilities HandlersTest::NO_CAPABILITIES(no_capabilities, no_capabilities, "");
+const ServerCapabilities HandlersTest::CAPABILITIES_WITH_SERVER_NAME(no_capabilities, no_capabilities, SERVER_NAME);
 const int32_t HandlersTest::AUTH_SESSION_STATE = 1;
 const std::string HandlersTest::ASSOCIATED_IDENTITY1 = "associated_identity1@example.com";
 const std::string HandlersTest::ASSOCIATED_IDENTITY2 = "associated_identity2@example.com";
@@ -2591,14 +2598,14 @@ TEST_F(HandlersTest, RegistrationStatusOptParamsSubseqRegCapabs)
                                   0,
                                   DIAMETER_SUBSEQUENT_REGISTRATION,
                                   "",
-                                  CAPABILITIES);
+                                  CAPABILITIES_WITH_SERVER_NAME);
   EXPECT_CALL(*_httpstack, send_reply(_, 200, _));
   _caught_diam_tsx->on_response(uaa);
   _caught_fd_msg = NULL;
   delete _caught_diam_tsx; _caught_diam_tsx = NULL;
 
   // Build the expected JSON response and check it's correct.
-  EXPECT_EQ(build_icscf_json(DIAMETER_SUBSEQUENT_REGISTRATION, "", CAPABILITIES), req.content());
+  EXPECT_EQ(build_icscf_json(DIAMETER_SUBSEQUENT_REGISTRATION, "", CAPABILITIES_WITH_SERVER_NAME), req.content());
 }
 
 TEST_F(HandlersTest, RegistrationStatusFirstRegNoCapabs)
@@ -2800,14 +2807,14 @@ TEST_F(HandlersTest, LocationInfoOptParamsUnregisteredService)
                              0,
                              DIAMETER_UNREGISTERED_SERVICE,
                              "",
-                             CAPABILITIES);
+                             CAPABILITIES_WITH_SERVER_NAME);
   EXPECT_CALL(*_httpstack, send_reply(_, 200, _));
   _caught_diam_tsx->on_response(lia);
   _caught_fd_msg = NULL;
   delete _caught_diam_tsx; _caught_diam_tsx = NULL;
 
   // Build the expected JSON response and check it's correct.
-  EXPECT_EQ(build_icscf_json(DIAMETER_UNREGISTERED_SERVICE, "", CAPABILITIES), req.content());
+  EXPECT_EQ(build_icscf_json(DIAMETER_UNREGISTERED_SERVICE, "", CAPABILITIES_WITH_SERVER_NAME), req.content());
 }
 
 // The following tests all test HSS error response cases, and use a template


### PR DESCRIPTION
Graeme, can you review this change to check the server capabilities AVP for a server name. I've tested with the UTs. 

Fixes #77 
