### PR TITLE
Reviewer AJH: Query subscription XML column for list all IMPUs

### DIFF
--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -1026,7 +1026,7 @@ bool Cache::ListImpus::perform(CassandraStore::Client* client, SAS::TrailId trai
   // present). So if we ask for both and get either back, then the row does
   // really exists (and is not an artifact of a deleted row).
   SlicePredicate sp;
-  sp.__set_column_names({REG_STATE_COLUMN_NAME, EXISTS_COLUMN_NAME});
+  sp.__set_column_names({IMS_SUB_XML_COLUMN_NAME});
 
   KeyRange kr;
   kr.__set_start_key(""); // Start from the beginning.

--- a/src/handlers.cpp
+++ b/src/handlers.cpp
@@ -1325,7 +1325,7 @@ void ImpuRegDataTask::on_get_reg_data_success(CassandraStore::Operation* op)
       // Sprout wants to deregister this subscriber (because of a
       // REGISTER with Expires: 0, a timeout of all bindings, a failed
       // app server, etc.).
-      if (_original_state == RegistrationState::REGISTERED)
+      if (_original_state != RegistrationState::NOT_REGISTERED)
       {
         // Forget about this subscriber entirely and send an appropriate SAR.
         TRC_DEBUG("Handling deregistration");


### PR DESCRIPTION
***This PR is currently against the cached-data-api branch. If that branch has been merged by the time this gets merged, this should be merged into dev!***

Currently querying the list all IMPUs API doesn't return subscribers with unregistered service if you have an HSS configured because the reg state column doesn't exist. @rkd-msw thinks this is the right fix. I'm indifferent but it seems to work.