### PR TITLE
[Reviewer: None] Use updated check-uptime script.

### DIFF
--- a/homestead.root/usr/share/clearwater/infrastructure/scripts/homestead.monit
+++ b/homestead.root/usr/share/clearwater/infrastructure/scripts/homestead.monit
@@ -41,7 +41,7 @@ cat > /etc/monit/conf.d/homestead.monit <<EOF
 # Monitor the service's PID file and memory use.
 check process homestead_process with pidfile /var/run/homestead/homestead.pid
   group homestead
-  
+
   # The start, stop and restart commands are linked to alarms
   start program = "/bin/bash -c '/usr/share/clearwater/bin/issue_alarm.py monit 1500.3; /etc/init.d/homestead start'"
   stop program = "/bin/bash -c '/usr/share/clearwater/bin/issue_alarm.py monit 1500.3; /etc/init.d/homestead stop'"
@@ -52,11 +52,11 @@ check process homestead_process with pidfile /var/run/homestead/homestead.pid
   if memory > 80% for 6 cycles then exec "/bin/bash -c '/usr/share/clearwater/bin/issue_alarm.py monit 1500.3; /etc/init.d/homestead abort'"
 
 # Clear any alarms if the process has been running long enough.
-check program homestead_uptime with path "/usr/share/clearwater/bin/check-uptime /var/run/homestead/homestead.pid"
+check program homestead_uptime with path "/usr/share/clearwater/bin/check-uptime /var/run/homestead/homestead.pid monit 1500.1"
   group homestead
   depends on homestead_process
   every 3 cycles
-  if status = 0 then exec "/usr/share/clearwater/bin/issue_alarm.py monit 1500.1"
+  if status != 0 then alert
 
 # Check the HTTP interface. This depends on the Homestead process (and so won't run
 # unless the Homestead process is running)


### PR DESCRIPTION
Use check-uptime to clear alarms and avoid suprious monit failures.