### PR TITLE
[Reviewer: Krista] Add config option to control shared IFC support

### DIFF
--- a/debian/homestead.init.d
+++ b/debian/homestead.init.d
@@ -160,6 +160,7 @@ get_daemon_args()
 
 
         [ "$sas_use_signaling_interface" != "Y" ] || sas_signaling_if_arg="--sas-use-signaling-interface"
+        [ "$support_shared_ifc" == "N" ] || support_shared_ifcs_arg="--support-shared-ifcs"
 
         [ -z "$diameter_timeout_ms" ] || diameter_timeout_ms_arg="--diameter-timeout-ms=$diameter_timeout_ms"
         [ -z "$signaling_namespace" ] || namespace_prefix="ip netns exec $signaling_namespace"
@@ -197,6 +198,7 @@ get_daemon_args()
                      $min_token_rate_arg
                      $exception_max_ttl_arg
                      $sas_signaling_if_arg
+                     $support_shared_ifcs_arg
                      --access-log=$log_directory
                      --log-file=$log_directory
                      --log-level=$log_level

--- a/debian/homestead.init.d
+++ b/debian/homestead.init.d
@@ -135,8 +135,8 @@ get_daemon_args()
 
 
         [ "$sas_use_signaling_interface" != "Y" ] || sas_signaling_if_arg="--sas-use-signaling-interface"
-        [ "$support_shared_ifc" == "N" ] || support_shared_ifcs_arg="--support-shared-ifcs"
 
+        [ -z "$request_shared_ifcs" ] || request_shared_ifcs_arg="--request-shared-ifcs=$request_shared_ifcs"
         [ -z "$diameter_timeout_ms" ] || diameter_timeout_ms_arg="--diameter-timeout-ms=$diameter_timeout_ms"
         [ -z "$signaling_namespace" ] || namespace_prefix="ip netns exec $signaling_namespace"
         [ -z "$target_latency_us" ] || target_latency_us_arg="--target-latency-us=$target_latency_us"
@@ -173,7 +173,7 @@ get_daemon_args()
                      $min_token_rate_arg
                      $exception_max_ttl_arg
                      $sas_signaling_if_arg
-                     $support_shared_ifcs_arg
+                     $request_shared_ifcs_arg
                      --access-log=$log_directory
                      --log-file=$log_directory
                      --log-level=$log_level

--- a/include/cx.h
+++ b/include/cx.h
@@ -289,6 +289,7 @@ public:
                           const std::string& impu,
                           const std::string& server_name,
                           const Cx::ServerAssignmentType type,
+                          const bool support_shared_ifcs,
                           const std::string& wildcard = "");
   inline ServerAssignmentRequest(Diameter::Message& msg) : Diameter::Message(msg) {};
 

--- a/include/handlers.h
+++ b/include/handlers.h
@@ -459,16 +459,19 @@ public:
     Config(bool _hss_configured = true,
            int _hss_reregistration_time = 3600,
            int _record_ttl = 7200,
-           int _diameter_timeout_ms = 200) :
+           int _diameter_timeout_ms = 200,
+           bool _support_shared_ifcs = true) :
       hss_configured(_hss_configured),
       hss_reregistration_time(_hss_reregistration_time),
       record_ttl(_record_ttl),
-      diameter_timeout_ms(_diameter_timeout_ms) {}
+      diameter_timeout_ms(_diameter_timeout_ms),
+      support_shared_ifcs(_support_shared_ifcs) {}
 
     bool hss_configured;
     int hss_reregistration_time;
     int record_ttl;
     int diameter_timeout_ms;
+    bool support_shared_ifcs;
   };
 
   ImpuRegDataTask(HttpStack::Request& req, const Config* cfg, SAS::TrailId trail) :

