### PR TITLE
[Reviewer: Matt] Fix memory leak in UT

### DIFF
--- a/src/ut/handlers_test.cpp
+++ b/src/ut/handlers_test.cpp
@@ -3119,6 +3119,9 @@ TEST_F(HandlersTest, LocationInfoUnregisteredError)
   task->run();
   ASSERT_FALSE(_caught_diam_tsx == NULL);
 
+  // Move the caught message onto the stack to avoid memory leaks
+  Diameter::Message msg(_cx_dict, _caught_fd_msg, _mock_stack);
+  Cx::LocationInfoRequest lir(msg);
   // Build an LIA and expect a successful HTTP response.
   Cx::LocationInfoAnswer lia(_cx_dict,
                              _mock_stack,


### PR DESCRIPTION
The Jenkins memory leak errors were because I hadn't created a Diameter::Message and checked its properties in my new UT (to minimise the amount of things each test was asserting). Unfortunately, doing that also moves the contents of `_caught_fd_msg` onto the stack, so if we don't do that we leak memory.

This just creates (but doesn't use) a Diameter::Message to make sure that `_caught_fd_msg` is cleaned up properly.