### PR TITLE
[Reviewer: GDR] Add cached data management API. 

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -37,7 +37,7 @@ Description: Debugging symbols for homestead-node, the HSS Cache/Gateway node
 
 Package: homestead
 Architecture: any
-Depends: clearwater-infrastructure, clearwater-tcp-scalability, clearwater-log-cleanup, homestead-libs, libboost-regex1.54.0, libzmq3, libcurl3-gnutls, gnutls-bin, clearwater-socket-factory, libboost-filesystem1.54.0, libsnmp30 (>= 5.7.2~dfsg-clearwater4), clearwater-monit
+Depends: clearwater-infrastructure, clearwater-tcp-scalability, clearwater-log-cleanup, homestead-libs, libboost-regex1.54.0, libzmq3, libcurl3-gnutls, gnutls-bin, clearwater-socket-factory, libboost-filesystem1.54.0, libsnmp30 (>= 5.7.2~dfsg-clearwater4), clearwater-monit, clearwater-nginx
 Suggests: homestead-dbg, clearwater-logging, clearwater-snmp-alarm-agent
 Description: Homestead, the HSS Cache/Gateway
 

--- a/homestead.root/usr/share/clearwater/infrastructure/scripts/create-homestead-nginx-config
+++ b/homestead.root/usr/share/clearwater/infrastructure/scripts/create-homestead-nginx-config
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+# @file create-homestead-nginx-config
+#
+# Project Clearwater - IMS in the Cloud
+# Copyright (C) 2016 Metaswitch Networks Ltd
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version, along with the "Special Exception" for use of
+# the program along with SSL, set forth below. This program is distributed
+# in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details. You should have received a copy of the GNU General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+# The author can be reached by email at clearwater@metaswitch.com or by
+# post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+#
+# Special Exception
+# Metaswitch Networks Ltd  grants you permission to copy, modify,
+# propagate, and distribute a work formed by combining OpenSSL with The
+# Software, or a work derivative of such a combination, even if such
+# copying, modification, propagation, or distribution would otherwise
+# violate the terms of the GPL. You must comply with the GPL in all
+# respects for all of the code used other than OpenSSL.
+# "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+# Project and licensed under the OpenSSL Licenses, or a work based on such
+# software and licensed under the OpenSSL Licenses.
+# "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+# under which the OpenSSL Project distributes the OpenSSL toolkit software,
+# as those licenses appear in the file LICENSE-OPENSSL.
+
+# This file creates an nginx config file for homestead.
+
+. /etc/clearwater/config
+
+if [ -n "$hs_hostname" ]
+then
+  site_file=/etc/nginx/sites-available/homestead
+  enabled_file=/etc/nginx/sites-enabled/homestead
+  temp_file=$(mktemp homestead.nginx.XXXXXXXX)
+
+  cat > $temp_file << EOF
+upstream http_homestead {
+        server unix:/tmp/homestead-http-mgmt-socket;
+
+        # The minimum number of idle connections to keep alive to the upstream.
+        keepalive 16;
+}
+
+server {
+        listen       [::]:8886 ipv6only=off;
+        server_name  $hs_hostname;
+
+        location / {
+                proxy_pass http://http_homestead;
+                proxy_http_version 1.1;
+
+                # The client may have instructed the server to close the
+                # connection - do not forward this upstream.
+                proxy_set_header Connection "";
+        }
+}
+EOF
+
+  if ! diff $temp_file $enabled_file > /dev/null 2>&1
+  then
+    # Update the site file
+    mv $temp_file $site_file
+
+    # Enable the homestead nginx site
+    if ( nginx_ensite homestead > /dev/null )
+    then
+      service nginx stop
+    fi
+  else
+    rm $temp_file
+  fi
+fi

--- a/homestead.root/usr/share/clearwater/infrastructure/scripts/create-homestead-nginx-config
+++ b/homestead.root/usr/share/clearwater/infrastructure/scripts/create-homestead-nginx-config
@@ -38,11 +38,17 @@
 
 . /etc/clearwater/config
 
-if [ -n "$hs_hostname" ]
+split_domain_and_port()
+{
+  echo $1 | perl -ne '$_ =~ /(.+):([0-9]+)$/ && print "$1 $2\n"'
+}
+
+if [ -n "$hs_mgmt_hostname" ]
 then
   site_file=/etc/nginx/sites-available/homestead
   enabled_file=/etc/nginx/sites-enabled/homestead
   temp_file=$(mktemp homestead.nginx.XXXXXXXX)
