### PR TITLE
[Reviewer: Ellie] Add SAS log for unsupported auth scheme from HSS

### DIFF
--- a/include/homesteadsasevent.h
+++ b/include/homesteadsasevent.h
@@ -45,6 +45,7 @@ namespace SASEvent
   // Homestead events
   //----------------------------------------------------------------------------
   const int INVALID_SCHEME = HOMESTEAD_BASE + 0x0000;
+  const int UNSUPPORTED_SCHEME = HOMESTEAD_BASE + 0x0001;
   const int NO_IMPU_AKA = HOMESTEAD_BASE + 0x0010;
   const int NO_AV_CACHE = HOMESTEAD_BASE + 0x0020;
   const int NO_AV_HSS = HOMESTEAD_BASE + 0x0030;

--- a/src/handlers.cpp
+++ b/src/handlers.cpp
@@ -399,6 +399,10 @@ void ImpiTask::on_mar_response(Diameter::Message& rsp)
     }
     else
     {
+      TRC_DEBUG("Unsupported auth scheme: %s", sip_auth_scheme.c_str());
+      SAS::Event event(this->trail(), SASEvent::UNSUPPORTED_SCHEME, 0);
+      event.add_var_param(sip_auth_scheme);
+      SAS::report_event(event);
       send_http_reply(HTTP_NOT_FOUND);
     }
   }


### PR DESCRIPTION
Fixes #308 

**Testing done**
 - tested that an unsupported scheme (in this case `Early-IMS-Security`) triggered this debug log and SAS log