### PR TITLE
Remove deprecated ImpuIMSSubscriptionTask

### DIFF
--- a/include/handlers.h
+++ b/include/handlers.h
@@ -532,20 +532,6 @@ public:
   virtual void run();
 };
 
-class ImpuIMSSubscriptionTask : public ImpuRegDataTask
-{
-public:
-  ImpuIMSSubscriptionTask(HttpStack::Request& req,
-                          const Config* cfg,
-                          SAS::TrailId trail) :
-    ImpuRegDataTask(req, cfg, trail)
-  {};
-
-  void run();
-private:
-  void send_reply();
-};
-
 class RegistrationTerminationTask : public Diameter::Task
 {
 public:

--- a/src/handlers.cpp
+++ b/src/handlers.cpp
@@ -1527,8 +1527,6 @@ void ImpuRegDataTask::on_get_reg_data_failure(CassandraStore::Operation* op,
                                               CassandraStore::ResultCode error,
                                               std::string& text)
 {
-  printf("I cover this");
-
   TRC_DEBUG("IMS subscription cache query failed: %u, %s", error, text.c_str());
   SAS::Event event(this->trail(), SASEvent::NO_REG_DATA_CACHE, 0);
   SAS::report_event(event);

--- a/src/handlers.cpp
+++ b/src/handlers.cpp
@@ -1527,6 +1527,8 @@ void ImpuRegDataTask::on_get_reg_data_failure(CassandraStore::Operation* op,
                                               CassandraStore::ResultCode error,
                                               std::string& text)
 {
+  printf("I cover this");
+
   TRC_DEBUG("IMS subscription cache query failed: %u, %s", error, text.c_str());
   SAS::Event event(this->trail(), SASEvent::NO_REG_DATA_CACHE, 0);
   SAS::report_event(event);
@@ -1907,54 +1909,6 @@ void ImpuReadRegDataTask::run()
   }
 
   ImpuRegDataTask::run();
-}
-
-//
-// IMPU IMS Subscription handling for URLs of the form
-// "/impu/<public ID>". Deprecated.
-//
-
-void ImpuIMSSubscriptionTask::run()
-{
-  const std::string prefix = "/impu/";
-  std::string path = _req.full_path();
-
-  _impu = path.substr(prefix.length());
-  _impi = _req.param("private_id");
-  TRC_DEBUG("Parsed HTTP request: private ID %s, public ID %s",
-            _impi.c_str(), _impu.c_str());
-
-  if (_impi.empty())
-  {
-    _type = RequestType::CALL;
-  }
-  else
-  {
-    _type = RequestType::REG;
-  }
-
-  TRC_DEBUG("Try to find IMS Subscription information in the cache");
-  CassandraStore::Operation* get_reg_data = _cache->create_GetRegData(_impu);
-  CassandraStore::Transaction* tsx =
-    new CacheTransaction(this,
-                         &ImpuRegDataTask::on_get_reg_data_success,
-                         &ImpuRegDataTask::on_get_reg_data_failure);
-  _cache->do_async(get_reg_data, tsx);
-}
-
-void ImpuIMSSubscriptionTask::send_reply()
-{
-  if (_xml != "")
-  {
-    TRC_DEBUG("Building 200 OK response to send");
-    _req.add_content(_xml);
-    send_http_reply(HTTP_OK);
-  }
-  else
-  {
-    TRC_DEBUG("No XML User-Data available, returning 404");
-    send_http_reply(HTTP_NOT_FOUND);
-  }
 }
 
 void RegistrationTerminationTask::run()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -846,9 +846,6 @@ int main(int argc, char**argv)
                                               options.hss_reregistration_time,
                                               record_ttl,
                                               options.diameter_timeout_ms);
-  ImpuIMSSubscriptionTask::Config impu_handler_config_old(hss_configured,
-                                                          options.hss_reregistration_time,
-                                                          options.diameter_timeout_ms);
   ImpuListTask::Config impu_list_config;
 
   HttpStackUtils::PingHandler ping_handler;
