### PR TITLE
Support wildcarded public ids on LIA

### DIFF
--- a/include/cx.h
+++ b/include/cx.h
@@ -184,7 +184,7 @@ public:
                      const int32_t& experimental_result_code,
                      const std::string& scscf,
                      const ServerCapabilities& capabs,
-                     const std::string& wildcarded_pub_id = "");
+                     const std::string& wildcarded_public_identity = "");
   inline LocationInfoAnswer(Diameter::Message& msg) : Diameter::Message(msg) {};
 
   inline bool server_name(std::string& str) const
@@ -192,7 +192,7 @@ public:
     return get_str_from_avp(((Cx::Dictionary*)dict())->SERVER_NAME, str);
   }
 
-  inline bool wildcarded_pub_id(std::string& str) const
+  inline bool wildcarded_public_identity(std::string& str) const
   {
     return get_str_from_avp(((Cx::Dictionary*)dict())->
                             WILDCARDED_PUBLIC_IDENTITY, str);

--- a/include/cx.h
+++ b/include/cx.h
@@ -94,6 +94,7 @@ public:
   const Diameter::Dictionary::AVP SECONDARY_CHARGING_COLLECTION_FUNCTION_NAME;
   const Diameter::Dictionary::AVP PRIMARY_EVENT_CHARGING_FUNCTION_NAME;
   const Diameter::Dictionary::AVP SECONDARY_EVENT_CHARGING_FUNCTION_NAME;
+  const Diameter::Dictionary::AVP WILDCARDED_PUBLIC_IDENTITY;
 };
 
 class UserAuthorizationRequest : public Diameter::Message
@@ -182,13 +183,21 @@ public:
                      const uint32_t& vendor_id,
                      const int32_t& experimental_result_code,
                      const std::string& scscf,
-                     const ServerCapabilities& capabs);
+                     const ServerCapabilities& capabs,
+                     const std::string& wildcarded_pub_id = "");
   inline LocationInfoAnswer(Diameter::Message& msg) : Diameter::Message(msg) {};
 
   inline bool server_name(std::string& str) const
   {
     return get_str_from_avp(((Cx::Dictionary*)dict())->SERVER_NAME, str);
   }
+
+  inline bool wildcarded_pub_id(std::string& str) const
+  {
+    return get_str_from_avp(((Cx::Dictionary*)dict())->
+                            WILDCARDED_PUBLIC_IDENTITY, str);
+  }
+
   ServerCapabilities server_capabilities() const;
 };
 

--- a/src/cx.cpp
+++ b/src/cx.cpp
@@ -277,7 +277,7 @@ LocationInfoAnswer::LocationInfoAnswer(const Dictionary* dict,
                                        const int32_t& experimental_result_code,
                                        const std::string& server_name,
                                        const ServerCapabilities& capabs,
-                                       const std::string& wildcarded_pub_id) :
+                                       const std::string& wildcarded_public_identity) :
                                        Diameter::Message(dict, dict->USER_AUTHORIZATION_ANSWER, stack)
 {
   TRC_DEBUG("Building Location-Info answer");
@@ -328,9 +328,9 @@ LocationInfoAnswer::LocationInfoAnswer(const Dictionary* dict,
   }
   add(server_capabilities);
 
-  if (!wildcarded_pub_id.empty())
+  if (!wildcarded_public_identity.empty())
   {
-    add(Diameter::AVP(dict->WILDCARDED_PUBLIC_IDENTITY).val_str(wildcarded_pub_id));
+    add(Diameter::AVP(dict->WILDCARDED_PUBLIC_IDENTITY).val_str(wildcarded_public_identity));
   }
 }
 

--- a/src/cx.cpp
+++ b/src/cx.cpp
@@ -93,7 +93,8 @@ Dictionary::Dictionary() :
   PRIMARY_CHARGING_COLLECTION_FUNCTION_NAME("3GPP", "Primary-Charging-Collection-Function-Name"),
   SECONDARY_CHARGING_COLLECTION_FUNCTION_NAME("3GPP", "Secondary-Charging-Collection-Function-Name"),
   PRIMARY_EVENT_CHARGING_FUNCTION_NAME("3GPP", "Primary-Event-Charging-Function-Name"),
-  SECONDARY_EVENT_CHARGING_FUNCTION_NAME("3GPP", "Secondary-Event-Charging-Function-Name")
+  SECONDARY_EVENT_CHARGING_FUNCTION_NAME("3GPP", "Secondary-Event-Charging-Function-Name"),
+  WILDCARDED_PUBLIC_IDENTITY("3GPP", "Wildcarded-Public-Identity")
 {
 }
 
