### PR TITLE
Reviewer Alex - Speed up incremental compiles

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -54,7 +54,13 @@ TARGET_SOURCES_TEST := test_main.cpp \
                        mockfreediameter.cpp \
                        mock_sas.cpp \
                        realmmanager_test.cpp \
-                       diameterresolver_test.cpp
+                       diameterresolver_test.cpp \
+											 mockcache.cpp \
+											 mockstatisticsmanager.cpp \
+											 mockdiameterstack.cpp \
+											 mockhttpstack.cpp \
+											 mockhttpconnection.cpp \
+											 mockdiameterresolver.cpp
 
 TARGET_EXTRA_OBJS_TEST := gmock-all.o \
                           gtest-all.o

--- a/src/ut/mockcache.cpp
+++ b/src/ut/mockcache.cpp
@@ -1,0 +1,4 @@
+#include "mockcache.hpp"
+
+MockCache::MockCache() {};
+MockCache::~MockCache() {};

--- a/src/ut/mockcache.hpp
+++ b/src/ut/mockcache.hpp
@@ -47,8 +47,8 @@ static DigestAuthVector mock_digest_av;
 class MockCache : public MockCassandraStore<Cache>
 {
 public:
-  MockCache() {};
-  virtual ~MockCache() {};
+  MockCache();
+  virtual ~MockCache();
 
   //
   // Methods that create cache request objects.

--- a/src/ut/mockdiameterresolver.cpp
+++ b/src/ut/mockdiameterresolver.cpp
@@ -1,0 +1,5 @@
+#include "mockdiameterresolver.hpp"
+
+MockDiameterResolver::MockDiameterResolver() :
+  DiameterResolver(NULL, AF_INET) {}
+MockDiameterResolver::~MockDiameterResolver() {}

--- a/src/ut/mockdiameterresolver.hpp
+++ b/src/ut/mockdiameterresolver.hpp
@@ -43,10 +43,8 @@
 class MockDiameterResolver : public DiameterResolver
 {
 public:
-  MockDiameterResolver() :
-    DiameterResolver(NULL, AF_INET)
-  {};
-  virtual ~MockDiameterResolver() {};
+  MockDiameterResolver();
+  virtual ~MockDiameterResolver();
 
   MOCK_METHOD5(resolve, void(const std::string&,
                              const std::string&,

--- a/src/ut/mockhttpconnection.cpp
+++ b/src/ut/mockhttpconnection.cpp
@@ -1,0 +1,5 @@
+#include "mockhttpconnection.hpp"
+
+MockHttpConnection::MockHttpConnection(HttpResolver* resolver) :
+  HttpConnection("", false, resolver, SASEvent::HttpLogLevel::PROTOCOL) {};
+MockHttpConnection::~MockHttpConnection() {};

--- a/src/ut/mockhttpconnection.hpp
+++ b/src/ut/mockhttpconnection.hpp
@@ -43,10 +43,8 @@
 class MockHttpConnection : public HttpConnection
 {
 public:
-  MockHttpConnection(HttpResolver* resolver) :
-    HttpConnection("", false, resolver, SASEvent::HttpLogLevel::PROTOCOL)
-  {};
-  virtual ~MockHttpConnection() {};
+  MockHttpConnection(HttpResolver* resolver);
+  virtual ~MockHttpConnection();
 
   MOCK_METHOD3(send_delete, long(const std::string& path, SAS::TrailId trail, const std::string& body));
 };

--- a/src/ut/mockstatisticsmanager.cpp
+++ b/src/ut/mockstatisticsmanager.cpp
@@ -1,0 +1,4 @@
+#include "mockstatisticsmanager.hpp"
+
+MockStatisticsManager::MockStatisticsManager() : StatisticsManager(10) {}
+MockStatisticsManager::~MockStatisticsManager() {}

--- a/src/ut/mockstatisticsmanager.hpp
+++ b/src/ut/mockstatisticsmanager.hpp
@@ -44,8 +44,8 @@ class MockStatisticsManager : public StatisticsManager
 {
 public:
   // Short poll timeout to not slowdown test shutdown.
-  MockStatisticsManager() : StatisticsManager(10) {}
-  virtual ~MockStatisticsManager() {}
+  MockStatisticsManager();
+  virtual ~MockStatisticsManager();
 
   MOCK_METHOD1(update_H_latency_us, void(unsigned long sample));
   MOCK_METHOD1(update_H_hss_latency_us, void(unsigned long sample));


### PR DESCRIPTION
Don't say I'm not nice to you!  Taking a hint from https://code.google.com/p/googlemock/wiki/CookBook#Making_the_Compilation_Faster, I've move the constructors of many of our GoogleMock objects out to their own files.  This makes negligible difference to a fresh build, but speeds up incremental builds by a decent amount.

Before:

```
ubuntu@ip-10-48-154-121:~/src/homestead-ng/src$ touch ut/handlers_test.cpp
ubuntu@ip-10-48-154-121:~/src/homestead-ng/src$ time make build_test
/home/ubuntu/src/homestead-ng/build/obj/homestead_test/handlers_test.depends
g++  <snip>  -c <snip> ut/handlers_test.cpp
g++  <snip> -o /home/ubuntu/src/homestead-ng/build/bin/homestead_test <snip>

real    0m29.575s
user    0m26.546s
sys     0m2.928s
```

After:

```
ubuntu@ip-10-48-154-121:~/src/homestead-ng/src$ touch ut/handlers_test.cpp
ubuntu@ip-10-48-154-121:~/src/homestead-ng/src$ time make build_test
/home/ubuntu/src/homestead-ng/build/obj/homestead_test/handlers_test.depends
g++  <snip>  -c <snip> ut/handlers_test.cpp
g++  <snip> -o /home/ubuntu/src/homestead-ng/build/bin/homestead_test <snip>

real    0m20.668s
user    0m18.197s
sys     0m2.384s
```

Factoring out the `0m3.831s` it takes to do the link afterwards, this has reduced the compilation time of that file by **35%**.

Further gains can be made elsewhere by doing the same trick to other mock classes, but I've focussed on the "long pole in the tent" to get the best "bang for buck"... "synergy".
