### PR TITLE
[Reviewer: Ellie] Add quotes around server_name to cope with semicolons

### DIFF
--- a/debian/homestead.init.d
+++ b/debian/homestead.init.d
@@ -180,7 +180,7 @@ get_daemon_args()
                      $dest_realm
                      --dest-host=$hss_hostname
                      --max-peers=$max_peers
-                     --server-name=$server_name
+                     --server-name=\"$server_name\"
                      --impu-cache-ttl=$impu_cache_ttl
                      --hss-reregistration-time=$hss_reregistration_time
                      --sprout-http-name=$sprout_http_name


### PR DESCRIPTION
I've tested live, and confirmed:
* `ps aux | grep homestead` gives me the full command line (not cut off at the first semicolon)
* `sudo service homestead restart` doesn't give the error `/etc/init.d/homestead: 1: eval: --impu-cache-ttl=0: not found`