### PR TITLE
[Reviewer: Andy] Add known benign leak to homestead exceptions

### DIFF
--- a/src/ut/homestead_test.supp
+++ b/src/ut/homestead_test.supp
@@ -29,3 +29,15 @@
    fun:evthread_use_pthreads
    ...
 }
+
+{
+   gnutls_global_init allocates memory that is not reliably released by gnutls_global_deinit.  However, since freeDiameter initialisation is a once done at homestead (DiameterStack) startup, this is benign.
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   obj:/usr/lib/x86_64-linux-gnu/libgnutls.so.26.22.6
+   fun:gnutls_pkcs11_init
+   fun:gnutls_global_init
+   fun:fd_core_initialize
+   ...
+}

--- a/src/ut/homestead_test.supp
+++ b/src/ut/homestead_test.supp
@@ -31,7 +31,7 @@
 }
 
 {
-   gnutls_global_init allocates memory that is not reliably released by gnutls_global_deinit.  However, since freeDiameter initialisation is a once done at homestead (DiameterStack) startup, this is benign.
+   gnutls_global_init allocates memory that is not reliably released by gnutls_global_deinit.  However, since freeDiameter initialisation is done once at homestead (DiameterStack) startup, this is benign.
    Memcheck:Leak
    match-leak-kinds: definite
    fun:malloc


### PR DESCRIPTION
This is the fix to the homestead UTs which complain (on some build systems) about an apparent memory leak in gnutls_init (as called by fd_core_initialize during DiameterStack startup).  

This is benign.  While the memory is indeed apparently leaked during the test, Homestead does not repeatedly start Diameter stacks outside of the UTs, so the leak can be ignored.