### PR TITLE
[Reviewer: Adam] Cassandra fixes

### DIFF
--- a/include/cache.h
+++ b/include/cache.h
@@ -199,7 +199,7 @@ public:
     return new PutAuthVector(private_id, auth_vector, timestamp, ttl);
   }
 
-  class GetRegData : public CassandraStore::Operation
+  class GetRegData : public CassandraStore::HAOperation
   {
   public:
     /// Get the IMS subscription XML for a public identity.
@@ -267,7 +267,7 @@ public:
   // database operation that stores associations between IMPIs and
   // primary public IDs for use in handling RTRs, see GetAssociatedPrimaryPublicIDs.
 
-  class GetAssociatedPublicIDs : public CassandraStore::Operation
+  class GetAssociatedPublicIDs : public CassandraStore::HAOperation
   {
   public:
     /// Get the public Ids that are associated with a single private ID.
@@ -315,7 +315,7 @@ public:
   /// when we have a HSS) not the "impi" table (storing the SIP digest
   /// HA1 and all the public IDs associated with this IMPI, and only
   /// used when subscribers are locally provisioned).
-  class GetAssociatedPrimaryPublicIDs : public CassandraStore::Operation
+  class GetAssociatedPrimaryPublicIDs : public CassandraStore::HAOperation
   {
   public:
     /// Get the primary public Ids that are associated with a single private ID.
@@ -352,7 +352,7 @@ public:
     return new GetAssociatedPrimaryPublicIDs(private_ids);
   }
 
-  class GetAuthVector : public CassandraStore::Operation
+  class GetAuthVector : public CassandraStore::HAOperation
   {
   public:
     /// Get the auth vector of a private ID.
@@ -526,7 +526,7 @@ public:
 
   /// The main use-case is for Registration-Termination-Requests.
 
-  class DissociateImplicitRegistrationSetFromImpi : public CassandraStore::Operation
+  class DissociateImplicitRegistrationSetFromImpi : public CassandraStore::HAOperation
   {
   public:
     /// Delete a mapping from private IDs to the IMPUs they have authenticated.

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -302,7 +302,7 @@ bool Cache::PutAuthVector::perform(CassandraStore::Client* client,
 
 Cache::GetRegData::
 GetRegData(const std::string& public_id) :
-  CassandraStore::Operation(),
+  CassandraStore::HAOperation(),
   _public_id(public_id),
   _xml(),
   _reg_state(RegistrationState::NOT_REGISTERED),
@@ -327,7 +327,7 @@ bool Cache::GetRegData::perform(CassandraStore::Client* client,
 
   try
   {
-    client->ha_get_all_columns(IMPU, _public_id, results, trail);
+    ha_get_all_columns(client, IMPU, _public_id, results, trail);
 
     for(std::vector<ColumnOrSuperColumn>::iterator it = results.begin(); it != results.end(); ++it)
     {
@@ -484,7 +484,7 @@ void Cache::GetRegData::get_result(Cache::GetRegData::Result& result)
 
 Cache::GetAssociatedPublicIDs::
 GetAssociatedPublicIDs(const std::string& private_id) :
-  CassandraStore::Operation(),
+  CassandraStore::HAOperation(),
   _private_ids(1, private_id),
   _public_ids()
 {}
@@ -492,7 +492,7 @@ GetAssociatedPublicIDs(const std::string& private_id) :
 
 Cache::GetAssociatedPublicIDs::
 GetAssociatedPublicIDs(const std::vector<std::string>& private_ids) :
-  CassandraStore::Operation(),
+  CassandraStore::HAOperation(),
   _private_ids(private_ids),
   _public_ids()
 {}
@@ -514,11 +514,12 @@ bool Cache::GetAssociatedPublicIDs::perform(CassandraStore::Client* client,
             _private_ids.size());
   try
   {
-    client->ha_multiget_columns_with_prefix(IMPI,
-                                            _private_ids,
-                                            ASSOC_PUBLIC_ID_COLUMN_PREFIX,
-                                            columns,
-                                            trail);
+    ha_multiget_columns_with_prefix(client,
+                                    IMPI,
+                                    _private_ids,
+                                    ASSOC_PUBLIC_ID_COLUMN_PREFIX,
+                                    columns,
+                                    trail);
   }
   catch(CassandraStore::RowNotFoundException& rnfe)
   {
@@ -559,14 +560,14 @@ void Cache::GetAssociatedPublicIDs::get_result(std::vector<std::string>& ids)
 
 Cache::GetAssociatedPrimaryPublicIDs::
 GetAssociatedPrimaryPublicIDs(const std::string& private_id) :
-  CassandraStore::Operation(),
+  CassandraStore::HAOperation(),
   _private_ids(1, private_id),
   _public_ids()
 {}
 
 Cache::GetAssociatedPrimaryPublicIDs::
 GetAssociatedPrimaryPublicIDs(const std::vector<std::string>& private_ids) :
-  CassandraStore::Operation(),
+  CassandraStore::HAOperation(),
   _private_ids(private_ids),
   _public_ids()
 {}
@@ -581,11 +582,12 @@ bool Cache::GetAssociatedPrimaryPublicIDs::perform(CassandraStore::Client* clien
   TRC_DEBUG("Looking for primary public IDs for private ID %s and %d others", _private_ids.front().c_str(), _private_ids.size());
   try
   {
-    client->ha_multiget_columns_with_prefix(IMPI_MAPPING,
-                                            _private_ids,
-                                            IMPI_MAPPING_PREFIX,
-                                            columns,
-                                            trail);
+    ha_multiget_columns_with_prefix(client,
+                                    IMPI_MAPPING,
+                                    _private_ids,
+                                    IMPI_MAPPING_PREFIX,
+                                    columns,
+                                    trail);
   }
   catch(CassandraStore::RowNotFoundException& rnfe)
   {
@@ -622,7 +624,7 @@ void Cache::GetAssociatedPrimaryPublicIDs::get_result(std::vector<std::string>& 
 
 Cache::GetAuthVector::
 GetAuthVector(const std::string& private_id) :
-  CassandraStore::Operation(),
+  CassandraStore::HAOperation(),
   _private_id(private_id),
   _public_id(""),
   _auth_vector()
@@ -632,7 +634,7 @@ GetAuthVector(const std::string& private_id) :
 Cache::GetAuthVector::
 GetAuthVector(const std::string& private_id,
               const std::string& public_id) :
-  CassandraStore::Operation(),
+  CassandraStore::HAOperation(),
   _private_id(private_id),
   _public_id(public_id),
   _auth_vector()
@@ -671,7 +673,7 @@ bool Cache::GetAuthVector::perform(CassandraStore::Client* client,
 
   TRC_DEBUG("Issuing cache query");
   std::vector<ColumnOrSuperColumn> results;
-  client->ha_get_columns(IMPI, _private_id, requested_columns, results, trail);
+  ha_get_columns(client, IMPI, _private_id, requested_columns, results, trail);
 
   for (std::vector<ColumnOrSuperColumn>::const_iterator it = results.begin();
        it != results.end();
@@ -862,7 +864,7 @@ Cache::DissociateImplicitRegistrationSetFromImpi::
 DissociateImplicitRegistrationSetFromImpi(const std::vector<std::string>& impus,
                                           const std::string& impi,
                                           int64_t timestamp) :
-  CassandraStore::Operation(),
+  CassandraStore::HAOperation(),
   _impus(impus),
   _timestamp(timestamp)
 {
@@ -873,7 +875,7 @@ Cache::DissociateImplicitRegistrationSetFromImpi::
 DissociateImplicitRegistrationSetFromImpi(const std::vector<std::string>& impus,
                                           const std::vector<std::string>& impis,
                                           int64_t timestamp) :
-  CassandraStore::Operation(),
+  CassandraStore::HAOperation(),
   _impus(impus),
   _impis(impis),
   _timestamp(timestamp)
@@ -907,11 +909,12 @@ bool Cache::DissociateImplicitRegistrationSetFromImpi::perform(CassandraStore::C
   // to check the first)
 
   std::vector<ColumnOrSuperColumn> columns;
-  client->ha_get_columns_with_prefix(IMPU,
-                                     primary_public_id,
-                                     IMPI_COLUMN_PREFIX,
-                                     columns,
-                                     trail);
+  ha_get_columns_with_prefix(client,
+                             IMPU,
+                             primary_public_id,
+                             IMPI_COLUMN_PREFIX,
+                             columns,
+                             trail);
   TRC_DEBUG("%d IMPIs are associated with this IRS", columns.size());
 
   std::set<std::string> associated_impis_set;

--- a/src/handlers.cpp
+++ b/src/handlers.cpp
@@ -190,14 +190,6 @@ void ImpiTask::on_get_av_failure(CassandraStore::Operation* op,
     TRC_DEBUG("No cached av found for private ID %s, public ID %s - reject", _impi.c_str(), _impu.c_str());
     send_http_reply(HTTP_NOT_FOUND);
   }
-  else if (error == CassandraStore::CONNECTION_ERROR)
-  {
-    // If the cache error is a failure to connect to the local Cassandra,
-    // then we want Sprout to retry the request to another Homestead (as this
-    // could be a local issue to the node). Send a 503.
-    TRC_DEBUG("Cache query failed: unable to connect to local Cassandra");
-    send_http_reply(HTTP_SERVER_UNAVAILABLE);
-  }
   else
   {
     // Send a 504 in all other cases (the request won't be retried)

--- a/src/handlers.cpp
+++ b/src/handlers.cpp
@@ -274,14 +274,6 @@ void ImpiTask::on_get_impu_failure(CassandraStore::Operation* op, CassandraStore
     TRC_DEBUG("No cached public ID found for private ID %s - reject", _impi.c_str());
     send_http_reply(HTTP_NOT_FOUND);
   }
-  else if (error == CassandraStore::CONNECTION_ERROR)
-  {
-    // If the cache error is a failure to connect to the local Cassandra,
-    // then we want Sprout to retry the request to another Homestead (as this
-    // could be a local issue to the node). Send a 503.
-    TRC_DEBUG("Cache query failed: unable to connect to local Cassandra");
-    send_http_reply(HTTP_SERVER_UNAVAILABLE);
-  }
   else
   {
     // Send a 504 in all other cases (the request won't be retried)
@@ -966,20 +958,9 @@ void ImpuLocationInfoTask::on_get_reg_data_failure(CassandraStore::Operation* op
   SAS::Event event(this->trail(), SASEvent::NO_REG_DATA_CACHE, 0);
   SAS::report_event(event);
 
-  if (error == CassandraStore::CONNECTION_ERROR)
-  {
-    // If the cache error is a failure to connect to the local Cassandra,
-    // then we want Sprout to retry the request to another Homestead (as this
-    // could be a local issue to the node). Send a 503.
-    TRC_DEBUG("Cache query failed: unable to connect to local Cassandra");
-    send_http_reply(HTTP_SERVER_UNAVAILABLE);
-  }
-  else
-  {
-    // Send a 504 in all other cases (the request won't be retried)
-    TRC_DEBUG("Cache query failed with rc %d", error);
-    send_http_reply(HTTP_GATEWAY_TIMEOUT);
-  }
+  // Send a a 504, as this request will have been retried to 2 Cassandras already
+  TRC_DEBUG("Cache query failed with rc %d", error);
+  send_http_reply(HTTP_GATEWAY_TIMEOUT);
 
   delete this;
 }
@@ -1550,14 +1531,6 @@ void ImpuRegDataTask::on_get_reg_data_failure(CassandraStore::Operation* op,
   {
     TRC_DEBUG("No IMS subscription found for public ID %s - reject", _impu.c_str());
     send_http_reply(HTTP_NOT_FOUND);
-  }
-  else if (error == CassandraStore::CONNECTION_ERROR)
-  {
-    // If the cache error is a failure to connect to the local Cassandra,
-    // then we want Sprout to retry the request to another Homestead (as this
-    // could be a local issue to the node). Send a 503.
-    TRC_DEBUG("Cache query failed: unable to connect to local Cassandra");
-    send_http_reply(HTTP_SERVER_UNAVAILABLE);
   }
   else
   {

--- a/src/ut/handlers_test.cpp
+++ b/src/ut/handlers_test.cpp
@@ -2229,9 +2229,8 @@ TEST_F(HandlersTest, DigestNoIMPUCacheConnectionFailure)
   CassandraStore::Transaction* t = mock_op.get_trx();
   ASSERT_FALSE(t == NULL);
 
-  // Once the cache transaction's failure callback is called, expect a 503 Service
-  // unavailable response.
-  EXPECT_CALL(*_httpstack, send_reply(_, 503, _));
+  // Once the cache transaction's failure callback is called, expect a 504
+  EXPECT_CALL(*_httpstack, send_reply(_, 504, _));
 
   mock_op._cass_status = CassandraStore::CONNECTION_ERROR;
   mock_op._cass_error_text = "error";
@@ -3104,7 +3103,7 @@ TEST_F(HandlersTest, IMSSubscriptionCacheNotFound)
   t->on_failure(&mock_op);
 }
 
-// Connection failures should translate into a 503 Service Unavailable error
+// Connection failures should translate into a 504 error
 TEST_F(HandlersTest, IMSSubscriptionCacheConnectionFailure)
 {
   // This test tests an IMS Subscription handler case where the cache
@@ -3131,8 +3130,8 @@ TEST_F(HandlersTest, IMSSubscriptionCacheConnectionFailure)
   CassandraStore::Transaction* t = mock_op.get_trx();
   ASSERT_FALSE(t == NULL);
 
-  // Expect a 503 HTTP response once the cache returns an error to the task.
-  EXPECT_CALL(*_httpstack, send_reply(_, 503, _));
+  // Expect a 504 HTTP response once the cache returns an error to the task.
+  EXPECT_CALL(*_httpstack, send_reply(_, 504, _));
 
   mock_op._cass_status = CassandraStore::CONNECTION_ERROR;
   mock_op._cass_error_text = "error";
@@ -3848,8 +3847,8 @@ TEST_F(HandlersTest, LocationInfoNoHSSConnectionError)
   EXPECT_DO_ASYNC(*_cache, mock_op);
   task->run();
 
-  // The cache indicates connection error, so expect a 503 Service Unavailable over HTTP.
-  EXPECT_CALL(*_httpstack, send_reply(_, 503, _));
+  // The cache indicates connection error, so expect a 504 over HTTP.
+  EXPECT_CALL(*_httpstack, send_reply(_, 504, _));
   CassandraStore::Transaction* t = mock_op.get_trx();
   ASSERT_FALSE(t == NULL);
   mock_op._cass_status = CassandraStore::CONNECTION_ERROR;

--- a/src/ut/handlers_test.cpp
+++ b/src/ut/handlers_test.cpp
@@ -4795,7 +4795,7 @@ TEST_F(HandlerStatsTest, DigestCacheConnectionFailure)
   ASSERT_FALSE(t == NULL);
 
   // Cache latency stats are updated when the transaction fails.
-  EXPECT_CALL(*_httpstack, send_reply(_, 503,  _));
+  EXPECT_CALL(*_httpstack, send_reply(_, 504,  _));
   EXPECT_CALL(*_stats, update_H_cache_latency_us(_));
 
   mock_op._cass_status = CassandraStore::CONNECTION_ERROR;


### PR DESCRIPTION
There are 2 parts:

### Don't send 503 HTTP responses on Cassandra connection errors (first 2 commits)
In split-storage, we retry to multiple cassandra nodes already, so we don't want Sprout to retry if there's an error.
I tested this by creating the error conditions manually, and making calls, verifying that we do indeed get 504 responses sent.

### Use the new HAOperation cassandra operation (3rd commit)
This is the corresponding change to https://github.com/Metaswitch/cpp-common/pull/649
Testing is described in that PR.

