### PR TITLE
[Reviewer: RKD] Ensure records are preserved until binding expires

### DIFF
--- a/debian/homestead.init.d
+++ b/debian/homestead.init.d
@@ -190,6 +190,7 @@ get_daemon_args()
                      --server-name=\"$server_name\"
                      --impu-cache-ttl=$impu_cache_ttl
                      --hss-reregistration-time=$hss_reregistration_time
+                     --reg-max-expires=$reg_max_expires
                      --sprout-http-name=$sprout_http_name
                      $scheme_args
                      $diameter_timeout_ms_arg

--- a/debian/homestead.init.d
+++ b/debian/homestead.init.d
@@ -100,23 +100,11 @@ get_settings()
         scscf=5054
         impu_cache_ttl=0
         max_peers=2
+        hss_reregistration_time=1800
         reg_max_expires=300
         log_level=2
         num_http_threads=$(($(grep processor /proc/cpuinfo | wc -l) * 50))
         . /etc/clearwater/config
-
-        if [ -z $hss_reregistration_time ]
-        then
-          # Default hss_reregistration_time to max(1800, $reg_max_expires/2), so
-          # that homestead only discards expired registration data when sprout
-          # does (at the earliest).
-          hss_reregistration_time=$(( $reg_max_expires / 2 ))
-
-          if [ $hss_reregistration_time -lt 1800 ]
-          then
-            hss_reregistration_time=1800
-          fi
-        fi
 
         # Derive server_name and sprout_http_name from other settings
         if [ -n "$scscf_uri" ]

--- a/include/handlers.h
+++ b/include/handlers.h
@@ -448,15 +448,18 @@ public:
   {
     Config(bool _hss_configured = true,
            int _hss_reregistration_time = 3600,
-           int _reg_max_expires = 300,
+           int _record_ttl = 7200,
            int _diameter_timeout_ms = 200) :
       hss_configured(_hss_configured),
       hss_reregistration_time(_hss_reregistration_time),
-      reg_max_expires(_reg_max_expires),
-      diameter_timeout_ms(_diameter_timeout_ms) {}
+      record_ttl(_record_ttl),
+      diameter_timeout_ms(_diameter_timeout_ms)
+    {
+    }
+
     bool hss_configured;
     int hss_reregistration_time;
-    int reg_max_expires;
+    int record_ttl;
     int diameter_timeout_ms;
   };
 
@@ -536,13 +539,11 @@ public:
     Config(Cache* _cache,
            Cx::Dictionary* _dict,
            SproutConnection* _sprout_conn,
-           int _hss_reregistration_time = 3600,
-           int _reg_max_expires = 300) :
+           int _hss_reregistration_time = 3600) :
       cache(_cache),
       dict(_dict),
       sprout_conn(_sprout_conn),
-      hss_reregistration_time(_hss_reregistration_time),
-      reg_max_expires(_reg_max_expires) {}
+      hss_reregistration_time(_hss_reregistration_time) {}
 
     Cache* cache;
     Cx::Dictionary* dict;
@@ -595,18 +596,18 @@ public:
            Cx::Dictionary* _dict,
            int _impu_cache_ttl = 0,
            int _hss_reregistration_time = 3600,
-           int _reg_max_expires = 300) :
+           int _record_ttl = 7200) :
       cache(_cache),
       dict(_dict),
       impu_cache_ttl(_impu_cache_ttl),
       hss_reregistration_time(_hss_reregistration_time),
-      reg_max_expires(_reg_max_expires) {}
+      record_ttl(_record_ttl) {}
 
     Cache* cache;
     Cx::Dictionary* dict;
     int impu_cache_ttl;
     int hss_reregistration_time;
-    int reg_max_expires;
+    int record_ttl;
   };
 
   PushProfileTask(const Diameter::Dictionary* dict,

--- a/include/handlers.h
+++ b/include/handlers.h
@@ -448,12 +448,15 @@ public:
   {
     Config(bool _hss_configured = true,
            int _hss_reregistration_time = 3600,
+           int _reg_max_expires = 300,
            int _diameter_timeout_ms = 200) :
       hss_configured(_hss_configured),
       hss_reregistration_time(_hss_reregistration_time),
+      reg_max_expires(_reg_max_expires),
       diameter_timeout_ms(_diameter_timeout_ms) {}
     bool hss_configured;
     int hss_reregistration_time;
+    int reg_max_expires;
     int diameter_timeout_ms;
   };
 
@@ -533,16 +536,19 @@ public:
     Config(Cache* _cache,
            Cx::Dictionary* _dict,
            SproutConnection* _sprout_conn,
-           int _hss_reregistration_time = 3600) :
+           int _hss_reregistration_time = 3600,
+           int _reg_max_expires = 300) :
       cache(_cache),
       dict(_dict),
       sprout_conn(_sprout_conn),
