### PR TITLE
[Reviewer: Seb] Make error codes consistent

### DIFF
--- a/src/handlers.cpp
+++ b/src/handlers.cpp
@@ -1714,7 +1714,7 @@ void ImpuRegDataTask::on_put_reg_data_failure(CassandraStore::Operation* op, Cas
   SAS::report_event(event);
 
   // Failed to cache Reg Data.  Return an error in the hope that the client might try again
-  send_http_reply(HTTP_SERVER_ERROR);
+  send_http_reply(HTTP_SERVER_UNAVAILABLE);
 
   delete this;
 }
@@ -1870,13 +1870,13 @@ void ImpuRegDataTask::on_del_impu_failure(CassandraStore::Operation* op, Cassand
   }
   else
   {
-    // Not benign.  Return the original error if it wasn't OK - otherwise reply with SERVER ERROR
+    // Not benign.  Return the original error if it wasn't OK
     SAS::Event event(this->trail(), SASEvent::CACHE_DELETE_IMPUS_FAIL, 0);
     event.add_static_param(error);
     event.add_var_param(text);
     SAS::report_event(event);
 
-    send_http_reply((_http_rc == HTTP_OK) ? HTTP_SERVER_ERROR : _http_rc);
+    send_http_reply((_http_rc == HTTP_OK) ? HTTP_SERVER_UNAVAILABLE : _http_rc);
     delete this;
   }
 }

--- a/src/ut/handlers_test.cpp
+++ b/src/ut/handlers_test.cpp
@@ -552,7 +552,7 @@ public:
 
       if (cache_error != CassandraStore::OK)
       {
-        EXPECT_CALL(*_httpstack, send_reply(_, 500, _));
+        EXPECT_CALL(*_httpstack, send_reply(_, 503, _));
         mock_op3._cass_status = CassandraStore::CONNECTION_ERROR;
         mock_op3._cass_error_text = "Connection error";
         t->on_failure(&mock_op3);
@@ -581,11 +581,11 @@ public:
 
       if (cache_error != CassandraStore::OK)
       {
-        // Send in a Cassandra error response to the Delete and expect a 500 Internal Server error response,
-        // unless its a benign "Not found" response
+        // Send in a Cassandra error response to the Delete and expect a
+        // 503 error response, unless it's a benign "Not found" response
         if (cache_error != CassandraStore::NOT_FOUND)
         {
-          EXPECT_CALL(*_httpstack, send_reply(_, 500, _));
+          EXPECT_CALL(*_httpstack, send_reply(_, 503, _));
         }
         else
         {


### PR DESCRIPTION
Consistently return a 503 when we hit an error on a request that can be retried.

Tested in UT

Fixes issue #389 
