### PR TITLE
[Reviewer: Ellie] Better errors when /etc/clearwater/config is missing settings

### DIFF
--- a/homestead.root/usr/share/clearwater/infrastructure/scripts/homestead
+++ b/homestead.root/usr/share/clearwater/infrastructure/scripts/homestead
@@ -55,7 +55,20 @@ acl_required=false
 
 if [[ -z "$identity" ]];
 then
+    if [[ -z "$public_hostname" ]];
+    then
+        echo "ERROR: must have a public_hostname set in /etc/clearwater/config" >&2
+        exit 1
+    fi
+
     identity=$public_hostname
+fi
+
+
+if [[ -z "$hs_hostname" ]];
+then
+    echo "ERROR: must have a hs_hostname set in /etc/clearwater/config" >&2
+    exit 1
 fi
 
 # Strip any characters not valid in an FQDN out of hs_hostname (for


### PR DESCRIPTION
Fixes #140. I'll test by doing a manual install with "public_hostnamme" set instead of "public_hostname" and check that the error is sensible.