### PR TITLE
[Reviewer: Andy] Dont attempt to start the diameterstack for testing

### DIFF
--- a/src/ut/cx_test.cpp
+++ b/src/ut/cx_test.cpp
@@ -96,7 +96,6 @@ public:
     _real_stack = Diameter::Stack::get_instance();
     _real_stack->initialize();
     _real_stack->configure(UT_DIR + "/diameterstack.conf", NULL);
-    _real_stack->start();
     _mock_stack = new MockDiameterStack();
     _cx_dict = new Cx::Dictionary();
   }

--- a/src/ut/diameterstack_test.cpp
+++ b/src/ut/diameterstack_test.cpp
@@ -91,7 +91,6 @@ public:
     _stack = Diameter::Stack::get_instance();
     _stack->initialize();
     _stack->configure(UT_DIR + "/diameterstack.conf", NULL);
-    _stack->start();
 
     _dict = new Cx::Dictionary();
 
@@ -155,7 +154,6 @@ public:
     _stack = Diameter::Stack::get_instance();
     _stack->initialize();
     _stack->configure(UT_DIR + "/diameterstack.conf", NULL, &_cm);
-    _stack->start();
 
     _dict = new Cx::Dictionary();
   }
@@ -185,7 +183,6 @@ TEST(DiameterStackTest, SimpleMainline)
   Diameter::Stack* stack = Diameter::Stack::get_instance();
   stack->initialize();
   stack->configure(UT_DIR + "/diameterstack.conf", NULL);
-  stack->start();
   stack->stop();
   stack->wait_stopped();
 }
@@ -197,7 +194,6 @@ TEST(DiameterStackTest, AdvertizeApplication)
   stack->configure(UT_DIR + "/diameterstack.conf", NULL);
   Diameter::Dictionary::Application app("Cx");
   stack->advertize_application(Diameter::Dictionary::Application::AUTH, app);
-  stack->start();
   stack->stop();
   stack->wait_stopped();
 }

--- a/src/ut/handlers_test.cpp
+++ b/src/ut/handlers_test.cpp
@@ -175,7 +175,6 @@ public:
     _real_stack = Diameter::Stack::get_instance();
     _real_stack->initialize();
     _real_stack->configure(UT_DIR + "/diameterstack.conf", NULL);
-    _real_stack->start();
     _mock_stack = new MockDiameterStack();
     _cx_dict = new Cx::Dictionary();
     _cache = new MockCache();


### PR DESCRIPTION
Stopped the unit tests from attempting to start a working diameter stack as this was causing test failures when the default port was already in use.