### PR TITLE
[Reviewer Andy] Change autn header to be base64 encoded and rename

### DIFF
--- a/include/handlers.h
+++ b/include/handlers.h
@@ -89,6 +89,9 @@ const std::string JSON_INTEGRITYKEY = "integritykey";
 const std::string JSON_RC = "result-code";
 const std::string JSON_SCSCF = "scscf";
 
+// HTTP query string field names
+const std::string AUTH_FIELD_NAME = "resync-auth";
+
 class HssCacheTask : public HttpStackUtils::Task
 {
 public:

--- a/src/Makefile
+++ b/src/Makefile
@@ -6,6 +6,7 @@ COMMON_SOURCES := accesslogger.cpp \
                   alarm.cpp \
                   base_communication_monitor.cpp \
                   baseresolver.cpp \
+                  base64.cpp \
                   cache.cpp \
                   cassandra_store.cpp \
                   communicationmonitor.cpp \

--- a/src/handlers.cpp
+++ b/src/handlers.cpp
@@ -46,6 +46,7 @@
 #include "rapidjson/stringbuffer.h"
 #include "rapidxml/rapidxml.hpp"
 #include "boost/algorithm/string/join.hpp"
+#include "base64.h"
 
 const std::string SIP_URI_PRE = "sip:";
 
@@ -496,7 +497,7 @@ bool ImpiAvTask::parse_request()
     return false;
   }
   _impu = _req.param("impu");
-  _authorization = _req.param("autn");
+  _authorization = base64_decode(_req.param("resync-auth"));
 
   return true;
 }

--- a/src/handlers.cpp
+++ b/src/handlers.cpp
@@ -497,7 +497,7 @@ bool ImpiAvTask::parse_request()
     return false;
   }
   _impu = _req.param("impu");
-  _authorization = base64_decode(_req.param("resync-auth"));
+  _authorization = base64_decode(_req.param(AUTH_FIELD_NAME));
 
   return true;
 }

--- a/src/ut/handlers_test.cpp
+++ b/src/ut/handlers_test.cpp
@@ -72,6 +72,7 @@
 #include "sproutconnection.h"
 #include "mock_health_checker.hpp"
 #include "fakesnmp.hpp"
+#include "base64.h"
 
 using ::testing::Return;
 using ::testing::ReturnRef;
@@ -2151,7 +2152,7 @@ TEST_F(HandlersTest, AvNoPublicIDHSSAKA)
   MockHttpStack::Request req(_httpstack,
                              "/impi/" + IMPI,
                              "av",
-                             "?autn=" + SIP_AUTHORIZATION);
+                             "?resync-auth=" + base64_encode(reinterpret_cast<const unsigned char*>(SIP_AUTHORIZATION.c_str()), SIP_AUTHORIZATION.length()));
   ImpiTask::Config cfg(true, 300, SCHEME_UNKNOWN, SCHEME_DIGEST, SCHEME_AKA);
   ImpiAvTask* task = new ImpiAvTask(req, &cfg, FAKE_TRAIL_ID);
 

--- a/src/ut/handlers_test.cpp
+++ b/src/ut/handlers_test.cpp
@@ -2152,7 +2152,7 @@ TEST_F(HandlersTest, AvNoPublicIDHSSAKA)
   MockHttpStack::Request req(_httpstack,
                              "/impi/" + IMPI,
                              "av",
-                             "?resync-auth=" + base64_encode(reinterpret_cast<const unsigned char*>(SIP_AUTHORIZATION.c_str()), SIP_AUTHORIZATION.length()));
+                             "?resync-auth=" + base64_encode(SIP_AUTHORIZATION));
   ImpiTask::Config cfg(true, 300, SCHEME_UNKNOWN, SCHEME_DIGEST, SCHEME_AKA);
   ImpiAvTask* task = new ImpiAvTask(req, &cfg, FAKE_TRAIL_ID);
 


### PR DESCRIPTION
Homestead part of https://github.com/Metaswitch/sprout/pull/1309.

Fixes https://github.com/Metaswitch/sprout/issues/1299

Also tested live. 

Please could you review?

Cheers,
Tom