### PR TITLE
[Reviewer AJH]: SAS trace HSS returncodes

### DIFF
--- a/include/handlers.h
+++ b/include/handlers.h
@@ -393,7 +393,7 @@ public:
 
   void run();
   void on_uar_response(Diameter::Message& rsp);
-  void sas_log_hss_failure(int32_t result_code);
+  void sas_log_hss_failure(int32_t result_code,int32_t experimental_result_code);
 
   typedef HssCacheTask::DiameterTransaction<ImpiRegistrationStatusTask> DiameterTransaction;
 
@@ -424,7 +424,7 @@ public:
 
   void run();
   void on_lir_response(Diameter::Message& rsp);
-  void sas_log_hss_failure(int32_t result_code);
+  void sas_log_hss_failure(int32_t result_code,int32_t experimental_result_code);
   void query_cache_reg_data();
   void on_get_reg_data_success(CassandraStore::Operation* op);
   void on_get_reg_data_failure(CassandraStore::Operation* op,

--- a/src/handlers.cpp
+++ b/src/handlers.cpp
@@ -689,20 +689,20 @@ void ImpiRegistrationStatusTask::on_uar_response(Diameter::Message& rsp)
            (experimental_result_code == DIAMETER_ERROR_IDENTITIES_DONT_MATCH))
   {
     TRC_INFO("User unknown or public/private ID conflict - reject");
-    sas_log_hss_failure(experimental_result_code);
+    sas_log_hss_failure(result_code, experimental_result_code);
     send_http_reply(HTTP_NOT_FOUND);
   }
   else if ((result_code == DIAMETER_AUTHORIZATION_REJECTED) ||
            (experimental_result_code == DIAMETER_ERROR_ROAMING_NOT_ALLOWED))
   {
     TRC_INFO("Authorization rejected due to roaming not allowed - reject");
-    sas_log_hss_failure(result_code ? result_code : experimental_result_code);
+    sas_log_hss_failure(result_code, experimental_result_code);
     send_http_reply(HTTP_FORBIDDEN);
   }
   else if (result_code == DIAMETER_TOO_BUSY)
   {
     TRC_INFO("HSS busy - reject");
-    sas_log_hss_failure(result_code);
+    sas_log_hss_failure(result_code, experimental_result_code);
     send_http_reply(HTTP_GATEWAY_TIMEOUT);
   }
   else if (result_code == DIAMETER_UNABLE_TO_DELIVER)
@@ -719,16 +719,18 @@ void ImpiRegistrationStatusTask::on_uar_response(Diameter::Message& rsp)
   {
     TRC_INFO("User-Authorization answer with result %d/%d - reject",
              result_code, experimental_result_code);
-    sas_log_hss_failure(result_code ? result_code : experimental_result_code);
+    sas_log_hss_failure(result_code, experimental_result_code);
     send_http_reply(HTTP_SERVER_ERROR);
   }
   delete this;
 }
 
-void ImpiRegistrationStatusTask::sas_log_hss_failure(int32_t result_code)
+void ImpiRegistrationStatusTask::sas_log_hss_failure(int32_t result_code,
+                                                     int32_t experimental_result_code)
 {
   SAS::Event event(this->trail(), SASEvent::REG_STATUS_HSS_FAIL, 0);
   event.add_static_param(result_code);
+  event.add_static_param(experimental_result_code);
   SAS::report_event(event);
 }
 
@@ -830,13 +832,13 @@ void ImpuLocationInfoTask::on_lir_response(Diameter::Message& rsp)
            (experimental_result_code == DIAMETER_ERROR_IDENTITY_NOT_REGISTERED))
   {
     TRC_INFO("User unknown or public/private ID conflict - reject");
-    sas_log_hss_failure(experimental_result_code);
+    sas_log_hss_failure(result_code, experimental_result_code);
     send_http_reply(HTTP_NOT_FOUND);
   }
   else if (result_code == DIAMETER_TOO_BUSY)
   {
     TRC_INFO("HSS busy - reject");
-    sas_log_hss_failure(result_code);
+    sas_log_hss_failure(result_code, experimental_result_code);
     send_http_reply(HTTP_GATEWAY_TIMEOUT);
   }
   else if (result_code == DIAMETER_UNABLE_TO_DELIVER)