-      hss_reregistration_time(_hss_reregistration_time) {}
+      hss_reregistration_time(_hss_reregistration_time),
+      reg_max_expires(_reg_max_expires) {}
 
     Cache* cache;
     Cx::Dictionary* dict;
     SproutConnection* sprout_conn;
     int hss_reregistration_time;
+    int reg_max_expires;
   };
 
   RegistrationTerminationTask(const Diameter::Dictionary* dict,
@@ -588,16 +594,19 @@ public:
     Config(Cache* _cache,
            Cx::Dictionary* _dict,
            int _impu_cache_ttl = 0,
-           int _hss_reregistration_time = 3600) :
+           int _hss_reregistration_time = 3600,
+           int _reg_max_expires = 300) :
       cache(_cache),
       dict(_dict),
       impu_cache_ttl(_impu_cache_ttl),
-      hss_reregistration_time(_hss_reregistration_time) {}
+      hss_reregistration_time(_hss_reregistration_time),
+      reg_max_expires(_reg_max_expires) {}
 
     Cache* cache;
     Cx::Dictionary* dict;
     int impu_cache_ttl;
     int hss_reregistration_time;
+    int reg_max_expires;
   };
 
   PushProfileTask(const Diameter::Dictionary* dict,

--- a/include/handlers.h
+++ b/include/handlers.h
@@ -453,9 +453,7 @@ public:
       hss_configured(_hss_configured),
       hss_reregistration_time(_hss_reregistration_time),
       record_ttl(_record_ttl),
-      diameter_timeout_ms(_diameter_timeout_ms)
-    {
-    }
+      diameter_timeout_ms(_diameter_timeout_ms) {}
 
     bool hss_configured;
     int hss_reregistration_time;

--- a/src/handlers.cpp
+++ b/src/handlers.cpp
@@ -1192,6 +1192,11 @@ void ImpuRegDataTask::on_get_reg_data_success(CassandraStore::Operation* op)
   // Split the processing depending on whether an HSS is configured.
   if (_cfg->hss_configured)
   {
+    // We need the record to last twice the HSS Re-registration
+    // time, or the max expiry of the registration, which ever one
+    // is longer.
+    int record_ttl = std::max(2 * _cfg->hss_reregistration_time, _cfg->reg_max_expires + 10);
+
     // If the subscriber is registering with a new binding, store
     // the private Id in the cache.
     if (new_binding)
@@ -1204,7 +1209,7 @@ void ImpuRegDataTask::on_get_reg_data_success(CassandraStore::Operation* op)
         _cache->create_PutAssociatedPrivateID(public_ids,
                                               _impi,
                                               Cache::generate_timestamp(),
-                                              (2 * _cfg->hss_reregistration_time));
+                                              record_ttl);
       CassandraStore::Transaction* tsx = new CacheTransaction;
 
       // TODO: Technically, we should be blocking our response until this PUT
@@ -1227,19 +1232,20 @@ void ImpuRegDataTask::on_get_reg_data_success(CassandraStore::Operation* op)
       // still need to tell the HSS.
       if ((_original_state == RegistrationState::REGISTERED) && (!new_binding))
       {
-        TRC_DEBUG("Handling re-registration");
+        int record_age = record_ttl - ttl;
+        TRC_DEBUG("Handling re-registration with binding age of %d", record_age);
         _new_state = RegistrationState::REGISTERED;
 
-        // We set the record's TTL to be double the --hss-reregistration-time
-        // option - once half that time has elapsed, it's time to re-notify the
-        // HSS.
+        // We refresh the record's TTL everytime we receive an SAA from
+        // the HSS. As such once the record is older than the HSS Reregistration
+        // time, we need to send a new SAR to the HSS.
         //
         // Alternatively we need to notify the HSS if the HTTP request does not
         // allow cached responses.
-        if (ttl < _cfg->hss_reregistration_time)
+        if (record_age >= _cfg->hss_reregistration_time)
         {
           TRC_DEBUG("Sending re-registration to HSS as %d seconds have passed",
-                    _cfg->hss_reregistration_time);
+                    record_age, _cfg->hss_reregistration_time);
           send_server_assignment_request(Cx::ServerAssignmentType::RE_REGISTRATION);
         }
         else if (cache_not_allowed)
@@ -1548,7 +1554,7 @@ void ImpuRegDataTask::put_in_cache()
     // setting the TTL to be the registration time, as it means there
     // are no gaps where the data has expired but we haven't received
     // a REGISTER yet.
-    ttl = (2 * _cfg->hss_reregistration_time);
+    ttl = std::max(2 * _cfg->hss_reregistration_time, _cfg->reg_max_expires + 10);
   }
   else
   {
@@ -2334,10 +2340,11 @@ void PushProfileTask::update_reg_data()
     }
 
     // Create the cache request object and a SAS event simultaneously.
