### PR TITLE
[Reviewer: Andy] Allow configuring the Cx MAR authentication scheme more flexibly

### DIFF
--- a/debian/homestead.init.d
+++ b/debian/homestead.init.d
@@ -154,8 +154,8 @@ get_daemon_args()
         fi
 
         [ "$hss_mar_lowercase_unknown" != "Y" ] || scheme_args="--scheme-unknown=unknown"
-        [ "$hss_mar_force_digest" != "Y" ] || scheme_args="--scheme-unknown=\"SIP Digest\" --scheme-aka=\"SIP Digest\""
-        [ "$hss_mar_force_aka" != "Y" ] || scheme_args="--scheme-unknown=Digest-AKAv1-MD5 --scheme-digest=Digest-AKAv1-MD5"
+        [ "$hss_mar_force_digest" != "Y" ] || scheme_args="--scheme-unknown=\"SIP Digest\" --scheme-digest=\"SIP Digest\" --scheme-aka=\"SIP Digest\""
+        [ "$hss_mar_force_aka" != "Y" ] || scheme_args="--scheme-unknown=Digest-AKAv1-MD5 --scheme-digest=Digest-AKAv1-MD5 --scheme-aka=Digest-AKAv1-MD5"
 
         [ -z "$diameter_timeout_ms" ] || diameter_timeout_ms_arg="--diameter-timeout-ms=$diameter_timeout_ms"
         [ -z "$signaling_namespace" ] || namespace_prefix="ip netns exec $signaling_namespace"

--- a/debian/homestead.init.d
+++ b/debian/homestead.init.d
@@ -153,7 +153,9 @@ get_daemon_args()
           diameter_timeout_ms=$(( ($target_latency_us + 499)/500 ))
         fi
 
-        [ "$hss_mar_lowercase_unknown" != "Y" ] || scheme_unknown_arg="--scheme-unknown=unknown"
+        [ "$hss_mar_lowercase_unknown" != "Y" ] || scheme_args="--scheme-unknown=unknown"
+        [ "$hss_mar_force_digest" != "Y" ] || scheme_args="--scheme-unknown=\"SIP Digest\" --scheme-aka=\"SIP Digest\""
+        [ "$hss_mar_force_aka" != "Y" ] || scheme_args="--scheme-unknown=Digest-AKAv1-MD5 --scheme-digest=Digest-AKAv1-MD5"
 
         [ -z "$diameter_timeout_ms" ] || diameter_timeout_ms_arg="--diameter-timeout-ms=$diameter_timeout_ms"
         [ -z "$signaling_namespace" ] || namespace_prefix="ip netns exec $signaling_namespace"
@@ -182,7 +184,7 @@ get_daemon_args()
                      --impu-cache-ttl=$impu_cache_ttl
                      --hss-reregistration-time=$hss_reregistration_time
                      --sprout-http-name=$sprout_http_name
-                     $scheme_unknown_arg
+                     $scheme_args
                      $diameter_timeout_ms_arg
                      $alarms_enabled_arg
                      $target_latency_us_arg
@@ -214,7 +216,7 @@ do_start()
         # daemon is not running, so attempt to start it.
         setup_environment
         get_daemon_args
-        $namespace_prefix start-stop-daemon --start --quiet --background --make-pidfile --pidfile $PIDFILE --exec $DAEMON --chuid $NAME --chdir $HOME -- $DAEMON_ARGS \
+        eval $namespace_prefix start-stop-daemon --start --quiet --background --make-pidfile --pidfile $PIDFILE --exec $DAEMON --chuid $NAME --chdir $HOME -- $DAEMON_ARGS \
                 || return 2
         # Add code here, if necessary, that waits for the process to be ready
         # to handle requests from services started subsequently which depend
@@ -254,7 +256,7 @@ do_run()
 {
         setup_environment
         get_daemon_args
-        $namespace_prefix start-stop-daemon --start --quiet --exec $DAEMON --chuid $NAME --chdir $HOME -- $DAEMON_ARGS \
+        eval $namespace_prefix start-stop-daemon --start --quiet --exec $DAEMON --chuid $NAME --chdir $HOME -- $DAEMON_ARGS \
                 || return 2
 }
 


### PR DESCRIPTION
I've encountered HSSes that, when you send them an authentication scheme of "Unknown", send back weird things like "Early IMS Security".

This adds two new config options to counter that:

`hss_mar_force_digest=Y` - that AVP will always be 'SIP Digest'
`hss_mar_force_aka=Y` - that AVP will always be 'Digest-AKAv1-MD5'

To allow the quotes in "SIP Digest", I've used 'eval', as recommended by http://stackoverflow.com/questions/7454526/bash-variable-containing-multiple-args-with-quotes/21163341#21163341.

I've tested live by setting this config and checking the log at https://github.com/Metaswitch/homestead/blob/dev/src/main.cpp#L332.