@@ -853,16 +855,18 @@ void ImpuLocationInfoTask::on_lir_response(Diameter::Message& rsp)
   {
     TRC_INFO("Location-Info answer with result %d/%d - reject",
              result_code, experimental_result_code);
-    sas_log_hss_failure(result_code ? result_code : experimental_result_code);
+    sas_log_hss_failure(result_code, experimental_result_code);
     send_http_reply(HTTP_SERVER_ERROR);
   }
   delete this;
 }
 
-void ImpuLocationInfoTask::sas_log_hss_failure(int32_t result_code)
+void ImpuLocationInfoTask::sas_log_hss_failure(int32_t result_code,
+                                               int32_t experimental_result_code)
 {
   SAS::Event event(this->trail(), SASEvent::LOC_INFO_HSS_FAIL, 0);
   event.add_static_param(result_code);
+  event.add_static_param(experimental_result_code);
   SAS::report_event(event);
 }
 

--- a/src/handlers.cpp
+++ b/src/handlers.cpp
@@ -728,6 +728,7 @@ void ImpiRegistrationStatusTask::on_uar_response(Diameter::Message& rsp)
 void ImpiRegistrationStatusTask::sas_log_hss_failure(int32_t result_code)
 {
   SAS::Event event(this->trail(), SASEvent::REG_STATUS_HSS_FAIL, 0);
+  event.add_static_param(result_code);
   SAS::report_event(event);
 }
 
@@ -861,6 +862,7 @@ void ImpuLocationInfoTask::on_lir_response(Diameter::Message& rsp)
 void ImpuLocationInfoTask::sas_log_hss_failure(int32_t result_code)
 {
   SAS::Event event(this->trail(), SASEvent::LOC_INFO_HSS_FAIL, 0);
+  event.add_static_param(result_code);
   SAS::report_event(event);
 }
 
@@ -1700,19 +1702,12 @@ void ImpuRegDataTask::on_sar_response(Diameter::Message& rsp)
       _http_rc = HTTP_SERVER_UNAVAILABLE;
       break;
       // LCOV_EXCL_STOP
-    case 5001:
-    {
-      TRC_INFO("Server-Assignment answer with result code %d - reject", result_code);
-      SAS::Event event(this->trail(), SASEvent::REG_DATA_HSS_FAIL, 0);
-      SAS::report_event(event);
-      _http_rc = HTTP_NOT_FOUND;
-    }
-    break;
     default:
       TRC_INFO("Server-Assignment answer with result code %d - reject", result_code);
       SAS::Event event(this->trail(), SASEvent::REG_DATA_HSS_FAIL, 0);
+      event.add_static_param(result_code);
       SAS::report_event(event);
-      _http_rc = HTTP_SERVER_ERROR;
+      _http_rc = (result_code == 5001) ? HTTP_NOT_FOUND : HTTP_SERVER_ERROR;
       break;
   }
 

--- a/src/handlers.cpp
+++ b/src/handlers.cpp
@@ -1687,8 +1687,9 @@ void ImpuRegDataTask::on_sar_response(Diameter::Message& rsp)
   Cx::ServerAssignmentAnswer saa(rsp);
   int32_t result_code = 0;
   saa.result_code(result_code);
+  int32_t experimental_result_code = saa.experimental_result_code();
   sar_results_tbl->increment(SNMP::DiameterAppId::BASE, result_code);
-  TRC_DEBUG("Received Server-Assignment answer with result code %d", result_code);
+  TRC_DEBUG("Received Server-Assignment answer with result code %d and experimental result code %d", result_code, experimental_result_code);
 
   switch (result_code)
   {
@@ -1710,6 +1711,7 @@ void ImpuRegDataTask::on_sar_response(Diameter::Message& rsp)
       TRC_INFO("Server-Assignment answer with result code %d - reject", result_code);
       SAS::Event event(this->trail(), SASEvent::REG_DATA_HSS_FAIL, 0);
       event.add_static_param(result_code);
+      event.add_static_param(experimental_result_code);
       SAS::report_event(event);
       _http_rc = (result_code == 5001) ? HTTP_NOT_FOUND : HTTP_SERVER_ERROR;
       break;


### PR DESCRIPTION
Added tracing of Diameter returncodes to SAS.

Tested using an HSS that was rejecting deregistrations with a 5003 DIAMETER_AUTHORIZATION_REJECTED error