### PR TITLE
[Reviewer: Matt] Send HTTP 503 rather than 504 on diameter transaction timeout

### DIFF
--- a/src/handlers.cpp
+++ b/src/handlers.cpp
@@ -110,7 +110,14 @@ void HssCacheTask::configure_stats(StatisticsManager* stats_manager)
 
 void HssCacheTask::on_diameter_timeout()
 {
-  send_http_reply(HTTP_GATEWAY_TIMEOUT);
+  // Although a Diameter timeout indicates that a downstream server has failed,
+  // we send a 503 response rather than a 504.
+  // This is because the request hasn't yet been retried, and it's possible that
+  // another homestead node may be able to complete the request. By sending a
+  // 503 response, we ensure that the request will be retried by the client if
+  // possible.
+  TRC_ERROR("Diameter timeout - respond with HTTP 503");
+  send_http_reply(HTTP_SERVER_UNAVAILABLE);
   delete this;
 }
 

--- a/src/ut/handlers_test.cpp
+++ b/src/ut/handlers_test.cpp
@@ -1684,7 +1684,7 @@ TEST_F(HandlersTest, DigestHSSTimeout)
   digest.qop = "qop";
   AKAAuthVector aka;
 
-  EXPECT_CALL(*_httpstack, send_reply(_, 504, _));
+  EXPECT_CALL(*_httpstack, send_reply(_, 503, _));
   _caught_diam_tsx->on_timeout();
   delete _caught_diam_tsx; _caught_diam_tsx = NULL;
 }
@@ -1713,7 +1713,7 @@ TEST_F(HandlersTest, DigestHSSConfigurableTimeout)
 
   // Turn the caught Diameter msg structure into a MAR.
   Diameter::Message msg(_cx_dict, _caught_fd_msg, _mock_stack);
-  EXPECT_CALL(*_httpstack, send_reply(_, 504, _));
+  EXPECT_CALL(*_httpstack, send_reply(_, 503, _));
   _caught_diam_tsx->on_timeout();
   delete _caught_diam_tsx; _caught_diam_tsx = NULL;
 }
@@ -3125,8 +3125,8 @@ TEST_F(HandlersTest, RegistrationStatusHSSTimeout)
   task->run();
   ASSERT_FALSE(_caught_diam_tsx == NULL);
 
-  // Expect a 504 response once we notify the task about the timeout error.
-  EXPECT_CALL(*_httpstack, send_reply(_, 504, _));
+  // Expect a 503 response once we notify the task about the timeout error.
+  EXPECT_CALL(*_httpstack, send_reply(_, 503, _));
   _caught_diam_tsx->on_timeout();
   fd_msg_free(_caught_fd_msg); _caught_fd_msg = NULL;
   delete _caught_diam_tsx; _caught_diam_tsx = NULL;
@@ -3152,9 +3152,9 @@ TEST_F(HandlersTest, RegistrationStatusHSSTimeoutFailsHealthCheck)
   task->run();
   ASSERT_FALSE(_caught_diam_tsx == NULL);
 
-  // Expect a 504 response once we notify the task about the timeout
+  // Expect a 503 response once we notify the task about the timeout
   // error. This should not trigger the health-checker.
-  EXPECT_CALL(*_httpstack, send_reply(_, 504, _));
+  EXPECT_CALL(*_httpstack, send_reply(_, 503, _));
   EXPECT_CALL(*hc, health_check_passed()).Times(0);
   _caught_diam_tsx->on_timeout();
 


### PR DESCRIPTION
This means we treat a timeout as the same as having no diameter connections, and
allows the HTTP client to retry the request to another node if appropriate.

This is intended as a fix for https://github.com/Metaswitch/sprout/issues/1658

Testing done:
 - manually verified that blocking HSS connections from one homestead now results in a 503 which is retried by the S-CSCF to another homestead node, resulting in the registration succeeding
 - fixed UTs and verified they all pass
 - the live tests pass
