### PR TITLE
[Reviewer: Matt] Pass the Diameter hostname to RealmManager along with the realm

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -743,21 +743,16 @@ int main(int argc, char**argv)
 
   DiameterResolver* diameter_resolver = NULL;
   RealmManager* realm_manager = NULL;
-  Diameter::Peer* peer = NULL;
-
-  if (!options.dest_realm.empty())
+  
+  if (hss_configured)
   {
     diameter_resolver = new DiameterResolver(dns_resolver, af);
     realm_manager = new RealmManager(diameter_stack,
                                      options.dest_realm,
+                                     options.dest_host,
                                      options.max_peers,
                                      diameter_resolver);
     realm_manager->start();
-  }
-  else if (!(options.dest_host.empty() || options.dest_host == "0.0.0.0"))
-  {
-    peer = new Diameter::Peer(options.dest_host);
-    diameter_stack->add(peer);
   }
 
   LOG_STATUS("Start-up complete - wait for termination signal");
@@ -797,17 +792,12 @@ int main(int argc, char**argv)
 
   delete sprout_conn; sprout_conn = NULL;
 
-  if (!options.dest_realm.empty())
+  if (hss_configured)
   {
     realm_manager->stop();
     delete realm_manager; realm_manager = NULL;
     delete diameter_resolver; diameter_resolver = NULL;
     delete dns_resolver; dns_resolver = NULL;
-  }
-  else if (!(options.dest_host.empty() || options.dest_host == "0.0.0.0"))
-  {
-    diameter_stack->remove(peer);
-    delete peer; peer = NULL;
   }
 
   delete stats_manager; stats_manager = NULL;

--- a/src/ut/realmmanager_test.cpp
+++ b/src/ut/realmmanager_test.cpp
@@ -47,6 +47,7 @@ class RealmmanagerTest : public testing::Test
 {
 public:
   static const std::string DIAMETER_REALM;
+  static const std::string DIAMETER_HOSTNAME;
 
   static MockDiameterStack* _mock_stack;
   static MockDiameterResolver* _mock_resolver;
@@ -79,6 +80,7 @@ public:
 };
 
 const std::string RealmmanagerTest::DIAMETER_REALM = "hss.example.com";
+const std::string RealmmanagerTest::DIAMETER_HOSTNAME = "hss1.example.com";
 
 MockDiameterStack* RealmmanagerTest::_mock_stack = NULL;
 MockDiameterResolver* RealmmanagerTest::_mock_resolver = NULL;
@@ -137,11 +139,12 @@ TEST_F(RealmmanagerTest, CreateDestroy)
 
   RealmManager* realm_manager = new RealmManager(_mock_stack,
                                                  DIAMETER_REALM,
+                                                 DIAMETER_HOSTNAME,
                                                  2,
                                                  _mock_resolver);
 
   targets.push_back(peer);
-  EXPECT_CALL(*_mock_resolver, resolve(DIAMETER_REALM, "", 2, _, _))
+  EXPECT_CALL(*_mock_resolver, resolve(DIAMETER_REALM, DIAMETER_HOSTNAME, 2, _, _))
     .WillOnce(DoAll(SetArgReferee<3>(targets), SetArgReferee<4>(15)));
   EXPECT_CALL(*_mock_stack, add(_))
     .Times(1)
@@ -187,6 +190,7 @@ TEST_F(RealmmanagerTest, ManageConnections)
   // Create a RealmManager.
   RealmManager* realm_manager = new RealmManager(_mock_stack,
                                                  DIAMETER_REALM,
+                                                 DIAMETER_HOSTNAME,
                                                  2,
                                                  _mock_resolver);
 
@@ -194,7 +198,7 @@ TEST_F(RealmmanagerTest, ManageConnections)
   // expect to try and connect to them.
   targets.push_back(peer1);
   targets.push_back(peer2);
-  EXPECT_CALL(*_mock_resolver, resolve(DIAMETER_REALM, "", 2, _, _))
+  EXPECT_CALL(*_mock_resolver, resolve(DIAMETER_REALM, DIAMETER_HOSTNAME, 2, _, _))
     .WillOnce(DoAll(SetArgReferee<3>(targets), SetArgReferee<4>(15)));
   EXPECT_CALL(*_mock_stack, add(_))
     .Times(2)
@@ -213,7 +217,7 @@ TEST_F(RealmmanagerTest, ManageConnections)
   targets.clear();
   targets.push_back(peer2);
   targets.push_back(peer3);
-  EXPECT_CALL(*_mock_resolver, resolve(DIAMETER_REALM, "", 2, _, _))
+  EXPECT_CALL(*_mock_resolver, resolve(DIAMETER_REALM, DIAMETER_HOSTNAME, 2, _, _))
     .WillOnce(DoAll(SetArgReferee<3>(targets), SetArgReferee<4>(10)));
   EXPECT_CALL(*_mock_stack, add(_))
     .Times(1)
@@ -229,7 +233,7 @@ TEST_F(RealmmanagerTest, ManageConnections)
   // one of the connections.
   targets.clear();
   targets.push_back(peer2);
-  EXPECT_CALL(*_mock_resolver, resolve(DIAMETER_REALM, "", 2, _, _))
+  EXPECT_CALL(*_mock_resolver, resolve(DIAMETER_REALM, DIAMETER_HOSTNAME, 2, _, _))
     .WillOnce(DoAll(SetArgReferee<3>(targets), SetArgReferee<4>(15)));
   EXPECT_CALL(*_mock_stack, remove(_))
     .Times(1);
@@ -242,7 +246,7 @@ TEST_F(RealmmanagerTest, ManageConnections)
   targets.clear();
   targets.push_back(peer2);
   targets.push_back(peer3);
-  EXPECT_CALL(*_mock_resolver, resolve(DIAMETER_REALM, "", 2, _, _))
+  EXPECT_CALL(*_mock_resolver, resolve(DIAMETER_REALM, DIAMETER_HOSTNAME, 2, _, _))
     .WillOnce(DoAll(SetArgReferee<3>(targets), SetArgReferee<4>(15)));
   EXPECT_CALL(*_mock_stack, add(_))
     .Times(1)
@@ -253,7 +257,7 @@ TEST_F(RealmmanagerTest, ManageConnections)
   // The diameter resolver returns no peers. We expect to tear down the one
   // connection (to peer2) that we have up.
   targets.clear();
-  EXPECT_CALL(*_mock_resolver, resolve(DIAMETER_REALM, "", 2, _, _))
+  EXPECT_CALL(*_mock_resolver, resolve(DIAMETER_REALM, DIAMETER_HOSTNAME, 2, _, _))
     .WillOnce(DoAll(SetArgReferee<3>(targets), SetArgReferee<4>(15)));
   EXPECT_CALL(*_mock_stack, remove(_))
     .Times(1);


### PR DESCRIPTION
This is the change we've discussed a couple of times now - to invoke RealmManager to manage the connections even if just a hss_hostname is specified, so the code is more consistent and predictable.

I'll test by setting up a HSS and configuring each of the three options:
* just hss_realm
* just hss_hostname
* both hss_realm and hss_hostname

and check that the CE/CEA exchage is successful in each case.

It's probably worth renaming RealmManager - how about DiameterConnectionManager?