@@ -857,7 +854,6 @@ int main(int argc, char**argv)
   HttpStackUtils::SpawningHandler<ImpiRegistrationStatusTask, ImpiRegistrationStatusTask::Config> impi_reg_status_handler(&registration_status_handler_config);
   HttpStackUtils::SpawningHandler<ImpuLocationInfoTask, ImpuLocationInfoTask::Config> impu_loc_info_handler(&location_info_handler_config);
   HttpStackUtils::SpawningHandler<ImpuRegDataTask, ImpuRegDataTask::Config> impu_reg_data_handler(&impu_handler_config);
-  HttpStackUtils::SpawningHandler<ImpuIMSSubscriptionTask, ImpuIMSSubscriptionTask::Config> impu_ims_sub_handler(&impu_handler_config_old);
   HttpStackUtils::SpawningHandler<ImpuListTask, ImpuListTask::Config> impu_list_handler(&impu_list_config);
 
   HttpStack* http_stack_sig = new HttpStack(options.http_threads,
@@ -882,8 +878,6 @@ int main(int argc, char**argv)
                                      &impu_loc_info_handler);
     http_stack_sig->register_handler("^/impu/[^/]*/reg-data$",
                                      &impu_reg_data_handler);
-    http_stack_sig->register_handler("^/impu/",
-                                     &impu_ims_sub_handler);
     http_stack_sig->start();
   }
   catch (HttpStack::Exception& e)

--- a/src/ut/handlers_test.cpp
+++ b/src/ut/handlers_test.cpp
@@ -2950,7 +2950,7 @@ TEST_F(HandlersTest, IMSSubscriptionCacheFailure)
   // subscription information for the specified public ID.
   MockCache::MockGetRegData mock_op;
   EXPECT_CALL(*_cache, create_GetRegData(IMPU))
-     .WillOnce(Return(&mock_op));
+    .WillOnce(Return(&mock_op));
   EXPECT_DO_ASYNC(*_cache, mock_op);
 
   task->run();

--- a/src/ut/handlers_test.cpp
+++ b/src/ut/handlers_test.cpp
@@ -2741,111 +2741,6 @@ TEST_F(HandlersTest, IMSSubscriptionNoHSSUnknownCall)
   _caught_fd_msg = NULL;
 }
 