+    int ttl = std::max(2 * _cfg->hss_reregistration_time, _cfg->reg_max_expires + 10);
     Cache::PutRegData* put_reg_data =
       _cfg->cache->create_PutRegData(_impus,
                                      Cache::generate_timestamp(),
-                                     (2 * _cfg->hss_reregistration_time));
+                                     ttl);
     SAS::Event event(this->trail(), SASEvent::CACHE_PUT_REG_DATA, 0);
 
     std::string impus_str = boost::algorithm::join(_impus, ", ");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -811,13 +811,10 @@ int main(int argc, char**argv)
                                        options.scheme_digest,
                                        options.scheme_aka,
                                        options.diameter_timeout_ms);
-
   ImpiRegistrationStatusTask::Config registration_status_handler_config(hss_configured,
                                                                         options.diameter_timeout_ms);
-
   ImpuLocationInfoTask::Config location_info_handler_config(hss_configured,
                                                             options.diameter_timeout_ms);
-
   ImpuRegDataTask::Config impu_handler_config(hss_configured,
                                               options.hss_reregistration_time,
                                               record_ttl,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -83,6 +83,7 @@ struct options
   std::string server_name;
   int impu_cache_ttl;
   int hss_reregistration_time;
+  int reg_max_expires;
   std::string sprout_http_name;
   std::string scheme_unknown;
   std::string scheme_digest;
@@ -128,7 +129,8 @@ enum OptionTypes
   FORCE_HSS_PEER,
   SAS_USE_SIGNALING_IF,
   PIDFILE,
-  DAEMON
+  DAEMON,
+  REG_MAX_EXPIRES
 };
 
 const static struct option long_opt[] =
@@ -148,6 +150,7 @@ const static struct option long_opt[] =
   {"server-name",                 required_argument, NULL, 's'},
   {"impu-cache-ttl",              required_argument, NULL, 'i'},
   {"hss-reregistration-time",     required_argument, NULL, 'I'},
+  {"reg-max-expires",             required_argument, NULL, REG_MAX_EXPIRES},
   {"sprout-http-name",            required_argument, NULL, 'j'},
   {"scheme-unknown",              required_argument, NULL, SCHEME_UNKNOWN},
   {"scheme-digest",               required_argument, NULL, SCHEME_DIGEST},
@@ -341,6 +344,11 @@ int init_options(int argc, char**argv, struct options& options)
     case 'I':
       TRC_INFO("HSS reregistration time: %s", optarg);
       options.hss_reregistration_time = atoi(optarg);
+      break;
+
+    case REG_MAX_EXPIRES:
+      TRC_INFO("Maximum registration expiry time: %s", optarg);
+      options.reg_max_expires = atoi(optarg);
       break;
 
     case 'j':
@@ -543,6 +551,7 @@ int main(int argc, char**argv)
   options.access_log_enabled = false;
   options.impu_cache_ttl = 0;
   options.hss_reregistration_time = 1800;
+  options.reg_max_expires = 300;
   options.sprout_http_name = "sprout-http-name.unknown";
   options.log_to_file = false;
   options.log_level = 0;
@@ -747,8 +756,17 @@ int main(int argc, char**argv)
                               host_counter);
     dict = new Cx::Dictionary();
 
-    rtr_config = new RegistrationTerminationTask::Config(cache, dict, sprout_conn, options.hss_reregistration_time);
-    ppr_config = new PushProfileTask::Config(cache, dict, options.impu_cache_ttl, options.hss_reregistration_time);
+    rtr_config = new RegistrationTerminationTask::Config(cache,
+                                                         dict,
+                                                         sprout_conn,
+                                                         options.hss_reregistration_time,
+                                                         options.reg_max_expires);
+    ppr_config = new PushProfileTask::Config(cache,
+                                             dict,
+                                             options.impu_cache_ttl,
+                                             options.hss_reregistration_time,
+                                             options.reg_max_expires);
+
     rtr_task = new Diameter::SpawningHandler<RegistrationTerminationTask, RegistrationTerminationTask::Config>(dict, rtr_config);
     ppr_task = new Diameter::SpawningHandler<PushProfileTask, PushProfileTask::Config>(dict, ppr_config);
 

