### PR TITLE
[Reviewer: Ellie] Homestead depends on libevent-2.0-5 and libcurl3-gnutls

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,7 @@ Homepage: http://projectclearwater.org/
 
 Package: homestead-libs
 Architecture: any
-Depends: libsctp1
+Depends: libsctp1, libevent-2.0-5, libevent-pthreads-2.0-5
 Description: Libraries for homestead
 
 Package: homestead-libs-dbg
@@ -24,7 +24,7 @@ Description: Debugging symbols for homestead-libs
 
 Package: homestead
 Architecture: any
-Depends: clearwater-infrastructure, clearwater-tcp-scalability, clearwater-log-cleanup, homestead-libs, libboost-regex1.46.1, libzmq3, libevent-pthreads-2.0-5, gnutls-bin, clearwater-socket-factory, libboost-filesystem1.46.1
+Depends: clearwater-infrastructure, clearwater-tcp-scalability, clearwater-log-cleanup, homestead-libs, libboost-regex1.46.1, libzmq3, libcurl3-gnutls, gnutls-bin, clearwater-socket-factory, libboost-filesystem1.46.1
 Suggests: homestead-dbg, clearwater-logging, clearwater-snmp-handler-homestead, clearwater-snmp-handler-alarm
 Description: homestead, the HSS Cache/Gateway
 


### PR DESCRIPTION
Ellie,

Please can you review this, which fixes #192.

I've tested live, and have similar changes to other components ready to go.

Matt