### PR TITLE
[Reviewer: KH1] Add support for the UAR-Flags AVP

### DIFF
--- a/include/cx.h
+++ b/include/cx.h
@@ -99,6 +99,7 @@ public:
   const Diameter::Dictionary::AVP FEATURE_LIST_ID;
   const Diameter::Dictionary::AVP FEATURE_LIST;
   const Diameter::Dictionary::AVP WILDCARDED_PUBLIC_IDENTITY;
+  const Diameter::Dictionary::AVP UAR_FLAGS;
 };
 
 class UserAuthorizationRequest : public Diameter::Message
@@ -111,7 +112,8 @@ public:
                            const std::string& impi,
                            const std::string& impu,
                            const std::string& visited_network_identifier,
-                           const std::string& authorization_type);
+                           const std::string& authorization_type,
+                           const bool& emergency);
   inline UserAuthorizationRequest(Diameter::Message& msg) : Diameter::Message(msg) {};
 
   inline std::string impu() const
@@ -127,6 +129,10 @@ public:
   inline bool auth_type(int32_t& i32) const
   {
     return get_i32_from_avp(((Cx::Dictionary*)dict())->USER_AUTHORIZATION_TYPE, i32);
+  }
+  inline bool uar_flags(uint32_t& u32) const
+  {
+    return get_u32_from_avp(((Cx::Dictionary*)dict())->UAR_FLAGS, u32);
   }
 };
 

--- a/include/handlers.h
+++ b/include/handlers.h
@@ -397,7 +397,7 @@ public:
   };
 
   ImpiRegistrationStatusTask(HttpStack::Request& req, const Config* cfg, SAS::TrailId trail) :
-    HssCacheTask(req, trail), _cfg(cfg), _impi(), _impu(), _visited_network(), _authorization_type()
+    HssCacheTask(req, trail), _cfg(cfg), _impi(), _impu(), _visited_network(), _authorization_type(), _emergency()
   {}
 
   void run();
@@ -412,6 +412,7 @@ private:
   std::string _impu;
   std::string _visited_network;
   std::string _authorization_type;
+  bool _emergency;
 };
 
 class ImpuLocationInfoTask : public HssCacheTask

--- a/src/cx.cpp
+++ b/src/cx.cpp
@@ -98,7 +98,8 @@ Dictionary::Dictionary() :
   VENDOR_ID("Vendor-Id"),
   FEATURE_LIST_ID("3GPP", "Feature-List-ID"),
   FEATURE_LIST("3GPP", "Feature-List"),
-  WILDCARDED_PUBLIC_IDENTITY("3GPP", "Wildcarded-Public-Identity")
+  WILDCARDED_PUBLIC_IDENTITY("3GPP", "Wildcarded-Public-Identity"),
+  UAR_FLAGS("3GPP", "UAR-Flags")
 {
 }
 
@@ -109,7 +110,8 @@ UserAuthorizationRequest::UserAuthorizationRequest(const Dictionary* dict,
                                                    const std::string& impi,
                                                    const std::string& impu,
                                                    const std::string& visited_network_identifier,
-                                                   const std::string& authorization_type) :
+                                                   const std::string& authorization_type,
+                                                   const bool& emergency) :
                                                    Diameter::Message(dict, dict->USER_AUTHORIZATION_REQUEST, stack)
 {
   TRC_DEBUG("Building User-Authorization request for %s/%s", impi.c_str(), impu.c_str());
@@ -139,6 +141,13 @@ UserAuthorizationRequest::UserAuthorizationRequest(const Dictionary* dict,
   else
   {
     add(Diameter::AVP(dict->USER_AUTHORIZATION_TYPE).val_i32(0));
+  }
+
+  // UAR_FLAGS AVP is a u32 and contains a bit mask. The 0th bit is set for
+  // IMS emergency registrations.
+  if (emergency)
+  {
+    add(Diameter::AVP(dict->UAR_FLAGS).val_u32(1));
   }
 }
 

--- a/src/handlers.cpp
+++ b/src/handlers.cpp
@@ -623,6 +623,8 @@ void ImpiRegistrationStatusTask::run()
       _visited_network = _dest_realm;
     }
     _authorization_type = _req.param("auth-type");