@@ -275,7 +276,8 @@ LocationInfoAnswer::LocationInfoAnswer(const Dictionary* dict,
                                        const uint32_t& vendor_id,
                                        const int32_t& experimental_result_code,
                                        const std::string& server_name,
-                                       const ServerCapabilities& capabs) :
+                                       const ServerCapabilities& capabs,
+                                       const std::string& wildcarded_pub_id) :
                                        Diameter::Message(dict, dict->USER_AUTHORIZATION_ANSWER, stack)
 {
   TRC_DEBUG("Building Location-Info answer");
@@ -325,6 +327,11 @@ LocationInfoAnswer::LocationInfoAnswer(const Dictionary* dict,
     }
   }
   add(server_capabilities);
+
+  if (!wildcarded_pub_id.empty())
+  {
+    add(Diameter::AVP(dict->WILDCARDED_PUBLIC_IDENTITY).val_str(wildcarded_pub_id));
+  }
 }
 
 ServerCapabilities LocationInfoAnswer::server_capabilities() const

--- a/src/handlers.cpp
+++ b/src/handlers.cpp
@@ -859,7 +859,7 @@ void ImpuLocationInfoTask::on_lir_response(Diameter::Message& rsp)
     writer.String(JSON_RC.c_str());
     writer.Int(result_code ? result_code : experimental_result_code);
     std::string server_name;
-    std::string wildcarded_pub_id;
+    std::string wildcarded_public_identity;
 
     // If the HSS returned a server_name, return that. If not, return the
     // server capabilities, even if none are returned by the HSS.
@@ -886,11 +886,11 @@ void ImpuLocationInfoTask::on_lir_response(Diameter::Message& rsp)
 
     // If the HSS returned a wildcarded public user identity, add this to
     // the response.
-    if (lia.wildcarded_pub_id(wildcarded_pub_id))
+    if (lia.wildcarded_public_identity(wildcarded_public_identity))
     {
-      TRC_DEBUG("Got Wildcarded-Public-Id %s", wildcarded_pub_id.c_str());
+      TRC_DEBUG("Got Wildcarded-Public-Id %s", wildcarded_public_identity.c_str());
       writer.String(JSON_WILDCARD.c_str());
-      writer.String(wildcarded_pub_id.c_str());
+      writer.String(wildcarded_public_identity.c_str());
     }
 
     writer.EndObject();

--- a/src/handlers.cpp
+++ b/src/handlers.cpp
@@ -859,6 +859,7 @@ void ImpuLocationInfoTask::on_lir_response(Diameter::Message& rsp)
     writer.String(JSON_RC.c_str());
     writer.Int(result_code ? result_code : experimental_result_code);
     std::string server_name;
+    std::string wildcarded_pub_id;
 
     // If the HSS returned a server_name, return that. If not, return the
     // server capabilities, even if none are returned by the HSS.
@@ -885,11 +886,11 @@ void ImpuLocationInfoTask::on_lir_response(Diameter::Message& rsp)
 
     // If the HSS returned a wildcarded public user identity, add this to
     // the response.
-    // !KH1! - to add in the message parsing here.
-    if (false)
+    if (lia.wildcarded_pub_id(wildcarded_pub_id))
     {
+      TRC_DEBUG("Got Wildcarded-Public-Id %s", wildcarded_pub_id.c_str());
       writer.String(JSON_WILDCARD.c_str());
-      writer.String("AVP");
+      writer.String(wildcarded_pub_id.c_str());
     }
 
     writer.EndObject();

--- a/src/ut/handlers_test.cpp
+++ b/src/ut/handlers_test.cpp
@@ -373,10 +373,8 @@ public:
 
     if (!wildcard.empty())
     {
-      // !KH1!
-      // Temporarily commented out as this requires the LIA parsing code
-      //writer.String(JSON_WILDCARD.c_str());
-      //writer.String(wildcard.c_str());
+      writer.String(JSON_WILDCARD.c_str());
+      writer.String(wildcard.c_str());
     }
 
     writer.EndObject();
@@ -3558,14 +3556,14 @@ TEST_F(HandlersTest, LocationInfoWithWildcard)
   EXPECT_FALSE(lir.auth_type(test_i32));
 
   // Build an LIA and expect a successful HTTP response.
-  // !KH1! - The LIA needs to have the wildcard parsing in it.
   Cx::LocationInfoAnswer lia(_cx_dict,
                              _mock_stack,
                              DIAMETER_SUCCESS,
                              0,
                              0,
                              SERVER_NAME,
-                             CAPABILITIES);
+                             CAPABILITIES,
+                             WILDCARD);
   EXPECT_CALL(*_httpstack, send_reply(_, 200, _));
 
   _caught_diam_tsx->on_response(lia);


### PR DESCRIPTION
Homestead can now parse the "Wildcarded-Public-Id" AVP from the LIA, and pass it onto sprout over http.

I've modified HandlersTest.LocationInfoWithWildcard (written by EM) to test this works, and it passes.
All other homestead tests still pass.