### PR TITLE
Support barred IMPUs for RTRs

### DIFF
--- a/include/cache.h
+++ b/include/cache.h
@@ -73,9 +73,11 @@ public:
     /// Constructors. Stores off the public IDs that we're changing, the
     /// timestamp, and the TTL. Then creates a blank PutRegData object.
     PutRegData(const std::string& public_id,
+               const std::string& default_public_id,
                const int64_t timestamp,
                const int32_t ttl = 0);
     PutRegData(const std::vector<std::string>& public_ids,
+               const std::string& default_public_id,
                const int64_t timestamp,
                const int32_t ttl = 0);
 
@@ -103,6 +105,8 @@ public:
 
   protected:
     std::vector<std::string> _public_ids;
+    // The default public identity is the first unbarred public identity.
+    std::string _default_public_id;
     int64_t _timestamp;
     int32_t _ttl;
 
@@ -113,19 +117,23 @@ public:
   };
 
   virtual PutRegData* create_PutRegData(const std::string& public_id,
+                                        const std::string& default_public_id,
                                         const int64_t timestamp,
                                         const int32_t ttl = 0)
   {
     return new PutRegData(public_id,
+                          default_public_id,
                           timestamp,
                           ttl);
   }
 
   virtual PutRegData* create_PutRegData(const std::vector<std::string>& public_ids,
+                                        const std::string& default_public_id,
                                         const int64_t timestamp,
                                         const int32_t ttl = 0)
   {
     return new PutRegData(public_ids,
+                          default_public_id,
                           timestamp,
                           ttl);
   }
@@ -138,6 +146,7 @@ public:
     /// @param impus The public IDs.
     /// @param impi the private ID to associate with them.
     PutAssociatedPrivateID(const std::vector<std::string>& impus,
+                           const std::string& default_public_id,
                            const std::string& impi,
                            const int64_t timestamp,
                            const int32_t ttl = 0);
@@ -145,6 +154,8 @@ public:
 
   protected:
     std::vector<std::string> _impus;
+    // The default public identity is the first unbarred impu.
+    std::string _default_public_id;
     std::string _impi;
     int64_t _timestamp;
     int32_t _ttl;
@@ -154,11 +165,12 @@ public:
 
   virtual PutAssociatedPrivateID* create_PutAssociatedPrivateID(
     const std::vector<std::string>& impus,
+    const std::string& default_public_id,
     const std::string& impi,
     const int64_t timestamp,
     const int32_t ttl = 0)
   {
-    return new PutAssociatedPrivateID(impus, impi, timestamp, ttl);
+    return new PutAssociatedPrivateID(impus, default_public_id, impi, timestamp, ttl);
   }
 
   class PutAssociatedPublicID : public CassandraStore::Operation

--- a/include/handlers.h
+++ b/include/handlers.h
@@ -586,7 +586,7 @@ private:
   int32_t _deregistration_reason;
   std::vector<std::string> _impis;
   std::vector<std::string> _impus;
