### PR TITLE
[Reviewer: Matt] Tweak the Cassandra is_registered column so we heal better from netsplits

### DIFF
--- a/include/handlers.h
+++ b/include/handlers.h
@@ -504,6 +504,7 @@ protected:
   std::string _type_param;
   RequestType _type;
   std::string _xml;
+  RegistrationState _original_state;
   RegistrationState _new_state;
   ChargingAddresses _charging_addrs;
   long _http_rc;

--- a/src/handlers.cpp
+++ b/src/handlers.cpp
@@ -1622,7 +1622,10 @@ void ImpuRegDataTask::put_in_cache()
       // Using a timestamp in the past for the UNREGISTERED case means that,
       // when we do the last-write-wins conflict resolution, we'll always make
       // the REGISTERED state win.
-      timestamp -= (_cfg->hss_reregistration_time * 2);
+      //
+      // Multiply by 1,000,000 - timestamps are in microseconds
+      int64_t diff = (int64_t)_cfg->hss_reregistration_time * 2 * 1000000;
+      timestamp = timestamp - diff;
     }
 
     Cache::PutRegData* put_reg_data = _cache->create_PutRegData(public_ids,

--- a/src/handlers.cpp
+++ b/src/handlers.cpp
@@ -1142,22 +1142,21 @@ void ImpuRegDataTask::on_get_reg_data_success(CassandraStore::Operation* op)
   Cache::GetRegData* get_reg_data = (Cache::GetRegData*)op;
   sas_log_get_reg_data_success(get_reg_data, trail());
 
-  RegistrationState old_state;
   std::vector<std::string> associated_impis;
   int32_t ttl = 0;
   get_reg_data->get_xml(_xml, ttl);
-  get_reg_data->get_registration_state(old_state, ttl);
+  get_reg_data->get_registration_state(_original_state, ttl);
   get_reg_data->get_associated_impis(associated_impis);
   get_reg_data->get_charging_addrs(_charging_addrs);
   bool new_binding = false;
   TRC_DEBUG("TTL for this database record is %d, IMS Subscription XML is %s, registration state is %s, and the charging addresses are %s",
             ttl,
             _xml.empty() ? "empty" : "not empty",
-            regstate_to_str(old_state).c_str(),
+            regstate_to_str(_original_state).c_str(),
             _charging_addrs.empty() ? "empty" : _charging_addrs.log_string().c_str());
 
   // By default, we should remain in the existing state.
-  _new_state = old_state;
+  _new_state = _original_state;
 
   // GET requests shouldn't change the state - just respond with what
   // we have in the database
@@ -1220,7 +1219,7 @@ void ImpuRegDataTask::on_get_reg_data_success(CassandraStore::Operation* op)
       // is an initial registration or a re-registration. If this subscriber
       // is already registered but is registering with a new binding, we
       // still need to tell the HSS.
-      if ((old_state == RegistrationState::REGISTERED) && (!new_binding))
+      if ((_original_state == RegistrationState::REGISTERED) && (!new_binding))
       {
         TRC_DEBUG("Handling re-registration");
         _new_state = RegistrationState::REGISTERED;
@@ -1265,7 +1264,7 @@ void ImpuRegDataTask::on_get_reg_data_success(CassandraStore::Operation* op)
       // (INVITE, PUBLISH, MESSAGE etc.).
       TRC_DEBUG("Handling call");
 
-      if (old_state == RegistrationState::NOT_REGISTERED)
+      if (_original_state == RegistrationState::NOT_REGISTERED)
       {
         // We don't know anything about this subscriber. Send a
         // Server-Assignment-Request to provide unregistered service for
@@ -1288,7 +1287,7 @@ void ImpuRegDataTask::on_get_reg_data_success(CassandraStore::Operation* op)
       // Sprout wants to deregister this subscriber (because of a
       // REGISTER with Expires: 0, a timeout of all bindings, a failed
       // app server, etc.).
-      if (old_state == RegistrationState::REGISTERED)
+      if (_original_state == RegistrationState::REGISTERED)
       {
         // Forget about this subscriber entirely and send an appropriate SAR.
         TRC_DEBUG("Handling deregistration");
@@ -1337,7 +1336,7 @@ void ImpuRegDataTask::on_get_reg_data_success(CassandraStore::Operation* op)
       // This message was based on a REGISTER request from Sprout. Check
       // the subscriber's state in Cassandra to determine whether this
       // is an initial registration or a re-registration.
-      switch (old_state)
+      switch (_original_state)
       {
       case RegistrationState::REGISTERED:
         // No state changes in the cache are required for a re-register -
@@ -1371,7 +1370,7 @@ void ImpuRegDataTask::on_get_reg_data_success(CassandraStore::Operation* op)
       // (INVITE, PUBLISH, MESSAGE etc.).
       TRC_DEBUG("Handling call");
 
-      if (old_state == RegistrationState::NOT_REGISTERED)
+      if (_original_state == RegistrationState::NOT_REGISTERED)
       {
         // We don't know anything about this subscriber so reject
         // the request.
@@ -1389,7 +1388,7 @@ void ImpuRegDataTask::on_get_reg_data_success(CassandraStore::Operation* op)
       // Sprout wants to deregister this subscriber (because of a
       // REGISTER with Expires: 0, a timeout of all bindings, a failed
       // app server, etc.).
-      if (old_state == RegistrationState::REGISTERED)
+      if (_original_state == RegistrationState::REGISTERED)
       {
         // Move the subscriber into unregistered state (but retain the
         // data, as it's not stored anywhere else).
@@ -1610,7 +1609,8 @@ void ImpuRegDataTask::put_in_cache()
 
     int64_t timestamp = Cache::generate_timestamp();
 
-    if (_new_state == RegistrationState::UNREGISTERED)
+    if ((_original_state == RegistrationState::NOT_REGISTERED) &&
+        (_new_state == RegistrationState::UNREGISTERED))
     {
       // Force the timestamp to be at least two re-registration intervals in
       // the past. This handles the case where:

--- a/src/ut/handlers_test.cpp
+++ b/src/ut/handlers_test.cpp
@@ -523,7 +523,8 @@ public:
         .WillOnce(Return(&mock_op3));
       EXPECT_CALL(mock_op3, with_xml(IMPU_IMS_SUBSCRIPTION))
         .WillOnce(ReturnRef(mock_op3));
-      if (expected_new_state != RegistrationState::UNCHANGED)
+      if ((expected_new_state != RegistrationState::UNCHANGED) &&
+          (expected_new_state != RegistrationState::UNREGISTERED))
       {
         EXPECT_CALL(mock_op3, with_reg_state(expected_new_state))
           .WillOnce(ReturnRef(mock_op3));


### PR DESCRIPTION
I think this fixes #345.

I should be able to repro the problem (and then test that it's fixed) by creating 2 GR sites through Chef and following the repro instructions in that issue.