--- a/src/cx.cpp
+++ b/src/cx.cpp
@@ -690,6 +690,7 @@ ServerAssignmentRequest::ServerAssignmentRequest(const Dictionary* dict,
                                                  const std::string& impu,
                                                  const std::string& server_name,
                                                  const Cx::ServerAssignmentType type,
+                                                 const bool support_shared_ifcs,
                                                  const std::string& wildcard) :
                                                  Diameter::Message(dict, dict->SERVER_ASSIGNMENT_REQUEST, stack)
 {
@@ -698,30 +699,39 @@ ServerAssignmentRequest::ServerAssignmentRequest(const Dictionary* dict,
   add_app_id(Diameter::Dictionary::Application::AUTH, dict->TGPP, dict->CX);
   add(Diameter::AVP(dict->AUTH_SESSION_STATE).val_i32(1));
   add_origin();
+
   if (!dest_host.empty())
   {
     add(Diameter::AVP(dict->DESTINATION_HOST).val_str(dest_host));
   }
+
   add(Diameter::AVP(dict->DESTINATION_REALM).val_str(dest_realm));
+
   if (!impi.empty())
   {
     TRC_DEBUG("Specifying User-Name %s", impi.c_str());
     add(Diameter::AVP(dict->USER_NAME).val_str(impi));
   }
+
   add(Diameter::AVP(dict->PUBLIC_IDENTITY).val_str(impu));
   add(Diameter::AVP(dict->SERVER_NAME).val_str(server_name));
   add(Diameter::AVP(dict->SERVER_ASSIGNMENT_TYPE).val_i32(type));
   add(Diameter::AVP(dict->USER_DATA_ALREADY_AVAILABLE).val_i32(0));
+
   if ((!wildcard.empty()) && (include_wildcard_on_sar(type)))
   {
     TRC_DEBUG("Including wildcarded public identity %s on SAR", wildcard.c_str());
     add(Diameter::AVP(dict->WILDCARDED_PUBLIC_IDENTITY).val_str(wildcard));
   }
-  Diameter::AVP supported_features(dict->SUPPORTED_FEATURES);
-  supported_features.add(Diameter::AVP(dict->VENDOR_ID).val_u32(10415));
-  supported_features.add(Diameter::AVP(dict->FEATURE_LIST_ID).val_u32(1));
-  supported_features.add(Diameter::AVP(dict->FEATURE_LIST).val_u32(1));
-  add(supported_features);
+
+  if (support_shared_ifcs)
+  {
+    Diameter::AVP supported_features(dict->SUPPORTED_FEATURES);
+    supported_features.add(Diameter::AVP(dict->VENDOR_ID).val_u32(10415));
+    supported_features.add(Diameter::AVP(dict->FEATURE_LIST_ID).val_u32(1));
+    supported_features.add(Diameter::AVP(dict->FEATURE_LIST).val_u32(1));
+    add(supported_features);
+  }
 }
 
 ServerAssignmentAnswer::ServerAssignmentAnswer(const Dictionary* dict,

--- a/src/handlers.cpp
+++ b/src/handlers.cpp
@@ -1610,6 +1610,7 @@ void ImpuRegDataTask::send_server_assignment_request(Cx::ServerAssignmentType ty
                                   (_provided_server_name == "" ? _configured_server_name :
                                    _provided_server_name),
                                   type,
+                                  _cfg->support_shared_ifcs,
                                   (_hss_wildcard.empty() ? _sprout_wildcard : _hss_wildcard));
   DiameterTransaction* tsx =
     new DiameterTransaction(_dict,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -84,7 +84,7 @@ struct options
   std::string pidfile;
   bool daemon;
   bool sas_signaling_if;
-  bool support_shared_ifcs;
+  bool request_shared_ifcs;
 };
 
 // Enum for option types not assigned short-forms
@@ -108,7 +108,7 @@ enum OptionTypes
   DNS_TIMEOUT,
   FORCE_HSS_PEER,
   SAS_USE_SIGNALING_IF,
-  SUPPORT_SHARED_IFCS,
+  REQUEST_SHARED_IFCS,
   PIDFILE,
   DAEMON,
   REG_MAX_EXPIRES
@@ -154,7 +154,7 @@ const static struct option long_opt[] =
   {"pidfile",                     required_argument, NULL, PIDFILE},
   {"daemon",                      no_argument,       NULL, DAEMON},
   {"sas-use-signaling-interface", no_argument,       NULL, SAS_USE_SIGNALING_IF},
-  {"support-shared-ifcs",         no_argument,       NULL, SUPPORT_SHARED_IFCS},
+  {"request-shared-ifcs",         no_argument,       NULL, REQUEST_SHARED_IFCS},
   {NULL,                          0,                 NULL, 0},
 };
 
@@ -220,7 +220,8 @@ void usage(void)
        "                            The amount of time to blacklist a Diameter peer when it is unresponsive.\n"
        "     --dns-timeout <milliseconds>\n"
        "                            The amount of time to wait for a DNS response (default: 200)n"
-       "     --support-shared-ifcs  Indicate support for Shared IFC sets in the Supported-Features AVP.\n"
+       "     --request-shared-ifcs <Y/N>\n"
+       "                            Indicate support for Shared IFC sets in the Supported-Features AVP.\n"
        " -F, --log-file <directory>\n"
        "                            Log to file in specified directory\n"
        " -L, --log-level N          Set log level to N (default: 4)\n"
@@ -469,8 +470,11 @@ int init_options(int argc, char**argv, struct options& options)
       options.sas_signaling_if = true;
       break;
 
-    case SUPPORT_SHARED_IFCS:
-      options.support_shared_ifcs = true;
+    case REQUEST_SHARED_IFCS:
+      if (strcmp(optarg, "Y") != 0)
+      {
+        options.request_shared_ifcs = false;
+      }
       break;
 
     case DAEMON:
@@ -570,7 +574,7 @@ int main(int argc, char**argv)
   options.pidfile = "";
   options.daemon = false;
   options.sas_signaling_if = false;
-  options.support_shared_ifcs = false;
+  options.request_shared_ifcs = true;
 
   if (init_logging_options(argc, argv, options) != 0)
   {
@@ -842,7 +846,7 @@ int main(int argc, char**argv)
                                               options.hss_reregistration_time,
                                               record_ttl,
                                               options.diameter_timeout_ms,
-                                              options.support_shared_ifcs);
+                                              options.request_shared_ifcs);
   ImpuListTask::Config impu_list_config;
 
   HttpStackUtils::PingHandler ping_handler;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -108,6 +108,7 @@ struct options
   std::string pidfile;
   bool daemon;
   bool sas_signaling_if;
