### PR TITLE
[Reviewer AMC] Default hss_reregistration_time based on reg_max_expires

### DIFF
--- a/debian/homestead.init.d
+++ b/debian/homestead.init.d
@@ -98,11 +98,23 @@ get_settings()
         hss_hostname=0.0.0.0
         signaling_dns_server=127.0.0.1
         scscf=5054
-
         impu_cache_ttl=0
-        hss_reregistration_time=1800
         max_peers=2
+        reg_max_expires=300
         . /etc/clearwater/config
+
+        if [ -z $hss_reregistration_time ]
+        then
+          # Default hss_reregistration_time to max(1800, $reg_max_expires/2), so
+          # that homestead only discards expired registration data when sprout
+          # does (at the earliest).
+          hss_reregistration_time=$(( $reg_max_expires / 2 ))
+
+          if [ $hss_reregistration_time -lt 1800 ]
+          then
+            hss_reregistration_time=1800
+          fi
+        fi
 
         log_level=2
         num_http_threads=$(($(grep processor /proc/cpuinfo | wc -l) * 50))


### PR DESCRIPTION
If a deployment has a value for hss_reregistration_time which is less than half of reg_max_expires, unexpected deregistration can occur (homestead might expire registrations before the clients EXPIRES timeout has elapsed).  

To minimise the chance of this happening, this PR defaults hss_registration_time to max (<the previous default - i.e. "1800">, $reg_max_expires / 2 ), thus allowing deployment administrators to configure arbitrary values for reg_max_expires without needing to explicitly configure hss_reregistration_time.

There are two related PRs (to be created shortly) in the following repositories

-  sprout.  A PR to add a comment to the code that defaults reg_max_expires that any changes to this value must be reflected in homestead.init.d
-  clearwater-docs.  hss_reregistration_time is moved to the "experimental settings" section of the "Modifying settings" page as its defaulting logic is now non-trivial 