### PR TITLE
Switch from Python version of bracket_ipv6_address to C++ version

### DIFF
--- a/debian/homestead.init.d
+++ b/debian/homestead.init.d
@@ -129,7 +129,7 @@ get_settings()
           server_name="sip:scscf.$sprout_hostname:$scscf;transport=TCP"
         fi
 
-        sprout_http_name=$(python /usr/share/clearwater/bin/bracket_ipv6_address.py $sprout_hostname):9888
+        sprout_http_name=$(/usr/share/clearwater/bin/bracket-ipv6-address $sprout_hostname):9888
 
         # Work out which features are enabled.
         if [ -d /etc/clearwater/features.d ]

--- a/homestead.root/usr/share/clearwater/bin/poll_homestead.sh
+++ b/homestead.root/usr/share/clearwater/bin/poll_homestead.sh
@@ -35,6 +35,6 @@
 # as those licenses appear in the file LICENSE-OPENSSL.
 
 . /etc/clearwater/config
-http_ip=$(/usr/share/clearwater/bin/bracket_ipv6_address.py $local_ip)
+http_ip=$(/usr/share/clearwater/bin/bracket-ipv6-address $local_ip)
 /usr/share/clearwater/bin/poll-http $http_ip:8888
 exit $?


### PR DESCRIPTION
Same as https://github.com/Metaswitch/clearwater-infrastructure/pull/332, but for this repo.