### PR TITLE
Allow more settings to be in /etc/clearwater/config

### DIFF
--- a/debian/homestead.init.d
+++ b/debian/homestead.init.d
@@ -80,20 +80,22 @@ log_directory=/var/log/$NAME
 #
 get_settings()
 {
-        # Set up defaults and then pull in the settings for this node.
+        # Set up defaults and then pull in any overrides.
         sas_server=0.0.0.0
         hss_hostname=0.0.0.0
         dns_server=127.0.0.1
         scscf=5054
         target_latency_us=100000
-        . /etc/clearwater/config
 
-        # Set up defaults for user settings then pull in any overrides.
         num_http_threads=$(($(grep processor /proc/cpuinfo | wc -l) * 50))
-        log_level=2
         impu_cache_ttl=0
         hss_reregistration_time=1800
+        max_peers=2
+        . /etc/clearwater/config
 
+        log_level=2
+
+        # Derive server_name and sprout_http_name from other settings
         if [ -n "$scscf_uri" ]
         then
           server_name=$scscf_uri
@@ -102,7 +104,8 @@ get_settings()
         fi
 
         sprout_http_name=$(python /usr/share/clearwater/bin/bracket_ipv6_address.py $sprout_hostname):9888
-        max_peers=2
+
+        # Pull in user_settings as a final level of overrides
         [ -r /etc/clearwater/user_settings ] && . /etc/clearwater/user_settings
 
         # Work out which features are enabled.


### PR DESCRIPTION
This allows `max_peers`, `num_http_threads`, `impu_cache_ttl` and `hss_reregistration_time` to be set in /etc/clearwater/config as well as /etc/clearwater/user_settings. user_settings takes priority, so there won't be a behaviour change unless one of those options is set in /etc/clearwater/config but not user_settings (and in that case the user probably *wants* that configuration option anyway).

`impu_cache_ttl` and `hss_reregistration_time` make much more sense in /etc/clearwater/config, because they affect Cassandra TTLs, and that's deployment-wide. `max_peers` also makes sense deployment-wide. `num_http_threads` maybe less so, but there's no harm in having the added flexibility.

Not tested - I propose to test by:
* setting hss_reregistration_time and max_peers to different values in /etc/clearwater/config and /etc/clearwater/user_settings, and checking that user_settings take priority
* setting hss_reregistration_time and max_peers in /etc/clearwater/config only, and checking that they are picked up