### PR TITLE
[Reviewer: Ellie] Don't create tables that already exist

### DIFF
--- a/homestead-cassandra.root/usr/share/clearwater/cassandra-schemas/homestead_cache.sh
+++ b/homestead-cassandra.root/usr/share/clearwater/cassandra-schemas/homestead_cache.sh
@@ -33,15 +33,15 @@ if [[ ! -e /var/lib/cassandra/data/homestead_cache ]] || \
 then
   # replication_str is set up by
   # /usr/share/clearwater/cassandra-schemas/replication_string.sh
-  echo "CREATE KEYSPACE homestead_cache WITH REPLICATION =  $replication_str;
+  echo "CREATE KEYSPACE IF NOT EXISTS homestead_cache WITH REPLICATION =  $replication_str;
         USE homestead_cache;
-        CREATE TABLE impi (
+        CREATE TABLE IF NOT EXISTS impi (
           private_id text PRIMARY KEY,
           digest_ha1 text,
           digest_realm text,
           digest_qop text)
         WITH COMPACT STORAGE AND read_repair_chance = 1.0;
-        CREATE TABLE impu (
+        CREATE TABLE IF NOT EXISTS impu (
           public_id text PRIMARY KEY,
           ims_subscription_xml text,
           is_registered boolean)
@@ -64,7 +64,7 @@ fi
 if [[ ! -e /var/lib/cassandra/data/homestead_cache/impi_mapping ]];
 then
   echo "USE homestead_cache;
-        CREATE TABLE impi_mapping (private_id text PRIMARY KEY, unused text) WITH COMPACT STORAGE AND read_repair_chance = 1.0;" | $CQLSH
+        CREATE TABLE IF NOT EXISTS impi_mapping (private_id text PRIMARY KEY, unused text) WITH COMPACT STORAGE AND read_repair_chance = 1.0;" | $CQLSH
 fi
 
 if [ -z "$speculative_retry_value" ]


### PR DESCRIPTION
If the keyspace/table already exists, don't add it.

This removes the scary red logs from upgrade, and fixes #396 

**testing done**
 - confirmed that the scary logs are removed