### PR TITLE
[Reviewer: Ellie] Don't link in unnecessary -lboost_date_time

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -84,7 +84,6 @@ COMMON_LDFLAGS := -L../usr/lib \
                   -lcares \
                   -lboost_regex \
                   -lboost_system \
-                  -lboost_date_time \
                   -lpthread \
                   -lcurl \
                   -lc \


### PR DESCRIPTION
Homestead (and some other projects) pass -lboost_date_time to the linker, but:

- this isn't actually used - I've confirmed that Homestead links without it
- https://github.com/Metaswitch/homestead/blob/dev/debian/control doesn't depend on libboost-date-time1.54.0, so if it was ever used, Homestead would fail to start

I'll apply the same change to our other Makefiles.