--- a/src/ut/handlers_test.cpp
+++ b/src/ut/handlers_test.cpp
@@ -429,11 +429,16 @@ public:
                          std::string expected_result = REGDATA_RESULT,
                          RegistrationState expected_new_state = RegistrationState::REGISTERED,
                          bool expect_deletion = false,
-                         CassandraStore::ResultCode cache_error = CassandraStore::OK)
+                         CassandraStore::ResultCode cache_error = CassandraStore::OK,
+                         int hss_reregistration_timeout = 3600,
+                         int reg_max_expires = 300,
+                         int expected_ttl = 7200)
   {
     // Configure the task to use a HSS, and send a RE_REGISTRATION
     // SAR to the HSS every hour.
-    ImpuRegDataTask::Config cfg(true, 3600);
+    ImpuRegDataTask::Config cfg(true,
+                                hss_reregistration_timeout,
+                                reg_max_expires);
     ImpuRegDataTask* task = new ImpuRegDataTask(req, &cfg, FAKE_TRAIL_ID);
 
     // Once the request is processed by the task, we expect it to
@@ -470,7 +475,7 @@ public:
     MockCache::MockPutAssociatedPrivateID mock_op2;
     if (new_binding)
     {
-      EXPECT_CALL(*_cache, create_PutAssociatedPrivateID(IMPU_REG_SET, IMPI, _, 7200))
+      EXPECT_CALL(*_cache, create_PutAssociatedPrivateID(IMPU_REG_SET, IMPI, _, expected_ttl))
         .WillOnce(Return(&mock_op2));
       EXPECT_DO_ASYNC(*_cache, mock_op2);
     }
@@ -519,7 +524,7 @@ public:
       // Once we simulate the Diameter response, check that the
       // database is updated.
       MockCache::MockPutRegData mock_op3;
-      EXPECT_CALL(*_cache, create_PutRegData(IMPU_REG_SET, _, 7200))
+      EXPECT_CALL(*_cache, create_PutRegData(IMPU_REG_SET, _, expected_ttl))
         .WillOnce(Return(&mock_op3));
       EXPECT_CALL(mock_op3, with_xml(IMPU_IMS_SUBSCRIPTION))
         .WillOnce(ReturnRef(mock_op3));
@@ -606,8 +611,10 @@ public:
   void reg_data_template_no_sar(std::string request_type,
                                 bool use_impi,
                                 RegistrationState db_regstate,
-                                int db_ttl = 3600,
-                                std::string expected_result = REGDATA_RESULT)
+                                int db_ttl = 7200,
+                                std::string expected_result = REGDATA_RESULT,
+                                int hss_reregistration_timeout = 3600,
+                                int reg_max_expires = 300)
   {
     MockHttpStack::Request req(_httpstack,
                                "/impu/" + IMPU + "/reg-data",
@@ -618,7 +625,9 @@ public:
 
     // Configure the task to use a HSS, and send a RE_REGISTRATION
     // SAR to the HSS every hour.
-    ImpuRegDataTask::Config cfg(true, 3600);
+    ImpuRegDataTask::Config cfg(true,
+                                hss_reregistration_timeout,
+                                reg_max_expires);
     ImpuRegDataTask* task = new ImpuRegDataTask(req, &cfg, FAKE_TRAIL_ID);
 
     // Once the request is processed by the task, we expect it to
@@ -2327,20 +2336,42 @@ TEST_F(HandlersTest, IMSSubscriptionHSS_ReregNewBinding)
 }
 
 // Re-registration with no new binding, but with cached responses not allowed.
-// This means homestead still sends a SAR.
+// This means homestead still sends a SAR. We need the cache to be valid, i.e.
+// more than 3600.
 TEST_F(HandlersTest, IMSSubscriptionHSS_ReregCacheNotallowed)
 {
   MockHttpStack::Request req = make_request("reg", true, true);
   req.add_header_to_incoming_req("Cache-control", "no-cache");
-  reg_data_template(req, true, true, false, RegistrationState::REGISTERED, 2);
+  reg_data_template(req, true, true, false, RegistrationState::REGISTERED, 2, 7200);
 }
 
 // Re-registration when the database record is not old enough to
 // trigger a new SAR.
-
 TEST_F(HandlersTest, IMSSubscriptionHSS_ReregWithoutSAR)
 {
   reg_data_template_no_sar("reg", true, RegistrationState::REGISTERED);
+}
+
+// Re-registration when configured to always send a SAR - i.e.
+// hss_reregistration_timeout = 0. The ttl on the record is
+// expected to be 310
+TEST_F(HandlersTest, IMSSubscriptionHSS_ReregWithSARAlways)
+{
+  MockHttpStack::Request req = make_request("reg", true, true);
+  reg_data_template(req,
+                    true,
+                    true,
+                    false,
+                    RegistrationState::REGISTERED,
+                    2,
+                    310,
+                    REGDATA_RESULT,
+                    RegistrationState::REGISTERED,
+                    false,
+                    CassandraStore::OK,
+                    0,
+                    300,
+                    310);
 }
 
 // Call to a registered subscriber

--- a/src/ut/handlers_test.cpp
+++ b/src/ut/handlers_test.cpp
@@ -432,13 +432,13 @@ public:
                          CassandraStore::ResultCode cache_error = CassandraStore::OK,
                          int hss_reregistration_timeout = 3600,
                          int reg_max_expires = 300,
-                         int expected_ttl = 7200)
+                         int record_ttl = 7200)
   {
     // Configure the task to use a HSS, and send a RE_REGISTRATION
     // SAR to the HSS every hour.
     ImpuRegDataTask::Config cfg(true,
                                 hss_reregistration_timeout,
-                                reg_max_expires);
+                                record_ttl);
     ImpuRegDataTask* task = new ImpuRegDataTask(req, &cfg, FAKE_TRAIL_ID);
 
     // Once the request is processed by the task, we expect it to