+  bool support_shared_ifcs;
 };
 
 // Enum for option types not assigned short-forms
@@ -130,6 +131,7 @@ enum OptionTypes
   DIAMETER_BLACKLIST_DURATION,
   FORCE_HSS_PEER,
   SAS_USE_SIGNALING_IF,
+  SUPPORT_SHARED_IFCS,
   PIDFILE,
   DAEMON,
   REG_MAX_EXPIRES
@@ -174,6 +176,7 @@ const static struct option long_opt[] =
   {"pidfile",                     required_argument, NULL, PIDFILE},
   {"daemon",                      no_argument,       NULL, DAEMON},
   {"sas-use-signaling-interface", no_argument,       NULL, SAS_USE_SIGNALING_IF},
+  {"support-shared-ifcs",         no_argument,       NULL, SUPPORT_SHARED_IFCS},
   {NULL,                          0,                 NULL, 0},
 };
 
@@ -237,6 +240,7 @@ void usage(void)
        "                            The amount of time to blacklist an HTTP peer when it is unresponsive.\n"
        "     --diameter-blacklist-duration <secs>\n"
        "                            The amount of time to blacklist a Diameter peer when it is unresponsive.\n"
+       "     --support-shared-ifcs  Indicate support for Shared IFC sets in the Supported-Features AVP.\n"
        " -F, --log-file <directory>\n"
        "                            Log to file in specified directory\n"
        " -L, --log-level N          Set log level to N (default: 4)\n"
@@ -480,6 +484,10 @@ int init_options(int argc, char**argv, struct options& options)
       options.sas_signaling_if = true;
       break;
 
+    case SUPPORT_SHARED_IFCS:
+      options.support_shared_ifcs = true;
+      break;
+
     case DAEMON:
     case 'F':
     case 'L':
@@ -576,6 +584,7 @@ int main(int argc, char**argv)
   options.pidfile = "";
   options.daemon = false;
   options.sas_signaling_if = false;
+  options.support_shared_ifcs = false;
 
   if (init_logging_options(argc, argv, options) != 0)
   {
@@ -845,7 +854,8 @@ int main(int argc, char**argv)
   ImpuRegDataTask::Config impu_handler_config(hss_configured,
                                               options.hss_reregistration_time,
                                               record_ttl,
-                                              options.diameter_timeout_ms);
+                                              options.diameter_timeout_ms,
+                                              options.support_shared_ifcs);
   ImpuListTask::Config impu_list_config;
 
   HttpStackUtils::PingHandler ping_handler;

--- a/src/ut/cx_test.cpp
+++ b/src/ut/cx_test.cpp
@@ -374,7 +374,8 @@ TEST_F(CxTest, SARTest)
                                   IMPI,
                                   IMPU,
                                   SERVER_NAME,
-                                  TIMEOUT_DEREGISTRATION);
+                                  TIMEOUT_DEREGISTRATION,
+                                  true);
   launder_message(sar);
   check_common_request_fields(sar);
   EXPECT_EQ(IMPI, sar.impi());
@@ -408,7 +409,8 @@ TEST_F(CxTest, SARNoImpiTest)
                                   EMPTY_STRING,
                                   IMPU,
                                   SERVER_NAME,
-                                  UNREGISTERED_USER);
+                                  UNREGISTERED_USER,
+                                  true);
   launder_message(sar);
   check_common_request_fields(sar);
   EXPECT_EQ(EMPTY_STRING, sar.impi());
@@ -419,6 +421,26 @@ TEST_F(CxTest, SARNoImpiTest)
   EXPECT_EQ(UNREGISTERED_USER, test_i32);
   EXPECT_TRUE(sar.user_data_already_available(test_i32));
   EXPECT_EQ(0, test_i32);
+}
+
+// Test that if we don't support shared IFCs, we don't add a Supported-Features
+// AVP claiming we do
+TEST_F(CxTest, SARTestNoSharedIFCSupport)
+{
+  Cx::ServerAssignmentRequest sar(_cx_dict,
+                                  _mock_stack,
+                                  DEST_HOST,
+                                  DEST_REALM,
+                                  IMPI,
+                                  IMPU,
+                                  SERVER_NAME,
+                                  TIMEOUT_DEREGISTRATION,
+                                  false);
+  launder_message(sar);
+  check_common_request_fields(sar);
+
+  Diameter::AVP::iterator supported_feature_avp = sar.begin(((Cx::Dictionary*)sar.dict())->SUPPORTED_FEATURES);
+  EXPECT_EQ(supported_feature_avp, sar.end());
 }
 
 //


### PR DESCRIPTION
Adds support for a new config option to control setting the supported-features AVP for shared IFC sets