### PR TITLE
[Reviewer: Alex] Update UTs and schema

### DIFF
--- a/homestead.root/usr/share/clearwater/cassandra-schemas/homestead_cache.sh
+++ b/homestead.root/usr/share/clearwater/cassandra-schemas/homestead_cache.sh
@@ -1,4 +1,5 @@
 #! /bin/bash
+. /etc/clearwater/config
 
 if [[ ! -e /var/lib/cassandra/data/homestead_cache ]];
 then
@@ -37,3 +38,12 @@ then
   echo "USE homestead_cache;
         CREATE TABLE impi_mapping (private_id text PRIMARY KEY, unused text) WITH COMPACT STORAGE AND read_repair_chance = 1.0;" | /usr/share/clearwater/bin/run-in-signaling-namespace cqlsh
 fi
+
+if [ -z "$speculative_retry_value" ]
+then
+  speculative_retry_value="50ms"
+fi
+
+echo "USE homestead_cache;
+      ALTER TABLE impu WITH speculative_retry = '$speculative_retry_value';
+      ALTER TABLE impi WITH speculative_retry = '$speculative_retry_value';" | /usr/share/clearwater/bin/run-in-signaling-namespace cqlsh

--- a/homestead.root/usr/share/clearwater/cassandra-schemas/homestead_cache.sh
+++ b/homestead.root/usr/share/clearwater/cassandra-schemas/homestead_cache.sh
@@ -46,4 +46,5 @@ fi
 
 echo "USE homestead_cache;
       ALTER TABLE impu WITH speculative_retry = '$speculative_retry_value';
+      ALTER TABLE impi_mapping WITH speculative_retry = '$speculative_retry_value';
       ALTER TABLE impi WITH speculative_retry = '$speculative_retry_value';" | /usr/share/clearwater/bin/run-in-signaling-namespace cqlsh

--- a/src/ut/cache_test.cpp
+++ b/src/ut/cache_test.cpp
@@ -1334,7 +1334,7 @@ TEST_F(CacheRequestTest, HaGetMainline)
                                  "kermit",
                                  ColumnPathForTable("impu"),
                                  AllColumns(),
-                                 cass::ConsistencyLevel::LOCAL_QUORUM))
+                                 cass::ConsistencyLevel::TWO))
     .WillOnce(SetArgReferee<0>(slice));
 
   EXPECT_CALL(*trx, on_success(_))
@@ -1362,7 +1362,7 @@ TEST_F(CacheRequestTest, HaGet2ndReadNotFoundException)
 
   cass::NotFoundException nfe;
   EXPECT_CALL(_client, get_slice(_, _, _, _,
-                                 cass::ConsistencyLevel::LOCAL_QUORUM))
+                                 cass::ConsistencyLevel::TWO))
     .WillOnce(Throw(nfe));
 
   EXPECT_CALL(*trx, on_failure(OperationHasResult(CassandraStore::NOT_FOUND)));
@@ -1387,11 +1387,7 @@ TEST_F(CacheRequestTest, HaGet2ndReadUnavailableException)
 
   cass::UnavailableException ue;
   EXPECT_CALL(_client, get_slice(_, _, _, _,
-                                 cass::ConsistencyLevel::LOCAL_QUORUM))
-    .WillOnce(Throw(ue));
-
-  EXPECT_CALL(_client, get_slice(_, _, _, _,
-                                 cass::ConsistencyLevel::QUORUM))
+                                 cass::ConsistencyLevel::TWO))
     .WillOnce(Throw(ue));
 
   cass::NotFoundException nfe;


### PR DESCRIPTION
Update UTs to handle TWO reads (from https://github.com/Metaswitch/cpp-common/pull/390), and update the schema to set the speculative retry value. 

If this is OK I'll make the same change to the other cassandra schemas, update the SAS bundle and add speculative_retry_value to the documentation

Part of the fix needed for #268