@@ -475,7 +475,7 @@ public:
     MockCache::MockPutAssociatedPrivateID mock_op2;
     if (new_binding)
     {
-      EXPECT_CALL(*_cache, create_PutAssociatedPrivateID(IMPU_REG_SET, IMPI, _, expected_ttl))
+      EXPECT_CALL(*_cache, create_PutAssociatedPrivateID(IMPU_REG_SET, IMPI, _, record_ttl))
         .WillOnce(Return(&mock_op2));
       EXPECT_DO_ASYNC(*_cache, mock_op2);
     }
@@ -524,7 +524,7 @@ public:
       // Once we simulate the Diameter response, check that the
       // database is updated.
       MockCache::MockPutRegData mock_op3;
-      EXPECT_CALL(*_cache, create_PutRegData(IMPU_REG_SET, _, expected_ttl))
+      EXPECT_CALL(*_cache, create_PutRegData(IMPU_REG_SET, _, record_ttl))
         .WillOnce(Return(&mock_op3));
       EXPECT_CALL(mock_op3, with_xml(IMPU_IMS_SUBSCRIPTION))
         .WillOnce(ReturnRef(mock_op3));
@@ -614,7 +614,7 @@ public:
                                 int db_ttl = 7200,
                                 std::string expected_result = REGDATA_RESULT,
                                 int hss_reregistration_timeout = 3600,
-                                int reg_max_expires = 300)
+                                int record_ttl = 7200)
   {
     MockHttpStack::Request req(_httpstack,
                                "/impu/" + IMPU + "/reg-data",
@@ -627,7 +627,7 @@ public:
     // SAR to the HSS every hour.
     ImpuRegDataTask::Config cfg(true,
                                 hss_reregistration_timeout,
-                                reg_max_expires);
+                                record_ttl);
     ImpuRegDataTask* task = new ImpuRegDataTask(req, &cfg, FAKE_TRAIL_ID);
 
     // Once the request is processed by the task, we expect it to
@@ -4626,7 +4626,7 @@ TEST_F(HandlerStatsTest, IMSSubscriptionReregHSS)
                              "{\"reqtype\": \"reg\"}",
                              htp_method_PUT);
 
-  ImpuRegDataTask::Config cfg(true, 1800);
+  ImpuRegDataTask::Config cfg(true, 1800, 3600);
   ImpuRegDataTask* task = new ImpuRegDataTask(req, &cfg, FAKE_TRAIL_ID);
 
   // Once the task's run function is called, expect to lookup IMS


### PR DESCRIPTION
Fixes issue #360 as hss_reregistration_timeout can be configured to
0 to force all re-registrations to result in a SAR/SAA.