### PR TITLE
[Reviewer: Rob] Pass through the S-CSCF server name

### DIFF
--- a/docs/homestead_api.md
+++ b/docs/homestead_api.md
@@ -69,7 +69,7 @@ RegistrationState may take the values REGISTERED, UNREGISTERED or NOT_REGISTERED
 
 Changes to registration state can be done by:
 
-`PUT /impu/<public ID>/reg-data[?impi=<private ID>]`
+`PUT /impu/<public ID>/reg-data[?private_id=<private ID>&server_name=<S-CSCF name>]`
 
 The body of this PUT request is a JSON object, which has a mandatory "reqtype" field, specifying the type of SIP request this state change is based on. The response to a successful PUT request is the same as a GET request (200 OK with an XML body describing the current registration state).
 
@@ -80,7 +80,7 @@ The valid values of reqtype are:
 * `dereg-user`, `dereg-timeout`, `dereg-admin` - used to indicate that a deregistration (e.g. a REGISTER with `Expires: 0`, expiry of all bindings, or some other failure) has triggered this request. If a HSS is configured, Clearwater will delete any cached data for the subscriber (putting it in NOT_REGISTERED state) and send a Server-Assignment-Request with an appropriate type (USER_DEREGISTRATION, TIMEOUT_DEREGISTRATION or ADMINISTRATIVE_DEREGISTRATION). If a HSS is not configured, Clearwater will set the user to UNREGISTERED state.
 * `dereg-auth-failure` - used to indicate that a registration of a new binding has failed. This doesn't change any state on Homestead (as a registered user who fails to register a second binding shouldn't be de-registered, and an unregistered or not-registered user who fails to register is already in the right state) - it simply triggers a Server-Assignment-Request with Server-Assignment-Type AUTHENTICATION_FAILURE.
 
-These Server-Assignment-Types will specify a User-Name based on the `impi` query parameter (if provided), or on the PrivateID element in the cached User-Data. It will be omitted if neither of these are available.
+These Server-Assignment-Types will specify a User-Name based on the `private_id` query parameter (if provided), or on the PrivateID element in the cached User-Data. It will be omitted if neither of these are available. It will also specify the Server-Name based on the `server_name` query parameter (if provided), or the value of the configured S-CSCF URI (in `/etc/clearwater/shared_config`).
 
 The following error cases are possible:
 

--- a/include/handlers.h
+++ b/include/handlers.h
@@ -506,6 +506,7 @@ protected:
   RegistrationState _new_state;
   ChargingAddresses _charging_addrs;
   long _http_rc;
+  std::string _provided_server_name;
 };
 
 class ImpuIMSSubscriptionTask : public ImpuRegDataTask

--- a/include/handlers.h
+++ b/include/handlers.h
@@ -280,7 +280,7 @@ protected:
   static Diameter::Stack* _diameter_stack;
   static std::string _dest_realm;
   static std::string _dest_host;
-  static std::string _server_name;
+  static std::string _configured_server_name;
   static Cx::Dictionary* _dict;
   static Cache* _cache;
   static HealthChecker* _health_checker;

--- a/src/handlers.cpp
+++ b/src/handlers.cpp
@@ -53,7 +53,7 @@ const std::string SIP_URI_PRE = "sip:";
 Diameter::Stack* HssCacheTask::_diameter_stack = NULL;
 std::string HssCacheTask::_dest_realm;
 std::string HssCacheTask::_dest_host;
-std::string HssCacheTask::_server_name;
+std::string HssCacheTask::_configured_server_name;
 Cx::Dictionary* HssCacheTask::_dict;
 Cache* HssCacheTask::_cache = NULL;
 StatisticsManager* HssCacheTask::_stats_manager = NULL;
@@ -89,7 +89,7 @@ void HssCacheTask::configure_diameter(Diameter::Stack* diameter_stack,
   _diameter_stack = diameter_stack;
   _dest_realm = dest_realm;
   _dest_host = dest_host;
-  _server_name = server_name;
+  _configured_server_name = server_name;
   _dict = dict;
 }
 
@@ -326,7 +326,7 @@ void ImpiTask::send_mar()
                                 _dest_host,
                                 _impi,
                                 _impu,
-                                _server_name,
+                                _configured_server_name,
                                 _scheme,
                                 _authorization);
   DiameterTransaction* tsx =
@@ -617,7 +617,7 @@ void ImpiRegistrationStatusTask::run()
     writer.String(JSON_RC.c_str());
     writer.Int(DIAMETER_SUCCESS);
     writer.String(JSON_SCSCF.c_str());
-    writer.String(_server_name.c_str());
+    writer.String(_configured_server_name.c_str());
     writer.EndObject();
     _req.add_content(sb.GetString());
     send_http_reply(HTTP_OK);
@@ -888,14 +888,14 @@ void ImpuLocationInfoTask::on_get_reg_data_success(CassandraStore::Operation* op
   ((Cache::GetRegData*)op)->get_xml(xml, ttl);
   if (!xml.empty())
   {
-    TRC_DEBUG("Got IMS subscription XML from cache - fake response for server %s", _server_name.c_str());
+    TRC_DEBUG("Got IMS subscription XML from cache - fake response for server %s", _configured_server_name.c_str());
     rapidjson::StringBuffer sb;
     rapidjson::Writer<rapidjson::StringBuffer> writer(sb);
     writer.StartObject();
     writer.String(JSON_RC.c_str());
     writer.Int(DIAMETER_SUCCESS);
     writer.String(JSON_SCSCF.c_str());
-    writer.String(_server_name.c_str());
+    writer.String(_configured_server_name.c_str());
     writer.EndObject();
     _req.add_content(sb.GetString());
     send_http_reply(HTTP_OK);
@@ -1484,7 +1484,7 @@ void ImpuRegDataTask::send_server_assignment_request(Cx::ServerAssignmentType ty
                                   _dest_realm,
                                   _impi,
                                   _impu,
-                                  (_provided_server_name == "" ? _server_name :
+                                  (_provided_server_name == "" ? _configured_server_name :
                                    _provided_server_name),
                                   type);
   DiameterTransaction* tsx =

--- a/src/handlers.cpp
+++ b/src/handlers.cpp
@@ -1050,6 +1050,7 @@ void ImpuRegDataTask::run()
 
   _impu = path.substr(prefix.length(), path.find_first_of("/", prefix.length()) - prefix.length());
   _impi = _req.param("private_id");
+  _provided_server_name = _req.param("server_name");
   TRC_DEBUG("Parsed HTTP request: private ID %s, public ID %s",
             _impi.c_str(), _impu.c_str());
 
@@ -1483,7 +1484,8 @@ void ImpuRegDataTask::send_server_assignment_request(Cx::ServerAssignmentType ty
                                   _dest_realm,
                                   _impi,
                                   _impu,
-                                  _server_name,
+                                  (_provided_server_name == "" ? _server_name :
+                                   _provided_server_name),
                                   type);
   DiameterTransaction* tsx =
     new DiameterTransaction(_dict,


### PR DESCRIPTION
Allow Sprout to pass the server name through rather than always pulling it from the shared config

Fixes #66 (and is part of the fix for https://github.com/Metaswitch/sprout/issues/1405)