### PR TITLE
[No reviewer] Remove snmp handler

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -25,7 +25,7 @@ Description: Debugging symbols for homestead-libs
 Package: homestead
 Architecture: any
 Depends: clearwater-infrastructure, clearwater-tcp-scalability, clearwater-log-cleanup, homestead-libs, libboost-regex1.54.0, libzmq3, libcurl3-gnutls, gnutls-bin, clearwater-socket-factory, libboost-filesystem1.54.0, libsnmp30 (= 5.7.2~dfsg-clearwater1), clearwater-cassandra
-Suggests: homestead-dbg, clearwater-logging, clearwater-snmp-handler-homestead, clearwater-snmp-handler-alarm
+Suggests: homestead-dbg, clearwater-logging, clearwater-snmp-handler-alarm
 Description: homestead, the HSS Cache/Gateway
 
 Package: homestead-dbg


### PR DESCRIPTION
Remove snmp-handler as Homestead uses the new style stats