-// Verify that the old interface (without /reg-data in the URL) still works
-
-TEST_F(HandlersTest, LegacyIMSSubscriptionNoHSS)
-{
-  MockHttpStack::Request req(_httpstack,
-                             "/impu/" + IMPU,
-                             "",
-                             "?private_id=" + IMPI);
-  ImpuIMSSubscriptionTask::Config cfg(false, 3600);
-  ImpuIMSSubscriptionTask* task = new ImpuIMSSubscriptionTask(req, &cfg, FAKE_TRAIL_ID);
-
-  MockCache::MockGetRegData mock_op;
-  EXPECT_CALL(*_cache, create_GetRegData(IMPU))
-    .WillOnce(Return(&mock_op));
-  EXPECT_DO_ASYNC(*_cache, mock_op);
-  task->run();
-
-  CassandraStore::Transaction* t = mock_op.get_trx();
-  ASSERT_FALSE(t == NULL);
-  EXPECT_CALL(mock_op, get_xml(_, _)).Times(AtLeast(1))
-    .WillRepeatedly(SetArgReferee<0>(IMS_SUBSCRIPTION));
-  EXPECT_CALL(mock_op, get_registration_state(_, _)).Times(AtLeast(1))
-    .WillRepeatedly(SetArgReferee<0>(RegistrationState::REGISTERED));
-  EXPECT_CALL(mock_op, get_associated_impis(_)).Times(AtLeast(1));
-  EXPECT_CALL(mock_op, get_charging_addrs(_)).Times(AtLeast(1))
-    .WillRepeatedly(SetArgReferee<0>(NO_CHARGING_ADDRESSES));
-  EXPECT_CALL(*_httpstack, send_reply(_, 200, _));
-  t->on_success(&mock_op);
-
-  // Build the expected response and check it's correct
-  EXPECT_EQ(IMS_SUBSCRIPTION, req.content());
-
-  _caught_diam_tsx = NULL;
-  _caught_fd_msg = NULL;
-}
-
-TEST_F(HandlersTest, LegacyIMSSubscriptionNoHSS_NotFound)
-{
-  MockHttpStack::Request req(_httpstack,
-                             "/impu/" + IMPU,
-                             "",
-                             "?private_id=" + IMPI);
-  ImpuIMSSubscriptionTask::Config cfg(false, 3600);
-  ImpuIMSSubscriptionTask* task = new ImpuIMSSubscriptionTask(req, &cfg, FAKE_TRAIL_ID);
-
-  MockCache::MockGetRegData mock_op;
-  EXPECT_CALL(*_cache, create_GetRegData(IMPU))
-    .WillOnce(Return(&mock_op));
-  EXPECT_DO_ASYNC(*_cache, mock_op);
-  task->run();
-
-  CassandraStore::Transaction* t = mock_op.get_trx();
-  ASSERT_FALSE(t == NULL);
-  EXPECT_CALL(mock_op, get_xml(_, _)).Times(AtLeast(1))
-    .WillRepeatedly(SetArgReferee<0>(""));
-  EXPECT_CALL(mock_op, get_registration_state(_, _)).Times(AtLeast(1))
-    .WillRepeatedly(SetArgReferee<0>(RegistrationState::NOT_REGISTERED));
-  EXPECT_CALL(*_httpstack, send_reply(_, 404, _));
-  EXPECT_CALL(mock_op, get_associated_impis(_)).Times(AtLeast(1));
-  EXPECT_CALL(mock_op, get_charging_addrs(_)).Times(AtLeast(1))
-    .WillRepeatedly(SetArgReferee<0>(NO_CHARGING_ADDRESSES));
-  t->on_success(&mock_op);
-
-  // Build the expected response and check it's correct
-  EXPECT_EQ("", req.content());
-
-  _caught_diam_tsx = NULL;
-  _caught_fd_msg = NULL;
-}
-
-
-TEST_F(HandlersTest, LegacyIMSSubscriptionNoHSS_Unregistered)
-{
-  MockHttpStack::Request req(_httpstack,
-                             "/impu/" + IMPU,
-                             "",
-                             "");
-  ImpuIMSSubscriptionTask::Config cfg(false, 3600);
-  ImpuIMSSubscriptionTask* task = new ImpuIMSSubscriptionTask(req, &cfg, FAKE_TRAIL_ID);
-
-  MockCache::MockGetRegData mock_op;
-  EXPECT_CALL(*_cache, create_GetRegData(IMPU))
-    .WillOnce(Return(&mock_op));
-  EXPECT_DO_ASYNC(*_cache, mock_op);
-  task->run();
-
-  CassandraStore::Transaction* t = mock_op.get_trx();
-  ASSERT_FALSE(t == NULL);
-  EXPECT_CALL(mock_op, get_xml(_, _)).Times(AtLeast(1))
-    .WillRepeatedly(SetArgReferee<0>(IMS_SUBSCRIPTION));
-  EXPECT_CALL(mock_op, get_registration_state(_, _)).Times(AtLeast(1))
-    .WillRepeatedly(SetArgReferee<0>(RegistrationState::UNREGISTERED));
-  EXPECT_CALL(mock_op, get_associated_impis(_)).Times(AtLeast(1));
-  EXPECT_CALL(mock_op, get_charging_addrs(_)).Times(AtLeast(1))
-    .WillRepeatedly(SetArgReferee<0>(NO_CHARGING_ADDRESSES));
-  EXPECT_CALL(*_httpstack, send_reply(_, 200, _));
-  t->on_success(&mock_op);
-
-  // Build the expected response and check it's correct
-  EXPECT_EQ(IMS_SUBSCRIPTION, req.content());
-
-  _caught_diam_tsx = NULL;
-  _caught_fd_msg = NULL;
-}
-
 // Verify that when doing a GET rather than a PUT, we just read from
 // the cache, rather than doing a write or sending anything to the HSS.
 