+    std::string sos = _req.param("sos");
+    _emergency = sos == "true" ? true : false;
     TRC_DEBUG("Parsed HTTP request: private ID %s, public ID %s, visited network %s, authorization type %s",
               _impi.c_str(), _impu.c_str(), _visited_network.c_str(), _authorization_type.c_str());
 
@@ -633,7 +635,8 @@ void ImpiRegistrationStatusTask::run()
                                      _impi,
                                      _impu,
                                      _visited_network,
-                                     _authorization_type);
+                                     _authorization_type,
+                                     _emergency);
     DiameterTransaction* tsx =
       new DiameterTransaction(_dict,
                               this,

--- a/src/ut/cx_test.cpp
+++ b/src/ut/cx_test.cpp
@@ -84,6 +84,8 @@ public:
   static const std::deque<std::string> ECFS;
   static const ChargingAddresses NO_CHARGING_ADDRESSES;
   static const ChargingAddresses FULL_CHARGING_ADDRESSES;
+  static const bool NO_EMERGENCY;
+  static const bool EMERGENCY;
 
   static Diameter::Stack* _real_stack;
   static MockDiameterStack* _mock_stack;
@@ -216,6 +218,9 @@ const std::deque<std::string> CxTest::ECFS = {"ecf1", "ecf"};
 const std::deque<std::string> CxTest::CCFS = {"ccf1", "ccf2"};
 const ChargingAddresses CxTest::NO_CHARGING_ADDRESSES(NO_CFS, NO_CFS);
 const ChargingAddresses CxTest::FULL_CHARGING_ADDRESSES(CCFS, ECFS);
+const bool CxTest::NO_EMERGENCY = false;
+const bool CxTest::EMERGENCY = true;
+
 
 Diameter::Stack* CxTest::_real_stack = NULL;
 MockDiameterStack* CxTest::_mock_stack = NULL;
@@ -472,7 +477,8 @@ TEST_F(CxTest, UARTest)
                                    IMPI,
                                    IMPU,
                                    VISITED_NETWORK_IDENTIFIER,
-                                   AUTHORIZATION_TYPE_REG);
+                                   AUTHORIZATION_TYPE_REG,
+                                   NO_EMERGENCY);
   launder_message(uar);
   check_common_request_fields(uar);
   EXPECT_EQ(IMPI, uar.impi());
@@ -481,6 +487,7 @@ TEST_F(CxTest, UARTest)
   EXPECT_EQ(VISITED_NETWORK_IDENTIFIER, test_str);
   EXPECT_TRUE(uar.auth_type(test_i32));
   EXPECT_EQ(0, test_i32);
+  EXPECT_FALSE(uar.uar_flags(test_u32));
 }
 
 TEST_F(CxTest, UARAuthTypeDeregTest)
@@ -492,7 +499,8 @@ TEST_F(CxTest, UARAuthTypeDeregTest)
                                    IMPI,
                                    IMPU,
                                    VISITED_NETWORK_IDENTIFIER,
-                                   AUTHORIZATION_TYPE_DEREG);
+                                   AUTHORIZATION_TYPE_DEREG,
+                                   NO_EMERGENCY);
   launder_message(uar);
   check_common_request_fields(uar);
   EXPECT_EQ(IMPI, uar.impi());
@@ -501,6 +509,7 @@ TEST_F(CxTest, UARAuthTypeDeregTest)
   EXPECT_EQ(VISITED_NETWORK_IDENTIFIER, test_str);
   EXPECT_TRUE(uar.auth_type(test_i32));
   EXPECT_EQ(1, test_i32);
+  EXPECT_FALSE(uar.uar_flags(test_u32));
 }
 
 TEST_F(CxTest, UARAuthTypeCapabTest)
@@ -512,7 +521,8 @@ TEST_F(CxTest, UARAuthTypeCapabTest)
                                    IMPI,
                                    IMPU,
                                    VISITED_NETWORK_IDENTIFIER,
-                                   AUTHORIZATION_TYPE_CAPAB);
+                                   AUTHORIZATION_TYPE_CAPAB,
+                                   NO_EMERGENCY);
   launder_message(uar);
   check_common_request_fields(uar);
   EXPECT_EQ(IMPI, uar.impi());