-  std::vector<std::vector<std::string>> _registration_sets;
+  std::vector< std::pair<std::string, std::vector<std::string>> > _registration_sets;
 
   void get_assoc_primary_public_ids_success(CassandraStore::Operation* op);
   void get_assoc_primary_public_ids_failure(CassandraStore::Operation* op,

--- a/include/handlers.h
+++ b/include/handlers.h
@@ -647,11 +647,16 @@ private:
   ChargingAddresses _charging_addrs;
   std::string _impi;
   std::vector<std::string> _impus;
+  std::vector<std::string> _default_impus;
 
   void on_get_impus_success(CassandraStore::Operation* op);
   void on_get_impus_failure(CassandraStore::Operation* op,
                             CassandraStore::ResultCode error,
                             std::string& text);
+  void on_get_primary_impus_success(CassandraStore::Operation* op);
+  void on_get_primary_impus_failure(CassandraStore::Operation* op,
+                                    CassandraStore::ResultCode error,
+                                    std::string& text);
   void update_reg_data();
   void update_reg_data_success(CassandraStore::Operation* op);
   void update_reg_data_failure(CassandraStore::Operation* op,

--- a/include/homestead_xml_utils.h
+++ b/include/homestead_xml_utils.h
@@ -46,6 +46,8 @@
 namespace XmlUtils
 {
   std::vector<std::string> get_public_ids(const std::string& user_data);
+  void get_default_id(const std::string& user_data,
+                      std::string& default_id);
   std::vector<std::string> get_public_and_default_ids(const std::string& user_data,
                                                       std::string& default_id);
   std::string get_private_id(const std::string& user_data);

--- a/include/homestead_xml_utils.h
+++ b/include/homestead_xml_utils.h
@@ -46,6 +46,8 @@
 namespace XmlUtils
 {
   std::vector<std::string> get_public_ids(const std::string& user_data);
+  std::vector<std::string> get_public_and_default_ids(const std::string& user_data,
+                                                      std::string& default_id);
   std::string get_private_id(const std::string& user_data);
   int build_ClearwaterRegData_xml(RegistrationState state,
                                   std::string user_data,

--- a/include/homesteadsasevent.h
+++ b/include/homesteadsasevent.h
@@ -91,6 +91,8 @@ namespace SASEvent
   const int NO_SIP_URI_IN_IRS = HOMESTEAD_BASE + 0x220;
   const int PPR_RECEIVED = HOMESTEAD_BASE + 0x230;
   const int RTR_RECEIVED = HOMESTEAD_BASE + 0x240;
+  const int CACHE_GET_ASSOC_DEF_IMPU_FAIL = HOMESTEAD_BASE + 0x0250;
+  const int PPR_CHANGE_DEFAULT_IMPU = HOMESTEAD_BASE + 0x0260;
 
 } // namespace SASEvent
 

--- a/src/handlers.cpp
+++ b/src/handlers.cpp
@@ -2206,8 +2206,7 @@ void RegistrationTerminationTask::delete_registrations()
   std::vector<std::string> empty_vector;
   std::vector<std::string> default_public_identities;
 
-  // Extract the default public identities from the registration sets. These are the
-  // first public identities in the sets.
+  // Extract the default public identities from the registration sets.
   for (std::pair<std::string, std::vector<std::string>> reg_set : _registration_sets)
   {
     default_public_identities.push_back(reg_set.first);
@@ -2306,12 +2305,12 @@ void RegistrationTerminationTask::dissociate_implicit_registration_sets()
       _cfg->cache->create_DissociateImplicitRegistrationSetFromImpi(reg_set.second, _impis, Cache::generate_timestamp());
     CassandraStore::Transaction* tsx = new CacheTransaction;
 
-  // Note that this is an asynchronous operation and we are not attempting to
-  // wait for completion.  This is deliberate: Registration Termination is not
-  // driven by a client, and so there are no agents in the system that need to
-  // know when the async operation is complete (unlike a REGISTER from a SIP
-  // client which might follow the operation immediately with a request, such
-  // as a reg-event SUBSCRIBE, that relies on the cache being up to date).
+    // Note that this is an asynchronous operation and we are not attempting to
+    // wait for completion.  This is deliberate: Registration Termination is not
+    // driven by a client, and so there are no agents in the system that need to
+    // know when the async operation is complete (unlike a REGISTER from a SIP
+    // client which might follow the operation immediately with a request, such
+    // as a reg-event SUBSCRIBE, that relies on the cache being up to date).
     _cfg->cache->do_async(dissociate_reg_set, tsx);
   }
 }

--- a/src/homestead_xml_utils.cpp
+++ b/src/homestead_xml_utils.cpp
@@ -222,8 +222,17 @@ std::vector<std::string> get_public_ids(const std::string& user_data)
   return get_public_and_default_ids(user_data, unused_default_id);
 }
 
+// Parses the given User-Data XML to retrieve the default public ID (the first
+// unbarred public ID).
+void get_default_id(const std::string& user_data,
+                    std::string &default_id)
+{
+  std::vector<std::string> unused_public_ids;
+  unused_public_ids = get_public_and_default_ids(user_data, default_id);
+}
+
 // Parses the given User-Data XML to retrieve a list of all the public IDs, and
-// the default id (the first unbarred public ID).
+// the default public ID (the first unbarred public ID).
 std::vector<std::string> get_public_and_default_ids(const std::string &user_data,
                                                     std::string &default_id)
 {

--- a/src/homestead_xml_utils.cpp
+++ b/src/homestead_xml_utils.cpp
@@ -218,6 +218,8 @@ void add_charging_addr_node(const ChargingAddresses& charging_addrs,
 // Parses the given User-Data XML to retrieve a list of all the public IDs.
 std::vector<std::string> get_public_ids(const std::string& user_data)
 {
+  // Call into the function which parses out both the default id and the public
+  // IDs with a dummy default id that will not be returned.
   std::string default_id;
   return get_public_and_default_ids(user_data, default_id);
 }

--- a/src/homestead_xml_utils.cpp
+++ b/src/homestead_xml_utils.cpp
@@ -218,10 +218,8 @@ void add_charging_addr_node(const ChargingAddresses& charging_addrs,
 // Parses the given User-Data XML to retrieve a list of all the public IDs.
 std::vector<std::string> get_public_ids(const std::string& user_data)
 {
-  // Call into the function which parses out both the default id and the public
-  // IDs with a dummy default id that will not be returned.
-  std::string default_id;
-  return get_public_and_default_ids(user_data, default_id);
+  std::string unused_default_id;
+  return get_public_and_default_ids(user_data, unused_default_id);
 }
 
 // Parses the given User-Data XML to retrieve a list of all the public IDs, and

--- a/src/ut/cache_test.cpp
+++ b/src/ut/cache_test.cpp
@@ -368,7 +368,7 @@ TEST_F(CacheInitializationTest, Connection)
 TEST_F(CacheRequestTest, PutRegDataMainline)
 {
   TestTransaction *trx = make_trx();
-  Cache::PutRegData* put_reg_data = _cache.create_PutRegData("kermit", 1000, 300);
+  Cache::PutRegData* put_reg_data = _cache.create_PutRegData("kermit", "kermit", 1000, 300);
   put_reg_data->with_xml("<xml>")
                .with_reg_state(RegistrationState::REGISTERED)
                .with_associated_impis(IMPIS)
@@ -403,7 +403,7 @@ TEST_F(CacheRequestTest, PutRegDataMainline)
 TEST_F(CacheRequestTest, PutRegDataUnregistered)
 {
   TestTransaction *trx = make_trx();
-  Cache::PutRegData* put_reg_data = _cache.create_PutRegData("kermit", 1000, 300);
+  Cache::PutRegData* put_reg_data = _cache.create_PutRegData("kermit", "kermit", 1000, 300);
   put_reg_data->with_xml("<xml>")
                .with_reg_state(RegistrationState::UNREGISTERED)
                .with_associated_impis(IMPIS)
@@ -438,7 +438,7 @@ TEST_F(CacheRequestTest, PutRegDataUnregistered)
 TEST_F(CacheRequestTest, NoTTLOnPut)
 {
   TestTransaction *trx = make_trx();
-  Cache::PutRegData* put_reg_data = _cache.create_PutRegData("kermit", 1000);
+  Cache::PutRegData* put_reg_data = _cache.create_PutRegData("kermit", "kermit", 1000);
   put_reg_data->with_xml("<xml>")
                .with_reg_state(RegistrationState::REGISTERED)
                .with_associated_impis(IMPIS)
@@ -479,7 +479,7 @@ TEST_F(CacheRequestTest, PutRegDataMultipleIDs)
   std::vector<CassandraStore::RowColumns> expected;
 
   TestTransaction *trx = make_trx();
-  Cache::PutRegData* put_reg_data = _cache.create_PutRegData(ids, 1000);
+  Cache::PutRegData* put_reg_data = _cache.create_PutRegData(ids, "kermit", 1000);
   put_reg_data->with_xml("<xml>")
                .with_reg_state(RegistrationState::REGISTERED)
                .with_associated_impis(IMPIS)
@@ -519,7 +519,7 @@ TEST_F(CacheRequestTest, PutRegDataNoXml)
   std::vector<CassandraStore::RowColumns> expected;
 
   TestTransaction *trx = make_trx();
-  Cache::PutRegData* put_reg_data = _cache.create_PutRegData(ids, 1000);
+  Cache::PutRegData* put_reg_data = _cache.create_PutRegData(ids, "kermit", 1000);
   put_reg_data->with_charging_addrs(FULL_CHARGING_ADDRS);
 
   std::map<std::string, std::string> columns;
@@ -548,7 +548,7 @@ TEST_F(CacheRequestTest, PutRegDataNoChargingAddresses)
   std::vector<CassandraStore::RowColumns> expected;
 
   TestTransaction *trx = make_trx();
-  Cache::PutRegData* put_reg_data = _cache.create_PutRegData(ids, 1000);
+  Cache::PutRegData* put_reg_data = _cache.create_PutRegData(ids, "kermit", 1000);
   put_reg_data->with_xml("<xml>");
 
   std::map<std::string, std::string> columns;
@@ -576,7 +576,7 @@ MATCHER_P(OperationHasResult, expected_rc, "")
 TEST_F(CacheRequestTest, PutOneTransportEx)
 {
   TestTransaction *trx = make_trx();
-  Cache::PutRegData* put_reg_data = _cache.create_PutRegData("kermit", 1000);
+  Cache::PutRegData* put_reg_data = _cache.create_PutRegData("kermit", "kermit", 1000);
   put_reg_data->with_xml("<xml>");
 
   apache::thrift::transport::TTransportException te;
@@ -602,7 +602,7 @@ TEST_F(CacheRequestTest, PutOneTransportEx)
 TEST_F(CacheRequestTest, PutTwoTransportEx)
 {
   TestTransaction *trx = make_trx();
-  Cache::PutRegData* put_reg_data = _cache.create_PutRegData("kermit", 1000);
+  Cache::PutRegData* put_reg_data = _cache.create_PutRegData("kermit", "kermit", 1000);
   put_reg_data->with_xml("<xml>");
 
   apache::thrift::transport::TTransportException te;
@@ -623,7 +623,7 @@ TEST_F(CacheRequestTest, PutTwoTransportEx)
 TEST_F(CacheRequestTest, PutConnectTransportExThenPutTransportEx)
 {
   TestTransaction *trx = make_trx();
-  Cache::PutRegData* put_reg_data = _cache.create_PutRegData("kermit", 1000);
+  Cache::PutRegData* put_reg_data = _cache.create_PutRegData("kermit", "kermit", 1000);
   put_reg_data->with_xml("<xml>");
 
   apache::thrift::transport::TTransportException te;
@@ -645,7 +645,7 @@ TEST_F(CacheRequestTest, PutConnectTransportExThenPutTransportEx)
 TEST_F(CacheRequestTest, PutTransportThenUnknownException)
 {
   TestTransaction *trx = make_trx();
-  Cache::PutRegData* put_reg_data = _cache.create_PutRegData("kermit", 1000);
+  Cache::PutRegData* put_reg_data = _cache.create_PutRegData("kermit", "kermit", 1000);
   put_reg_data->with_xml("<xml>");
 
   apache::thrift::transport::TTransportException te;
@@ -667,7 +667,7 @@ TEST_F(CacheRequestTest, PutTransportThenUnknownException)
 TEST_F(CacheRequestTest, PutInvalidRequestException)
 {
   TestTransaction *trx = make_trx();
-  Cache::PutRegData* put_reg_data = _cache.create_PutRegData("kermit", 1000);
+  Cache::PutRegData* put_reg_data = _cache.create_PutRegData("kermit", "kermit", 1000);
   put_reg_data->with_xml("<xml>");
 
   cass::InvalidRequestException ire;
@@ -683,7 +683,7 @@ TEST_F(CacheRequestTest, PutInvalidRequestException)
 TEST_F(CacheRequestTest, PutNotFoundException)
 {
   TestTransaction *trx = make_trx();
-  Cache::PutRegData* put_reg_data = _cache.create_PutRegData("kermit", 1000);
+  Cache::PutRegData* put_reg_data = _cache.create_PutRegData("kermit", "kermit", 1000);
   put_reg_data->with_xml("<xml>");
 
   cass::NotFoundException nfe;
@@ -699,7 +699,7 @@ TEST_F(CacheRequestTest, PutNotFoundException)
 TEST_F(CacheRequestTest, PutNoResultsException)
 {
   TestTransaction *trx = make_trx();
-  Cache::PutRegData* put_reg_data = _cache.create_PutRegData("kermit", 1000);
+  Cache::PutRegData* put_reg_data = _cache.create_PutRegData("kermit", "kermit", 1000);
   put_reg_data->with_xml("<xml>");
 
   CassandraStore::RowNotFoundException rnfe("muppets", "kermit");
@@ -715,7 +715,7 @@ TEST_F(CacheRequestTest, PutNoResultsException)
 TEST_F(CacheRequestTest, PutUnknownException)
 {
   TestTransaction *trx = make_trx();
-  Cache::PutRegData* put_reg_data = _cache.create_PutRegData("kermit", 1000);
+  Cache::PutRegData* put_reg_data = _cache.create_PutRegData("kermit", "kermit", 1000);
   put_reg_data->with_xml("<xml>");
 
   std::string ex("Made up exception");
@@ -731,7 +731,7 @@ TEST_F(CacheRequestTest, PutUnknownException)
 TEST_F(CacheRequestTest, PutsHaveConsistencyLevelOne)
 {
   TestTransaction *trx = make_trx();
-  Cache::PutRegData* put_reg_data = _cache.create_PutRegData("kermit", 1000);
+  Cache::PutRegData* put_reg_data = _cache.create_PutRegData("kermit", "kermit", 1000);
   put_reg_data->with_xml("<xml>");
 
   EXPECT_CALL(_resolver, success(_targets[0])).Times(1);
@@ -803,7 +803,7 @@ TEST_F(CacheRequestTest, PutAssocPrivateIdMainline)
 {
   TestTransaction *trx = make_trx();
   CassandraStore::Operation* op =
-    _cache.create_PutAssociatedPrivateID({"kermit", "miss piggy"}, "gonzo", 1000);
+    _cache.create_PutAssociatedPrivateID({"kermit", "miss piggy"}, "kermit", "gonzo", 1000);
 
   std::vector<CassandraStore::RowColumns> expected;
 
@@ -1631,7 +1631,7 @@ ACTION_P2(CheckLatency, trx, ms) { trx->check_latency(ms * 1000); }
 TEST_F(CacheLatencyTest, PutRecordsLatency)
 {
   TestTransaction *trx = make_trx();
-  Cache::PutRegData* put_reg_data = _cache.create_PutRegData("kermit", 1000);
+  Cache::PutRegData* put_reg_data = _cache.create_PutRegData("kermit", "kermit", 1000);
   put_reg_data->with_xml("<xml>");
 
   std::map<std::string, std::string> columns;
@@ -1688,7 +1688,7 @@ TEST_F(CacheLatencyTest, GetRecordsLatency)
 TEST_F(CacheLatencyTest, ErrorRecordsLatency)
 {
   TestTransaction *trx = make_trx();
-  Cache::PutRegData* put_reg_data = _cache.create_PutRegData("kermit", 1000);
+  Cache::PutRegData* put_reg_data = _cache.create_PutRegData("kermit", "kermit", 1000);
   put_reg_data->with_xml("<xml>");
 
   cass::NotFoundException nfe;

--- a/src/ut/handlers_test.cpp
+++ b/src/ut/handlers_test.cpp
@@ -128,6 +128,8 @@ public:
   static const std::string IMPU_IMS_SUBSCRIPTION_INVALID;
   static const std::string IMPU3_IMS_SUBSCRIPTION;
   static const std::string IMPU_IMS_SUBSCRIPTION_WITH_BARRING;
+  static const std::string IMPU_IMS_SUBSCRIPTION_WITH_BARRING2;
+  static const std::string IMPU_IMS_SUBSCRIPTION_WITH_BARRING3;
   static const std::string IMPU_IMS_SUBSCRIPTION_BARRING_INDICATION;
   static const std::string SCHEME_UNKNOWN;
   static const std::string SCHEME_DIGEST;
@@ -138,10 +140,11 @@ public:
   static const std::string HTTP_PATH_REG_FALSE;
   static std::vector<std::string> EMPTY_VECTOR;
   static const std::string DEREG_BODY_PAIRINGS;
-  static const std::string DEREG_BODY_LIST;
   static const std::string DEREG_BODY_PAIRINGS2;
   static const std::string DEREG_BODY_PAIRINGS3;
   static const std::string DEREG_BODY_PAIRINGS4;
+  static const std::string DEREG_BODY_PAIRINGS5;
+  static const std::string DEREG_BODY_LIST;
   static const std::string DEREG_BODY_LIST2;
   static const std::string DEREG_BODY_LIST3;
   static const std::deque<std::string> NO_CFS;
@@ -1322,7 +1325,8 @@ public:
 
   void rtr_template_no_impus(int32_t dereg_reason,
                              std::string http_path,
-                             std::string body)
+                             std::string body,
+                             std::string cache_return_one)
   {
     // This is a template function for an RTR test where no public identities
     // are specified on the request.
@@ -1376,7 +1380,7 @@ public:
     t = mock_op2.get_trx();
     ASSERT_FALSE(t == NULL);
     EXPECT_CALL(mock_op2, get_xml(_, _)).Times(AtLeast(1))
-      .WillRepeatedly(DoAll(SetArgReferee<0>(IMPU_IMS_SUBSCRIPTION), SetArgReferee<1>(0)));
+      .WillRepeatedly(DoAll(SetArgReferee<0>(cache_return_one), SetArgReferee<1>(0)));
     EXPECT_CALL(mock_op2, get_registration_state(_, _)).Times(AtLeast(1))
       .WillRepeatedly(SetArgReferee<0>(RegistrationState::NOT_REGISTERED));
     EXPECT_CALL(mock_op2, get_associated_impis(_)).Times(AtLeast(1))
@@ -1716,6 +1720,8 @@ const std::string HandlersTest::IMPU_IMS_SUBSCRIPTION = "<?xml version=\"1.0\"?>
 const std::string HandlersTest::IMPU_IMS_SUBSCRIPTION_INVALID = "<?xml version=\"1.0\"?><IMSSubscriptio></IMSSubscriptio>";
 const std::string HandlersTest::IMPU3_IMS_SUBSCRIPTION = "<?xml version=\"1.0\"?><IMSSubscription><PrivateID>" + IMPI + "</PrivateID><ServiceProfile><PublicIdentity><Identity>" + IMPU3 + "</Identity></PublicIdentity><PublicIdentity><Identity>" + IMPU2 + "</Identity></PublicIdentity></ServiceProfile></IMSSubscription>";
 const std::string HandlersTest::IMPU_IMS_SUBSCRIPTION_WITH_BARRING = "<?xml version=\"1.0\"?><IMSSubscription><PrivateID>" + IMPI + "</PrivateID><ServiceProfile><PublicIdentity><Identity>" + IMPU + "</Identity><BarringIndication>1</BarringIndication></PublicIdentity><PublicIdentity><Identity>" + IMPU2 + "</Identity></PublicIdentity></ServiceProfile></IMSSubscription>";
+const std::string HandlersTest::IMPU_IMS_SUBSCRIPTION_WITH_BARRING2 = "<?xml version=\"1.0\"?><IMSSubscription><PrivateID>" + IMPI + "</PrivateID><ServiceProfile><PublicIdentity><Identity>" + IMPU + "</Identity><BarringIndication>1</BarringIndication></PublicIdentity><PublicIdentity><Identity>" + IMPU4 + "</Identity></PublicIdentity></ServiceProfile></IMSSubscription>";
+const std::string HandlersTest::IMPU_IMS_SUBSCRIPTION_WITH_BARRING3 = "<?xml version=\"1.0\"?><IMSSubscription><PrivateID>" + IMPI + "</PrivateID><ServiceProfile><PublicIdentity><Identity>" + IMPU + "</Identity></PublicIdentity><PublicIdentity><Identity>" + IMPU4 + "</Identity><BarringIndication>1</BarringIndication></PublicIdentity></ServiceProfile></IMSSubscription>";
 const std::string HandlersTest::IMPU_IMS_SUBSCRIPTION_BARRING_INDICATION = "<?xml version=\"1.0\"?><IMSSubscription><PrivateID>" + IMPI + "</PrivateID><ServiceProfile><PublicIdentity><Identity>" + IMPU + "</Identity><BarringIndication>0</BarringIndication></PublicIdentity><PublicIdentity><Identity>" + IMPU2 + "</Identity></PublicIdentity></ServiceProfile></IMSSubscription>";
 std::vector<std::string> HandlersTest::EMPTY_VECTOR = {};
 const std::string HandlersTest::DEREG_BODY_PAIRINGS = "{\"registrations\":[{\"primary-impu\":\"" + IMPU3 + "\",\"impi\":\"" + IMPI +
@@ -1741,6 +1747,12 @@ const std::string HandlersTest::DEREG_BODY_LIST3 = "{\"registrations\":[{\"prima
 const std::string HandlersTest::DEREG_BODY_PAIRINGS4 = "{\"registrations\":[{\"primary-impu\":\"" + IMPU + "\",\"impi\":\"" + IMPI +
                                                                        "\"},{\"primary-impu\":\"" + IMPU + "\",\"impi\":\"" + ASSOCIATED_IDENTITY1 +
                                                                        "\"},{\"primary-impu\":\"" + IMPU + "\",\"impi\":\"" + ASSOCIATED_IDENTITY2 + "\"}]}";
+const std::string HandlersTest::DEREG_BODY_PAIRINGS5 = "{\"registrations\":[{\"primary-impu\":\"" + IMPU4 + "\",\"impi\":\"" + IMPI +
+                                                                       "\"},{\"primary-impu\":\"" + IMPU4 + "\",\"impi\":\"" + ASSOCIATED_IDENTITY1 +
+                                                                       "\"},{\"primary-impu\":\"" + IMPU4 + "\",\"impi\":\"" + ASSOCIATED_IDENTITY2 +
+                                                                       "\"},{\"primary-impu\":\"" + IMPU3 + "\",\"impi\":\"" + IMPI +
+                                                                       "\"},{\"primary-impu\":\"" + IMPU3 + "\",\"impi\":\"" + ASSOCIATED_IDENTITY1 +
+                                                                       "\"},{\"primary-impu\":\"" + IMPU3 + "\",\"impi\":\"" + ASSOCIATED_IDENTITY2 + "\"}]}";
 const std::string HandlersTest::SCHEME_DIGEST = "SIP Digest";
 const std::string HandlersTest::SCHEME_AKA = "Digest-AKAv1-MD5";
 const std::string HandlersTest::SCHEME_AKAV2 = "Digest-AKAv2-SHA-256";
@@ -4019,22 +4031,22 @@ TEST_F(HandlersTest, RegistrationTerminationRemoveSCSCF)
 
 TEST_F(HandlersTest, RegistrationTerminationPermanentTerminationNoIMPUs)
 {
-  rtr_template_no_impus(PERMANENT_TERMINATION, HTTP_PATH_REG_FALSE, DEREG_BODY_PAIRINGS2);
+  rtr_template_no_impus(PERMANENT_TERMINATION, HTTP_PATH_REG_FALSE, DEREG_BODY_PAIRINGS2, IMPU_IMS_SUBSCRIPTION);
 }
 
 TEST_F(HandlersTest, RegistrationTerminationRemoveSCSCFNoIMPUS)
 {
-  rtr_template_no_impus(REMOVE_SCSCF, HTTP_PATH_REG_TRUE, DEREG_BODY_LIST2);
+  rtr_template_no_impus(REMOVE_SCSCF, HTTP_PATH_REG_TRUE, DEREG_BODY_LIST2, IMPU_IMS_SUBSCRIPTION);
 }
 
 TEST_F(HandlersTest, RegistrationTerminationServerChange)
 {
-  rtr_template_no_impus(SERVER_CHANGE, HTTP_PATH_REG_TRUE, DEREG_BODY_LIST2);
+  rtr_template_no_impus(SERVER_CHANGE, HTTP_PATH_REG_TRUE, DEREG_BODY_LIST2, IMPU_IMS_SUBSCRIPTION);
 }
 
 TEST_F(HandlersTest, RegistrationTerminationNewServerAssigned)
 {
-  rtr_template_no_impus(NEW_SERVER_ASSIGNED, HTTP_PATH_REG_FALSE, DEREG_BODY_LIST2);
+  rtr_template_no_impus(NEW_SERVER_ASSIGNED, HTTP_PATH_REG_FALSE, DEREG_BODY_LIST2, IMPU_IMS_SUBSCRIPTION);
 }
 
 TEST_F(HandlersTest, RegistrationTerminationHTTPBadMethod)
@@ -4091,6 +4103,20 @@ TEST_F(HandlersTest, RTRRemoveSCSCFIncludesBarring)
                             HTTP_PATH_REG_TRUE,
                             IMPU_IMS_SUBSCRIPTION_WITH_BARRING,
                             DEREG_BODY_LIST3);
+}
+
+// Test that an RTR on which no IMPUs are present, only the IMPI, is handled
+// correctly if the first IMPU in a set associated with that IMPI is barred.
+TEST_F(HandlersTest, RegistrationTerminationNoImpusFirstBarred)
+{
+  rtr_template_no_impus(PERMANENT_TERMINATION, HTTP_PATH_REG_FALSE, DEREG_BODY_PAIRINGS5, IMPU_IMS_SUBSCRIPTION_WITH_BARRING2);
+}
+
+// Test that an RTR on which no IMPUs are present, only the IMPI, is handled
+// correctly if the second IMPU in a set associated with that IMPI is barred.
+TEST_F(HandlersTest, RegistrationTerminationNoImpusSecondBarred)
+{
+  rtr_template_no_impus(PERMANENT_TERMINATION, HTTP_PATH_REG_FALSE, DEREG_BODY_PAIRINGS2, IMPU_IMS_SUBSCRIPTION_WITH_BARRING3);
 }
 
 TEST_F(HandlersTest, RegistrationTerminationNoRegSets)

--- a/src/ut/handlers_test.cpp
+++ b/src/ut/handlers_test.cpp
@@ -120,7 +120,6 @@ public:
   static const std::string IMPU3;
   static const std::string IMPU4;
   static std::vector<std::string> IMPUS;
-  static std::vector<std::string> IMPU_LIST_OF_ONE;
   static std::vector<std::string> ASSOCIATED_IDENTITY1_IN_VECTOR;
   static std::vector<std::string> IMPU_REG_SET;
   static std::vector<std::string> IMPU_REG_SET2;
@@ -1247,7 +1246,7 @@ public:
                                            PERMANENT_TERMINATION,
                                            IMPI,
                                            ASSOCIATED_IDENTITIES,
-                                           IMPU_LIST_OF_ONE,
+                                           IMPU_IN_VECTOR,
                                            AUTH_SESSION_STATE);
 
     // The free_on_delete flag controls whether we want to free the underlying
@@ -1702,7 +1701,6 @@ const int32_t HandlersTest::AUTH_SESSION_STATE = 1;
 const std::string HandlersTest::ASSOCIATED_IDENTITY1 = "associated_identity1@example.com";
 const std::string HandlersTest::ASSOCIATED_IDENTITY2 = "associated_identity2@example.com";
 std::vector<std::string> HandlersTest::ASSOCIATED_IDENTITIES = {ASSOCIATED_IDENTITY1, ASSOCIATED_IDENTITY2};
-std::vector<std::string> HandlersTest::IMPU_LIST_OF_ONE = {IMPU};
 std::vector<std::string> HandlersTest::IMPUS = {IMPU, IMPU2};
 std::vector<std::string> HandlersTest::IMPU_IN_VECTOR = {IMPU};
 std::vector<std::string> HandlersTest::IMPI_IN_VECTOR = {IMPI};
@@ -4054,16 +4052,20 @@ TEST_F(HandlersTest, RegistrationTerminationHTTPUnknownError)
   rtr_template(PERMANENT_TERMINATION, HTTP_PATH_REG_FALSE, DEREG_BODY_PAIRINGS, 999);
 }
 
-// Test the correct delete request is passed to sprout when the first public
-// identity is barred.
+// Test the correct delete request is passed to sprout and the correct
+// information is removed from Cassandra when the first public identity in an
+// implicit registration set is barred (and so the first public identity is not
+// the default public identity).
 TEST_F(HandlersTest, RegistrationTerminationIncludesBarredImpus)
 {
   rtr_template_with_barring(IMPU_IMS_SUBSCRIPTION_WITH_BARRING,
                             DEREG_BODY_PAIRINGS3);
 }
 
-// Test the correct delete request is passed to sprout when no identities are
-// barred, but the barring indication node is present.
+// Test the correct delete request is passed to sprout and the correct
+// information is removed from Cassandra when the first public identity in an
+// implicit registration set has a barring indication node associated with it
+// (although it is unbarred).
 TEST_F(HandlersTest, RegistrationTerminationIncludesBarredIndication)
 {
   rtr_template_with_barring(IMPU_IMS_SUBSCRIPTION_BARRING_INDICATION,

--- a/src/ut/mockcache.hpp
+++ b/src/ut/mockcache.hpp
@@ -56,16 +56,19 @@ public:
   //
   // Methods that create cache request objects.
   //
-  MOCK_METHOD3(create_PutRegData,
+  MOCK_METHOD4(create_PutRegData,
                PutRegData*(const std::string& public_id,
+                           const std::string& default_public_id,
                            const int64_t timestamp,
                            const int32_t ttl));
-  MOCK_METHOD3(create_PutRegData,
+  MOCK_METHOD4(create_PutRegData,
                PutRegData*(const std::vector<std::string>& public_ids,
+                           const std::string& default_public_id,
                            const int64_t timestamp,
                            const int32_t ttl));
-  MOCK_METHOD4(create_PutAssociatedPrivateID,
+  MOCK_METHOD5(create_PutAssociatedPrivateID,
                PutAssociatedPrivateID*(const std::vector<std::string>& impus,
+                                       const std::string& default_public_id,
                                        const std::string& impi,
                                        const int64_t timestamp,
                                        const int32_t ttl));
@@ -149,7 +152,7 @@ public:
   //
   class MockPutRegData : public PutRegData, public MockOperationMixin
   {
-    MockPutRegData() : PutRegData("", 0, 0) {}
+    MockPutRegData() : PutRegData("", "", 0, 0) {}
     virtual ~MockPutRegData() {}
 
     MOCK_METHOD1(with_xml, PutRegData&(const std::string& xml));
@@ -160,7 +163,7 @@ public:
 
   class MockPutAssociatedPrivateID : public PutAssociatedPrivateID, public MockOperationMixin
   {
-    MockPutAssociatedPrivateID() : PutAssociatedPrivateID({}, "", 0, 0) {}
+    MockPutAssociatedPrivateID() : PutAssociatedPrivateID({}, "", "", 0, 0) {}
     virtual ~MockPutAssociatedPrivateID() {}
   };
 


### PR DESCRIPTION
We can no longer guarantee that the default public id is the first public id in a registration set.
Instead, it is the first UNBARRED public id in a registration set.

Extra logic to pull out this updated definition of the default id has been added to the code that supports RTRs.

Several tests have been added to double check this works.
More tests need to be added in the future, before this code is added to V11, to handle the full range of RTRs that can be recieved.