+  server_name_and_port=( $( split_domain_and_port $hs_mgmt_hostname ) )
 
   cat > $temp_file << EOF
 upstream http_homestead {
@@ -54,7 +60,7 @@ upstream http_homestead {
 
 server {
         listen       [::]:8886 ipv6only=off;
-        server_name  $hs_hostname;
+        server_name  ${server_name_and_port[0]};
 
         location / {
                 proxy_pass http://http_homestead;

--- a/include/cache.h
+++ b/include/cache.h
@@ -597,7 +597,7 @@ public:
     ListImpus() {}
     virtual ~ListImpus() {}
 
-    std::vector<std::string>& get_impus_ref() { return _impus; }
+    virtual std::vector<std::string>& get_impus_ref() { return _impus; }
 
   protected:
     bool perform(CassandraStore::Client* client, SAS::TrailId trail);

--- a/include/cache.h
+++ b/include/cache.h
@@ -587,6 +587,27 @@ public:
   {
     return new DissociateImplicitRegistrationSetFromImpi(impus, impis, timestamp);
   }
+
+  ///
+  /// TODO
+  ///
+  class ListImpus : public CassandraStore::Operation
+  {
+  public:
+    ListImpus() {}
+    virtual ~ListImpus() {}
+
+    std::vector<std::string>& get_impus_ref() { return _impus; }
+
+  protected:
+    bool perform(CassandraStore::Client* client, SAS::TrailId trail);
+    std::vector<std::string> _impus;
+  };
+
+  virtual ListImpus* create_ListImpus()
+  {
+    return new ListImpus();
+  }
 };
 
 #endif

--- a/include/cache.h
+++ b/include/cache.h
@@ -588,20 +588,30 @@ public:
     return new DissociateImplicitRegistrationSetFromImpi(impus, impis, timestamp);
   }
 
-  /// Get all the IMPUs for which Homestead has data in its cache.
+  /// List the IMPUs for which Homestead has data in its cache.
   ///
-  /// - When an HSS is in use, this lists all subscribers for which homestead is
-  /// storing data learned from the HSS (which in practise is all subscribers
-  /// that are assigned to this S-CSCF in the HSS).
-  /// - When subscribers are locally provisioned this returns all provisioned
-  /// subscribers.
+  /// -  When an HSS is in use, this lists all subscribers for which homestead
+  ///    is storing data learned from the HSS (which in practise is all
+  ///    subscribers that are assigned to this S-CSCF in the HSS).
+  /// -  When subscribers are locally provisioned this returns all provisioned
+  ///    subscribers.
+  ///
+  /// This operation returns results in pseudo-random order (determined by the
+  /// cassandra partitioner).
+  ///
+  /// This operation returns at most 1000 results. Because of the way cassandra
+  /// stores data internally and because of how this is accessed over thrift,
+  /// the operation is not guaranteed to return all rows, even if there are
+  /// fewer than 1000 in the database. However rows will never be missed out
+  /// (e.g. if only 800 are returned, they will be the first 800 in the
+  /// pseudo-random order).
   class ListImpus : public CassandraStore::Operation
   {
   public:
     ListImpus() {}
     virtual ~ListImpus() {}
 
-    virtual std::vector<std::string>& get_impus_ref() { return _impus; }
+    virtual std::vector<std::string>& get_impus_reference() { return _impus; }
 
   protected:
     bool perform(CassandraStore::Client* client, SAS::TrailId trail);

--- a/include/cache.h
+++ b/include/cache.h
@@ -588,9 +588,13 @@ public:
     return new DissociateImplicitRegistrationSetFromImpi(impus, impis, timestamp);
   }
 
+  /// Get all the IMPUs for which Homestead has data in its cache.
   ///
-  /// TODO
-  ///
+  /// - When an HSS is in use, this lists all subscribers for which homestead is
+  /// storing data learned from the HSS (which in practise is all subscribers
+  /// that are assigned to this S-CSCF in the HSS).
+  /// - When subscribers are locally provisioned this returns all provisioned
+  /// subscribers.
   class ListImpus : public CassandraStore::Operation
   {
   public:

--- a/include/handlers.h
+++ b/include/handlers.h
@@ -92,6 +92,7 @@ const std::string JSON_INTEGRITYKEY = "integritykey";
 const std::string JSON_VERSION = "version";
 const std::string JSON_RC = "result-code";
 const std::string JSON_SCSCF = "scscf";
+const std::string JSON_IMPUS = "impus";
 
 // HTTP query string field names
 const std::string AUTH_FIELD_NAME = "resync-auth";
@@ -656,6 +657,30 @@ private:
                                CassandraStore::ResultCode error,
                                std::string& text);
   void send_ppa(const std::string result_code);
+};
+
+class ImpuListTask : public HssCacheTask
+{
+public:
+  struct Config {};
+
+  ImpuListTask(HttpStack::Request& req, const Config* cfg, SAS::TrailId trail) :
+    HssCacheTask(req, trail), _cfg(cfg)
+  {}
+
+  virtual ~ImpuListTask() {};
+
+  virtual void run();
+
+  void on_list_impu_success(CassandraStore::Operation* op);
+  void on_list_impu_failure(CassandraStore::Operation* op,
+                            CassandraStore::ResultCode error,
+                            std::string& text);
+
+  typedef HssCacheTask::CacheTransaction<ImpuListTask> CacheTransaction;
+
+protected:
+  const Config* _cfg;
 };
 
 void configure_cx_results_tables(SNMP::CxCounterTable* mar_results_table,

--- a/include/handlers.h
+++ b/include/handlers.h
@@ -521,6 +521,16 @@ protected:
   std::string _provided_server_name;
 };
 
+class ImpuReadRegDataTask : public ImpuRegDataTask
+{
+public:
+  // Just use the superclass's constructor.
+  using ImpuRegDataTask::ImpuRegDataTask;
+
+  virtual ~ImpuReadRegDataTask() {}
+  virtual void run();
+};
+
 class ImpuIMSSubscriptionTask : public ImpuRegDataTask
 {
 public:

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -1019,12 +1019,12 @@ bool Cache::ListImpus::perform(CassandraStore::Client* client, SAS::TrailId trai
   //
   // In Cassandra, deleted rows appear like rows with no columns. So we need to
   // ask for a column we know should exist (to determine if the row exists or
-  // not). The only column that must exists is the subscription XML, but this is
-  // large so we don't want to retrieve it for every subscriber. However, each
-  // row will have either been provisioned (meaning `_exists` will be present)
-  // or will have been created by registration (meaning `is_registered` will be
-  // present). So if we ask for both and get either back, then the row does
-  // really exists (and is not an artifact of a deleted row).
+  // not). The only column that must exists is the subscription XML so fetch
+  // this.
+  //
+  // TODO: The XML column contains a lot of data so it would be better to
+  // instead write an `_exists` column to cassandra and use that to determine if
+  // the row is present.
   SlicePredicate sp;
   sp.__set_column_names({IMS_SUB_XML_COLUMN_NAME});
 

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -1026,7 +1026,7 @@ bool Cache::ListImpus::perform(CassandraStore::Client* client, SAS::TrailId trai
   // present). So if we ask for both and get either back, then the row does
   // really exists (and is not an artifact of a deleted row).
   SlicePredicate sp;
-  sp.__set_column_names({REG_STATE_COLUMN_NAME, EXISTS_COLUMN_NAME});
+  sp.__set_column_names({IMS_SUB_XML_COLUMN_NAME});
 
   KeyRange kr;
   kr.__set_start_key(""); // Start from the beginning.

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -995,3 +995,35 @@ bool Cache::DissociateImplicitRegistrationSetFromImpi::perform(CassandraStore::C
 
   return true;
 }
+
+//
+// Operation that lists all the IMPUs in the impu table.
+//
+
+// The maximum number of IMPUs to request (and therefore return) on each
+// database query.
+const int MAX_IMPUS_TO_RETURN = 1000;
+
+bool Cache::ListImpus::perform(CassandraStore::Client* client, SAS::TrailId trail)
+{
+  std::vector<KeySlice> key_slices;
+
+  ColumnParent cparent;
+  cparent.__set_column_family("impu");
+
+  SlicePredicate sp;
+  sp.__set_column_names({});
+
+  KeyRange kr;
+  kr.__set_start_key("");
+  kr.__set_count(MAX_IMPUS_TO_RETURN);
+
+  client->get_range_slices(key_slices, cparent, sp, kr, ConsistencyLevel::ONE);
+
+  for (const KeySlice& key_slice: key_slices)
+  {
+    _impus.push_back(key_slice.key);
+  }
+
+  return true;
+}

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -65,6 +65,9 @@ const static std::string DIGEST_HA1_COLUMN_NAME      ="digest_ha1";
 const static std::string DIGEST_REALM_COLUMN_NAME    = "digest_realm";
 const static std::string DIGEST_QOP_COLUMN_NAME      = "digest_qop";
 
+// Column name marking rows created by homestead-prov
+const static std::string EXISTS_COLUMN_NAME = "_exists";
+
 // Variables to store the singleton cache object.
 //
 // Must create this after the constants above so that they have been
@@ -1008,21 +1011,37 @@ bool Cache::ListImpus::perform(CassandraStore::Client* client, SAS::TrailId trai
 {
   std::vector<KeySlice> key_slices;
 
+  // Specify what column family (table) we want to work on.
   ColumnParent cparent;
-  cparent.__set_column_family("impu");
+  cparent.__set_column_family(IMPU);
 
+  // Specify what columns we want. We ask for the reg_state and _exists columns.
+  //
+  // In Cassandra, deleted rows appear like rows with no columns. So we need to
+  // ask for a column we know should exist (to determine if the row exists or
+  // not). The only column that must exists is the subscription XML, but this is
+  // large so we don't want to retrieve it for every subscriber. However, each
+  // row will have either been provisioned (meaning `_exists` will be present)
+  // or will have been created by registration (meaning `is_registered` will be
+  // present). So if we ask for both and get either back, then the row does
+  // really exists (and is not an artifact of a deleted row).
   SlicePredicate sp;
-  sp.__set_column_names({});
+  sp.__set_column_names({REG_STATE_COLUMN_NAME, EXISTS_COLUMN_NAME});
 
   KeyRange kr;
-  kr.__set_start_key("");
+  kr.__set_start_key(""); // Start from the beginning.
+  kr.__set_end_key("");   // No end.
   kr.__set_count(MAX_IMPUS_TO_RETURN);
 
   client->get_range_slices(key_slices, cparent, sp, kr, ConsistencyLevel::ONE);
 
   for (const KeySlice& key_slice: key_slices)
   {
-    _impus.push_back(key_slice.key);
+    // Only report an IMPU if some of its columns exist (see comment above).
+    if (!key_slice.columns.empty())
+    {
+      _impus.push_back(key_slice.key);
+    }
   }
 
   return true;

--- a/src/handlers.cpp
+++ b/src/handlers.cpp
@@ -2509,7 +2509,7 @@ void ImpuListTask::run()
 void ImpuListTask::on_list_impu_success(CassandraStore::Operation* op)
 {
   Cache::ListImpus* list_impus = (Cache::ListImpus*)op;
-  std::vector<std::string>& impus = list_impus->get_impus_ref();
+  std::vector<std::string>& impus = list_impus->get_impus_reference();
   TRC_DEBUG("Listing impus returned %d results", impus.size());
 
   rapidjson::StringBuffer sb;

--- a/src/handlers.cpp
+++ b/src/handlers.cpp
@@ -1867,6 +1867,21 @@ void ImpuRegDataTask::on_del_impu_failure(CassandraStore::Operation* op, Cassand
 }
 
 //
+// Version of the reg-data task that is read only (for use on the management
+// interface).
+//
+void ImpuReadRegDataTask::run()
+{
+  if (_req.method() != htp_method_GET)
+  {
+    TRC_DEBUG("Reject non-GET for ImpuReadRegDataTask");
+    send_http_reply(HTTP_BADMETHOD);
+  }
+
+  ImpuRegDataTask::run();
+}
+
+//
 // IMPU IMS Subscription handling for URLs of the form
 // "/impu/<public ID>". Deprecated.
 //

--- a/src/handlers.cpp
+++ b/src/handlers.cpp
@@ -1325,7 +1325,7 @@ void ImpuRegDataTask::on_get_reg_data_success(CassandraStore::Operation* op)
       // Sprout wants to deregister this subscriber (because of a
       // REGISTER with Expires: 0, a timeout of all bindings, a failed
       // app server, etc.).
-      if (_original_state == RegistrationState::REGISTERED)
+      if (_original_state != RegistrationState::NOT_REGISTERED)
       {
         // Forget about this subscriber entirely and send an appropriate SAR.
         TRC_DEBUG("Handling deregistration");

--- a/src/handlers.cpp
+++ b/src/handlers.cpp
@@ -2487,6 +2487,63 @@ void PushProfileTask::send_ppa(const std::string result_code)
   delete this;
 }
 
+void ImpuListTask::run()
+{
+  if (_req.method() != htp_method_GET)
+  {
+    send_http_reply(HTTP_BADMETHOD);
+    delete this;
+    return;
+  }
+
+  CassandraStore::Operation* list_impus = _cache->create_ListImpus();
+  CassandraStore::Transaction* tsx =
+    new CacheTransaction(this,
+                         &ImpuListTask::on_list_impu_success,
+                         &ImpuListTask::on_list_impu_failure);
+  _cache->do_async(list_impus, tsx);
+}
+
+void ImpuListTask::on_list_impu_success(CassandraStore::Operation* op)
+{
+  Cache::ListImpus* list_impus = (Cache::ListImpus*)op;
+  std::vector<std::string>& impus = list_impus->get_impus_ref();
+  TRC_DEBUG("Listing impus returned %d results", impus.size());
+
+  rapidjson::StringBuffer sb;
+  rapidjson::Writer<rapidjson::StringBuffer> writer(sb);
+
+  writer.StartObject();
+  {
+    writer.String(JSON_IMPUS.c_str());
+    writer.StartArray();
+    {
+      for (const std::string& impu: impus)
+      {
+        writer.String(impu.c_str());
+      }
+    }
+    writer.EndArray();
+  }
+  writer.EndObject();
+
+  _req.add_content(sb.GetString());
+  send_http_reply(HTTP_OK);
+
+  delete this;
+  return;
+}
+
+void ImpuListTask::on_list_impu_failure(CassandraStore::Operation* op,
+                                        CassandraStore::ResultCode error,
+                                        std::string& text)
+{
+  TRC_INFO("Could not list impus. Error: %d (%s)", error, text.c_str());
+  send_http_reply(HTTP_SERVER_ERROR);
+  delete this;
+  return;
+}
+
 void configure_cx_results_tables(SNMP::CxCounterTable* mar_results_table,
                                  SNMP::CxCounterTable* sar_results_table,
                                  SNMP::CxCounterTable* uar_results_table,

--- a/src/handlers.cpp
+++ b/src/handlers.cpp
@@ -1876,6 +1876,8 @@ void ImpuReadRegDataTask::run()
   {
     TRC_DEBUG("Reject non-GET for ImpuReadRegDataTask");
     send_http_reply(HTTP_BADMETHOD);
+    delete this;
+    return;
   }
 
   ImpuRegDataTask::run();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -803,7 +803,7 @@ int main(int argc, char**argv)
     exit(2);
   }
 
-  HttpStack* http_stack = HttpStack::get_instance();
+  HttpStack* http_stack = new HttpStack();
   HssCacheTask::configure_diameter(diameter_stack,
                                    options.dest_realm.empty() ? options.home_domain : options.dest_realm,
                                    options.dest_host == "0.0.0.0" ? "" : options.dest_host,
@@ -963,6 +963,7 @@ int main(int argc, char**argv)
   delete ppr_results_table; ppr_results_table = NULL;
   delete rtr_results_table; rtr_results_table = NULL;
 
+  delete http_stack; http_stack = NULL;
   hc->stop_thread();
   delete hc; hc = NULL;
   delete exception_handler; exception_handler = NULL;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -648,7 +648,7 @@ int main(int argc, char**argv)
             options.sas_server,
             sas_write,
             options.sas_signaling_if ? create_connection_in_signaling_namespace
-            : create_connection_in_management_namespace);
+                                     : create_connection_in_management_namespace);
 
   // Set up the statistics (Homestead specific and Diameter)
   snmp_setup("homestead");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -880,6 +880,9 @@ int main(int argc, char**argv)
     exit(2);
   }
 
+  HttpStackUtils::SpawningHandler<ImpuReadRegDataTask, ImpuRegDataTask::Config>
+    impu_read_reg_data_handler(&impu_handler_config);
+
   HttpStack* http_stack_mgmt = new HttpStack(options.http_threads,
                                              exception_handler,
                                              access_logger,
@@ -890,6 +893,8 @@ int main(int argc, char**argv)
     http_stack_mgmt->bind_unix_socket(HTTP_MGMT_SOCKET_PATH);
     http_stack_mgmt->register_handler("^/ping$",
                                       &ping_handler);
+    http_stack_mgmt->register_handler("^/impu/[^/]*/reg-data$",
+                                      &impu_read_reg_data_handler);
     http_stack_mgmt->start();
   }
   catch (HttpStack::Exception& e)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -803,7 +803,6 @@ int main(int argc, char**argv)
     exit(2);
   }
 
-  HttpStack* http_stack = new HttpStack();
   HssCacheTask::configure_diameter(diameter_stack,
                                    options.dest_realm.empty() ? options.home_domain : options.dest_realm,
                                    options.dest_host == "0.0.0.0" ? "" : options.dest_host,
@@ -845,16 +844,16 @@ int main(int argc, char**argv)
   HttpStackUtils::SpawningHandler<ImpuRegDataTask, ImpuRegDataTask::Config> impu_reg_data_handler(&impu_handler_config);
   HttpStackUtils::SpawningHandler<ImpuIMSSubscriptionTask, ImpuIMSSubscriptionTask::Config> impu_ims_sub_handler(&impu_handler_config_old);
 
+  HttpStack* http_stack = new HttpStack(options.http_threads,
+                                        exception_handler,
+                                        access_logger,
+                                        load_monitor,
+                                        stats_manager);
   try
   {
     http_stack->initialize();
-    http_stack->configure(options.http_address,
-                          options.http_port,
-                          options.http_threads,
-                          exception_handler,
-                          access_logger,
-                          load_monitor,
-                          stats_manager);
+    http_stack->bind_tcp_socket(options.http_address,
+                                options.http_port);
     http_stack->register_handler("^/ping$",
                                     &ping_handler);
     http_stack->register_handler("^/impi/[^/]*/digest$",

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -178,7 +178,9 @@ const static struct option long_opt[] =
 };
 
 static std::string options_description = "l:r:c:H:t:u:S:D:d:p:s:i:I:a:F:L:h";
+
 static const std::string HTTP_MGMT_SOCKET_PATH = "/tmp/homestead-http-mgmt-socket";
+static const int NUM_HTTP_MGMT_THREADS = 5;
 
 void usage(void)
 {
@@ -885,7 +887,7 @@ int main(int argc, char**argv)
   HttpStackUtils::SpawningHandler<ImpuReadRegDataTask, ImpuRegDataTask::Config>
     impu_read_reg_data_handler(&impu_handler_config);
 
-  HttpStack* http_stack_mgmt = new HttpStack(options.http_threads,
+  HttpStack* http_stack_mgmt = new HttpStack(NUM_HTTP_MGMT_THREADS,
                                              exception_handler,
                                              access_logger,
                                              load_monitor);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -836,6 +836,7 @@ int main(int argc, char**argv)
   ImpuIMSSubscriptionTask::Config impu_handler_config_old(hss_configured,
                                                           options.hss_reregistration_time,
                                                           options.diameter_timeout_ms);
+  ImpuListTask::Config impu_list_config;
 
   HttpStackUtils::PingHandler ping_handler;
   HttpStackUtils::SpawningHandler<ImpiDigestTask, ImpiTask::Config> impi_digest_handler(&impi_handler_config);
@@ -844,6 +845,7 @@ int main(int argc, char**argv)
   HttpStackUtils::SpawningHandler<ImpuLocationInfoTask, ImpuLocationInfoTask::Config> impu_loc_info_handler(&location_info_handler_config);
   HttpStackUtils::SpawningHandler<ImpuRegDataTask, ImpuRegDataTask::Config> impu_reg_data_handler(&impu_handler_config);
   HttpStackUtils::SpawningHandler<ImpuIMSSubscriptionTask, ImpuIMSSubscriptionTask::Config> impu_ims_sub_handler(&impu_handler_config_old);
+  HttpStackUtils::SpawningHandler<ImpuListTask, ImpuListTask::Config> impu_list_handler(&impu_list_config);
 
   HttpStack* http_stack_sig = new HttpStack(options.http_threads,
                                             exception_handler,
@@ -895,6 +897,8 @@ int main(int argc, char**argv)
                                       &ping_handler);
     http_stack_mgmt->register_handler("^/impu/[^/]*/reg-data$",
                                       &impu_read_reg_data_handler);
+    http_stack_mgmt->register_handler("^/impu/?$",
+                                      &impu_list_handler);
     http_stack_mgmt->start();
   }
   catch (HttpStack::Exception& e)

--- a/src/ut/cache_test.cpp
+++ b/src/ut/cache_test.cpp
@@ -1907,11 +1907,11 @@ class ListImpusRecorder : public ResultRecorderInterface
 public:
   void save(CassandraStore::Operation* op)
   {
-    impus = dynamic_cast<Cache::ListImpus*>(op)->get_impus_ref();
+    impus = dynamic_cast<Cache::ListImpus*>(op)->get_impus_reference();
   }
+
   std::vector<std::string> impus;
 };
-
 
 // Tests listing IMPUs when there aren't any in the database.
 TEST_F(CacheRequestTest, ListImpusNoResults)

--- a/src/ut/handlers_test.cpp
+++ b/src/ut/handlers_test.cpp
@@ -5000,7 +5000,7 @@ TEST_F(HandlersTest, ListImpusNonePresent)
   std::vector<std::string> impus_to_return;
   CassandraStore::Transaction* t = mock_op.get_trx();
   ASSERT_FALSE(t == NULL);
-  EXPECT_CALL(mock_op, get_impus_ref())
+  EXPECT_CALL(mock_op, get_impus_reference())
     .Times(AtLeast(1)).WillRepeatedly(ReturnRef(impus_to_return));
   EXPECT_CALL(*_httpstack, send_reply(_, 200, _));
 
@@ -5024,7 +5024,7 @@ TEST_F(HandlersTest, ListImpusOnePresent)
   std::vector<std::string> impus_to_return = {"kermit"};
   CassandraStore::Transaction* t = mock_op.get_trx();
   ASSERT_FALSE(t == NULL);
-  EXPECT_CALL(mock_op, get_impus_ref())
+  EXPECT_CALL(mock_op, get_impus_reference())
     .Times(AtLeast(1)).WillRepeatedly(ReturnRef(impus_to_return));
   EXPECT_CALL(*_httpstack, send_reply(_, 200, _));
 
@@ -5048,7 +5048,7 @@ TEST_F(HandlersTest, ListImpusTwoPresent)
   std::vector<std::string> impus_to_return = {"kermit", "gonzo"};
   CassandraStore::Transaction* t = mock_op.get_trx();
   ASSERT_FALSE(t == NULL);
-  EXPECT_CALL(mock_op, get_impus_ref())
+  EXPECT_CALL(mock_op, get_impus_reference())
     .Times(AtLeast(1)).WillRepeatedly(ReturnRef(impus_to_return));
   EXPECT_CALL(*_httpstack, send_reply(_, 200, _));
 

--- a/src/ut/handlers_test.cpp
+++ b/src/ut/handlers_test.cpp
@@ -1378,6 +1378,36 @@ public:
     EXPECT_EQ(build_digest_json(digest), req.content());
   }
 
+
+  // Utility method that, when given an IMPU reg data task performs the actions to
+  // retrieve the IMS subscription.
+  void perform_get_ims_subscription(MockHttpStack::Request& req,
+                                    ImpuRegDataTask* task)
+  {
+    MockCache::MockGetRegData mock_op;
+    EXPECT_CALL(*_cache, create_GetRegData(IMPU))
+      .WillOnce(Return(&mock_op));
+    EXPECT_DO_ASYNC(*_cache, mock_op);
+    task->run();
+
+    CassandraStore::Transaction* t = mock_op.get_trx();
+    ASSERT_FALSE(t == NULL);
+    EXPECT_CALL(mock_op, get_xml(_, _)).Times(AtLeast(1))
+      .WillRepeatedly(SetArgReferee<0>(IMPU_IMS_SUBSCRIPTION));
+    EXPECT_CALL(mock_op, get_registration_state(_, _)).Times(AtLeast(1))
+      .WillRepeatedly(SetArgReferee<0>(RegistrationState::REGISTERED));
+    EXPECT_CALL(mock_op, get_associated_impis(_)).Times(AtLeast(1));
+    EXPECT_CALL(mock_op, get_charging_addrs(_)).Times(AtLeast(1))
+      .WillRepeatedly(SetArgReferee<0>(NO_CHARGING_ADDRESSES));
+
+    // HTTP response is sent straight back - no state is changed.
+    EXPECT_CALL(*_httpstack, send_reply(_, 200, _));
+    t->on_success(&mock_op);
+
+    // Build the expected response and check it's correct
+    EXPECT_EQ(REGDATA_RESULT, req.content());
+  }
+
   static void ignore_stats(bool ignore)
   {
     if (ignore)
@@ -2824,28 +2854,7 @@ TEST_F(HandlersTest, IMSSubscriptionGet)
   ImpuRegDataTask::Config cfg(true, 3600);
   ImpuRegDataTask* task = new ImpuRegDataTask(req, &cfg, FAKE_TRAIL_ID);
 
-  MockCache::MockGetRegData mock_op;
-  EXPECT_CALL(*_cache, create_GetRegData(IMPU))
-    .WillOnce(Return(&mock_op));
-  EXPECT_DO_ASYNC(*_cache, mock_op);
-  task->run();
-
-  CassandraStore::Transaction* t = mock_op.get_trx();
-  ASSERT_FALSE(t == NULL);
-  EXPECT_CALL(mock_op, get_xml(_, _)).Times(AtLeast(1))
-    .WillRepeatedly(SetArgReferee<0>(IMPU_IMS_SUBSCRIPTION));
-  EXPECT_CALL(mock_op, get_registration_state(_, _)).Times(AtLeast(1))
-    .WillRepeatedly(SetArgReferee<0>(RegistrationState::REGISTERED));
-  EXPECT_CALL(mock_op, get_associated_impis(_)).Times(AtLeast(1));
-  EXPECT_CALL(mock_op, get_charging_addrs(_)).Times(AtLeast(1))
-    .WillRepeatedly(SetArgReferee<0>(NO_CHARGING_ADDRESSES));
-
-  // HTTP response is sent straight back - no state is changed.
-  EXPECT_CALL(*_httpstack, send_reply(_, 200, _));
-  t->on_success(&mock_op);
-
-  // Build the expected response and check it's correct
-  EXPECT_EQ(REGDATA_RESULT, req.content());
+  perform_get_ims_subscription(req, task);
 }
 
 // Test error handling
@@ -3056,6 +3065,37 @@ TEST_F(HandlersTest, IMSSubscriptionCacheFailure)
   mock_op._cass_status = CassandraStore::UNKNOWN_ERROR;
   mock_op._cass_error_text = "error";
   t->on_failure(&mock_op);
+}
+
+TEST_F(HandlersTest, ReadRegDataSuccess)
+{
+  MockHttpStack::Request req(_httpstack,
+                             "/impu/" + IMPU + "/reg-data",
+                             "",
+                             "",
+                             "",
+                             htp_method_GET);
+  ImpuRegDataTask::Config cfg(true, 3600);
+  ImpuReadRegDataTask* task = new ImpuReadRegDataTask(req, &cfg, FAKE_TRAIL_ID);
+
+  perform_get_ims_subscription(req, task);
+}
+
+TEST_F(HandlersTest, ReadRegDataBadMethod)
+{
+  // Try to PUT to the read only API.
+  MockHttpStack::Request req(_httpstack,
+                             "/impu/" + IMPU + "/reg-data",
+                             "",
+                             "",
+                             "",
+                             htp_method_PUT);
+  ImpuRegDataTask::Config cfg(true, 3600);
+  ImpuReadRegDataTask* task = new ImpuReadRegDataTask(req, &cfg, FAKE_TRAIL_ID);
+
+  // This gets a 405 Bad Method.
+  EXPECT_CALL(*_httpstack, send_reply(_, 405, _));
+  task->run();
 }
 
 TEST_F(HandlersTest, RegistrationStatusHSSTimeout)
@@ -4809,7 +4849,6 @@ TEST_F(HandlerStatsTest, IMSSubscriptionReregHSS)
   t->on_success(&mock_op2);
   delete _caught_diam_tsx; _caught_diam_tsx = NULL;
 }
-
 
 TEST_F(HandlerStatsTest, RegistrationStatus)
 {

--- a/src/ut/mockcache.hpp
+++ b/src/ut/mockcache.hpp
@@ -119,6 +119,7 @@ public:
                DissociateImplicitRegistrationSetFromImpi*(const std::vector<std::string>& impus,
                                                           const std::vector<std::string>& impis,
                                                           int64_t timestamp));
+  MOCK_METHOD0(create_ListImpus, ListImpus*());
 
   // Mock request objects.
   //
@@ -232,6 +233,13 @@ public:
   {
     MockDissociateImplicitRegistrationSetFromImpi() : DissociateImplicitRegistrationSetFromImpi({}, "", 0) {}
     virtual ~MockDissociateImplicitRegistrationSetFromImpi() {}
+  };
+
+  class MockListImpus : public ListImpus, public MockOperationMixin
+  {
+    MockListImpus() : ListImpus() {}
+    virtual ~MockListImpus() {}
+    MOCK_METHOD0(get_impus_ref, std::vector<std::string>&());
   };
 };
 

--- a/src/ut/mockcache.hpp
+++ b/src/ut/mockcache.hpp
@@ -239,7 +239,7 @@ public:
   {
     MockListImpus() : ListImpus() {}
     virtual ~MockListImpus() {}
-    MOCK_METHOD0(get_impus_ref, std::vector<std::string>&());
+    MOCK_METHOD0(get_impus_reference, std::vector<std::string>&());
   };
 };
 


### PR DESCRIPTION
Hi Graeme, please can you review this change to add an HTTP management API to homestead to allow users to query a subscriber's IMS subscription, and to list all IMPUs homestead is storing data for.

I've tested this in UT, and also live using homestead prov:

* Try to get the subscription for a subscriber who doesn't exist. 
* Get the subscription of a subscriber that does exist. 
* List subscribers when none are configured. 
* List subscribers when some are configured. 

Graeme is doing a fuller live test.