@@ -521,6 +531,7 @@ TEST_F(CxTest, UARAuthTypeCapabTest)
   EXPECT_EQ(VISITED_NETWORK_IDENTIFIER, test_str);
   EXPECT_TRUE(uar.auth_type(test_i32));
   EXPECT_EQ(2, test_i32);
+  EXPECT_FALSE(uar.uar_flags(test_u32));
 }
 
 TEST_F(CxTest, UARNoAuthTypeTest)
@@ -532,7 +543,8 @@ TEST_F(CxTest, UARNoAuthTypeTest)
                                    IMPI,
                                    IMPU,
                                    VISITED_NETWORK_IDENTIFIER,
-                                   EMPTY_STRING);
+                                   EMPTY_STRING,
+                                   NO_EMERGENCY);
   launder_message(uar);
   check_common_request_fields(uar);
   EXPECT_EQ(IMPI, uar.impi());
@@ -541,6 +553,30 @@ TEST_F(CxTest, UARNoAuthTypeTest)
   EXPECT_EQ(VISITED_NETWORK_IDENTIFIER, test_str);
   EXPECT_TRUE(uar.auth_type(test_i32));
   EXPECT_EQ(0, test_i32);
+  EXPECT_FALSE(uar.uar_flags(test_u32));
+}
+
+TEST_F(CxTest, UAREmergencyTest)
+{
+  Cx::UserAuthorizationRequest uar(_cx_dict,
+                                   _mock_stack,
+                                   DEST_HOST,
+                                   DEST_REALM,
+                                   IMPI,
+                                   IMPU,
+                                   VISITED_NETWORK_IDENTIFIER,
+                                   AUTHORIZATION_TYPE_REG,
+                                   EMERGENCY);
+  launder_message(uar);
+  check_common_request_fields(uar);
+  EXPECT_EQ(IMPI, uar.impi());
+  EXPECT_EQ(IMPU, uar.impu());
+  EXPECT_TRUE(uar.visited_network(test_str));
+  EXPECT_EQ(VISITED_NETWORK_IDENTIFIER, test_str);
+  EXPECT_TRUE(uar.auth_type(test_i32));
+  EXPECT_EQ(0, test_i32);
+  EXPECT_TRUE(uar.uar_flags(test_u32));
+  EXPECT_EQ(1, test_u32);
 }
 
 //

--- a/src/ut/handlers_test.cpp
+++ b/src/ut/handlers_test.cpp
@@ -175,6 +175,7 @@ public:
 
   std::string test_str;
   int32_t test_i32;
+  uint32_t test_u32;
 
   HandlersTest() {}
   virtual ~HandlersTest()
@@ -3395,7 +3396,7 @@ TEST_F(HandlersTest, RegistrationStatusOptParamsSubseqRegCapabs)
   MockHttpStack::Request req(_httpstack,
                              "/impi/" + IMPI + "/",
                              "registration-status",
-                             "?impu=" + IMPU + "&visited-network=" + VISITED_NETWORK + "&auth-type=" + AUTH_TYPE_DEREG);
+                             "?impu=" + IMPU + "&visited-network=" + VISITED_NETWORK + "&auth-type=" + AUTH_TYPE_DEREG + "&sos=true");
 
   ImpiRegistrationStatusTask::Config cfg(true);
   ImpiRegistrationStatusTask* task = new ImpiRegistrationStatusTask(req, &cfg, FAKE_TRAIL_ID);
@@ -3421,6 +3422,8 @@ TEST_F(HandlersTest, RegistrationStatusOptParamsSubseqRegCapabs)
   EXPECT_EQ(VISITED_NETWORK, test_str);
   EXPECT_TRUE(uar.auth_type(test_i32));
   EXPECT_EQ(1, test_i32);
+  EXPECT_TRUE(uar.uar_flags(test_u32));
+  EXPECT_EQ(1, test_u32);
 
   // Build a UAA and expect a successful HTTP response.
   Cx::UserAuthorizationAnswer uaa(_cx_dict,


### PR DESCRIPTION
This PR takes the "sos=true" parameter on the UAR HTTP GET request from the I-CSCF and adds the UAR-Flags AVP on the Diameter UAR. Everything should be as in the design.

Sprout PR will follow shortly.