### PR TITLE
[Reviewer: Ellie] Add force_hss_peer config option

### DIFF
--- a/debian/homestead.init.d
+++ b/debian/homestead.init.d
@@ -177,6 +177,7 @@ get_daemon_args()
                      --http-threads=$num_http_threads
                      $dest_realm
                      --dest-host=$hss_hostname
+                     --hss-peer=$force_hss_peer
                      --max-peers=$max_peers
                      --server-name=$server_name
                      --impu-cache-ttl=$impu_cache_ttl

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -72,6 +72,7 @@ struct options
   std::string cassandra;
   std::string dest_realm;
   std::string dest_host;
+  std::string force_hss_peer;
   int max_peers;
   std::string server_name;
   int impu_cache_ttl;
@@ -115,7 +116,8 @@ enum OptionTypes
   MIN_TOKEN_RATE,
   EXCEPTION_MAX_TTL,
   HTTP_BLACKLIST_DURATION,
-  DIAMETER_BLACKLIST_DURATION
+  DIAMETER_BLACKLIST_DURATION,
+  FORCE_HSS_PEER
 };
 
 const static struct option long_opt[] =
@@ -130,6 +132,7 @@ const static struct option long_opt[] =
   {"cassandra",                   required_argument, NULL, 'S'},
   {"dest-realm",                  required_argument, NULL, 'D'},
   {"dest-host",                   required_argument, NULL, 'd'},
+  {"hss-peer",                    required_argument, NULL, FORCE_HSS_PEER},
   {"max-peers",                   required_argument, NULL, 'p'},
   {"server-name",                 required_argument, NULL, 's'},
   {"impu-cache-ttl",              required_argument, NULL, 'i'},
@@ -170,6 +173,7 @@ void usage(void)
        " -S, --cassandra <address>  Set the IP address or FQDN of the Cassandra database (default: localhost)"
        " -D, --dest-realm <name>    Set Destination-Realm on Cx messages\n"
        " -d, --dest-host <name>     Set Destination-Host on Cx messages\n"
+       "     --hss-peer <name>      IP address of HSS to connect to (rather than resolving Destination-Realm/Destination-Host)\n"
        " -p, --max-peers N          Number of peers to connect to (default: 2)\n"
        " -s, --server-name <name>   Set Server-Name on Cx messages\n"
        " -i, --impu-cache-ttl <secs>\n"
@@ -435,6 +439,10 @@ int init_options(int argc, char**argv, struct options& options)
                options.diameter_blacklist_duration);
       break;
 
+    case FORCE_HSS_PEER:
+      options.force_hss_peer = std::string(optarg);
+      break;
+
     case 'F':
     case 'L':
       // Ignore F and L - these are handled by init_logging_options
@@ -511,6 +519,7 @@ int main(int argc, char**argv)
   options.cassandra = "localhost";
   options.dest_realm = "";
   options.dest_host = "dest-host.unknown";
+  options.force_hss_peer = "";
   options.max_peers = 2;
   options.server_name = "sip:server-name.unknown";
   options.scheme_unknown = "Unknown";
@@ -811,11 +820,22 @@ int main(int argc, char**argv)
     diameter_resolver = new DiameterResolver(dns_resolver,
                                              af,
                                              options.diameter_blacklist_duration);
-    realm_manager = new RealmManager(diameter_stack,
-                                     options.dest_realm,
-                                     options.dest_host,
-                                     options.max_peers,
-                                     diameter_resolver);
+    if (options.force_hss_peer.empty())
+    {
+      realm_manager = new RealmManager(diameter_stack,
+                                       options.dest_realm,
+                                       options.dest_host,
+                                       options.max_peers,
+                                       diameter_resolver);
+    }
+    else
+    {
+      realm_manager = new RealmManager(diameter_stack,
+                                       "",
+                                       options.force_hss_peer,
+                                       options.max_peers,
+                                       diameter_resolver);
+    }
     realm_manager->start();
   }
 


### PR DESCRIPTION
Frequently (particularly in environments where DNS takes a long time to change - e.g. another team is managing the DNS server), I've wanted to be able to say "the HSS is reachable as IP address XXX, but the Destination-Host should be YYY, and the Destination-Realm should be ZZZ". (Currently, if you set hss_realm or hss_hostname, that gets resolved to find the peers, so there's no good way to uncouple the Diameter AVPs from the actual connection.)

This adds a config option to make that possible, so you can say:

```
force_hss_peer=XXX
hss_hostname=YYY
hss_realm=ZZZ
```

I haven't yet tested this live, but will do so.