@@ -2975,12 +2870,12 @@ TEST_F(HandlersTest, IMSSubscriptionCacheNotFound)
   // doesn't return a result. Start by building the HTTP request which will
   // invoke a cache lookup.
   MockHttpStack::Request req(_httpstack,
-                             "/impu/" + IMPU,
+                             "/impu/" + IMPU + "/reg-data",
                              "",
                              "");
 
-  ImpuIMSSubscriptionTask::Config cfg(false, 3600);
-  ImpuIMSSubscriptionTask* task = new ImpuIMSSubscriptionTask(req, &cfg, FAKE_TRAIL_ID);
+  ImpuRegDataTask::Config cfg(false, 3600);
+  ImpuRegDataTask* task = new ImpuRegDataTask(req, &cfg, FAKE_TRAIL_ID);
 
   // Once the task's run function is called, expect to lookup IMS
   // subscription information for the specified public ID.
@@ -3010,12 +2905,12 @@ TEST_F(HandlersTest, IMSSubscriptionCacheConnectionFailure)
   // has a connection failure. Start by building the HTTP request which
   // will invoke a cache lookup.
   MockHttpStack::Request req(_httpstack,
-                             "/impu/" + IMPU,
+                             "/impu/" + IMPU + "/reg-data",
                              "",
                              "");
 
-  ImpuIMSSubscriptionTask::Config cfg(false, 3600);
-  ImpuIMSSubscriptionTask* task = new ImpuIMSSubscriptionTask(req, &cfg, FAKE_TRAIL_ID);
+  ImpuRegDataTask::Config cfg(false, 3600);
+  ImpuRegDataTask* task = new ImpuRegDataTask(req, &cfg, FAKE_TRAIL_ID);
 
   // Once the task's run function is called, expect to lookup IMS
   // subscription information for the specified public ID.
@@ -3045,18 +2940,17 @@ TEST_F(HandlersTest, IMSSubscriptionCacheFailure)
   // has an unknown failure. Start by building the HTTP request which
   // will invoke a cache lookup.
   MockHttpStack::Request req(_httpstack,
-                             "/impu/" + IMPU,
+                             "/impu/" + IMPU + "/reg-data",
                              "",
                              "");
-
-  ImpuIMSSubscriptionTask::Config cfg(false, 3600);
-  ImpuIMSSubscriptionTask* task = new ImpuIMSSubscriptionTask(req, &cfg, FAKE_TRAIL_ID);
+  ImpuRegDataTask::Config cfg(false, 3600);
+  ImpuRegDataTask* task = new ImpuRegDataTask(req, &cfg, FAKE_TRAIL_ID);
 
   // Once the task's run function is called, expect to lookup IMS
   // subscription information for the specified public ID.
   MockCache::MockGetRegData mock_op;
   EXPECT_CALL(*_cache, create_GetRegData(IMPU))
-    .WillOnce(Return(&mock_op));
+     .WillOnce(Return(&mock_op));
   EXPECT_DO_ASYNC(*_cache, mock_op);
 
   task->run();


### PR DESCRIPTION
**Change made**
I've removed the old deprecated ImpuIMSSubscriptionTask class (deprecated in 2014).

**Testing done**
I've removed three tests relating to this outdated code, as they are tested in the new code.
I edited a further three tests so that they cover the new class (ImpuRegDataTask).
I've checked that all tests run, including the live tests.

EM - I didn't rename any tests as they are already consistently named "IMSSubscription..."