### PR TITLE
Unit test needs to link libdl when built using Ubuntu 14.04's tools chain (gcc 4.8.2)

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -135,7 +135,7 @@ LDFLAGS_BUILD += -lsas
 LDFLAGS_TEST += -Wl,-rpath=$(ROOT)/usr/lib
 
 # Test build also uses libcurl (to verify HttpStack operation)
-LDFLAGS_TEST += -lcurl
+LDFLAGS_TEST += -lcurl -ldl
 
 # Now the GMock / GTest boilerplate.
 GTEST_HEADERS := $(GTEST_DIR)/include/gtest/*.h \


### PR DESCRIPTION
The unit tests would not run on Ubuntu 14.04 with specifically linking against libdl, so that has been added to the unit test ld flags. With this option the unit tests run as expected and has no deleterious affect in an Ubuntu 12.04 build environment.
