### PR TITLE
[Reviewer: Ellie] Suppress output of poll_cassandra when adding schemas

### DIFF
--- a/homestead-cassandra.root/usr/share/clearwater/cassandra-schemas/homestead_cache.sh
+++ b/homestead-cassandra.root/usr/share/clearwater/cassandra-schemas/homestead_cache.sh
@@ -8,6 +8,8 @@ cassandra_hostname="127.0.0.1"
 
 quit_if_no_cassandra
 
+echo "Adding Cassandra schemas..."
+
 CQLSH="/usr/share/clearwater/bin/run-in-signaling-namespace cqlsh $cassandra_hostname"
 
 if [[ ! -e /var/lib/cassandra/data/homestead_cache ]] || \
@@ -20,7 +22,7 @@ then
   while [ $? -ne 0 ]; do
     ((count++))
     if [ $count -gt 120 ]; then
-      echo "Cassandra isn't responsive, unable to add schemas"
+      echo "Cassandra isn't responsive, unable to add schemas yet"
       exit 1
     fi
 

--- a/homestead-cassandra.root/usr/share/clearwater/cassandra-schemas/homestead_cache.sh
+++ b/homestead-cassandra.root/usr/share/clearwater/cassandra-schemas/homestead_cache.sh
@@ -15,7 +15,7 @@ if [[ ! -e /var/lib/cassandra/data/homestead_cache ]] || \
 then
   # Wait for the cassandra cluster to come online
   count=0
-  /usr/share/clearwater/bin/poll_cassandra.sh --no-grace-period
+  /usr/share/clearwater/bin/poll_cassandra.sh --no-grace-period > /dev/null 2>&1
 
   while [ $? -ne 0 ]; do
     ((count++))
@@ -25,7 +25,8 @@ then
     fi
 
     sleep 1
-    /usr/share/clearwater/bin/poll_cassandra.sh --no-grace-period
+    /usr/share/clearwater/bin/poll_cassandra.sh --no-grace-period > /dev/null 2>&1
+
   done
 
   # replication_str is set up by

--- a/homestead-cassandra.root/usr/share/clearwater/cassandra-schemas/homestead_cache.sh
+++ b/homestead-cassandra.root/usr/share/clearwater/cassandra-schemas/homestead_cache.sh
@@ -8,29 +8,29 @@ cassandra_hostname="127.0.0.1"
 
 quit_if_no_cassandra
 
-echo "Adding Cassandra schemas..."
+echo "Adding/updating Cassandra schemas..."
+
+# Wait for the cassandra cluster to come online
+count=0
+/usr/share/clearwater/bin/poll_cassandra.sh --no-grace-period > /dev/null 2>&1
+
+while [ $? -ne 0 ]; do
+  ((count++))
+  if [ $count -gt 120 ]; then
+    echo "Cassandra isn't responsive, unable to add/update schemas yet"
+    exit 1
+  fi
+
+  sleep 1
+  /usr/share/clearwater/bin/poll_cassandra.sh --no-grace-period > /dev/null 2>&1
+
+done
 
 CQLSH="/usr/share/clearwater/bin/run-in-signaling-namespace cqlsh $cassandra_hostname"
 
 if [[ ! -e /var/lib/cassandra/data/homestead_cache ]] || \
    [[ $cassandra_hostname != "127.0.0.1" ]];
 then
-  # Wait for the cassandra cluster to come online
-  count=0
-  /usr/share/clearwater/bin/poll_cassandra.sh --no-grace-period > /dev/null 2>&1
-
-  while [ $? -ne 0 ]; do
-    ((count++))
-    if [ $count -gt 120 ]; then
-      echo "Cassandra isn't responsive, unable to add schemas yet"
-      exit 1
-    fi
-
-    sleep 1
-    /usr/share/clearwater/bin/poll_cassandra.sh --no-grace-period > /dev/null 2>&1
-
-  done
-
   # replication_str is set up by
   # /usr/share/clearwater/cassandra-schemas/replication_string.sh
   echo "CREATE KEYSPACE homestead_cache WITH REPLICATION =  $replication_str;


### PR DESCRIPTION
We already print an error and exit if we can't poll cassandra within 2 minutes,
so this removes a benign but scary sounding log when you upgrade

Fixes #333 

**Testing done**
 - tested that we no longer see the benign logs when upgrading