### PR TITLE
[No review required]: Correct dependency on clearwater-snmp-handler-alarm to clearwater-snm…

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -25,7 +25,7 @@ Description: Debugging symbols for homestead-libs
 Package: homestead
 Architecture: any
 Depends: clearwater-infrastructure, clearwater-tcp-scalability, clearwater-log-cleanup, homestead-libs, libboost-regex1.54.0, libzmq3, libcurl3-gnutls, gnutls-bin, clearwater-socket-factory, libboost-filesystem1.54.0, libsnmp30 (>= 5.7.2~dfsg-clearwater4), clearwater-cassandra
-Suggests: homestead-dbg, clearwater-logging, clearwater-snmp-handler-alarm
+Suggests: homestead-dbg, clearwater-logging, clearwater-snmp-alarm-agent
 Description: homestead, the HSS Cache/Gateway
 
 Package: homestead-dbg


### PR DESCRIPTION
…p-alarm-agent

Same as https://github.com/Metaswitch/clearwater-live-test/pull/118