### PR TITLE
[Reviewer: Ellie] Connect to local host when adding cassandra schemas

### DIFF
--- a/homestead-cassandra.root/usr/share/clearwater/cassandra-schemas/homestead_cache.sh
+++ b/homestead-cassandra.root/usr/share/clearwater/cassandra-schemas/homestead_cache.sh
@@ -26,7 +26,7 @@ while [ $? -ne 0 ]; do
 
 done
 
-CQLSH="/usr/share/clearwater/bin/run-in-signaling-namespace cqlsh $cassandra_hostname"
+CQLSH="/usr/share/clearwater/bin/run-in-signaling-namespace cqlsh"
 
 if [[ ! -e /var/lib/cassandra/data/homestead_cache ]] || \
    [[ $cassandra_hostname != "127.0.0.1" ]];


### PR DESCRIPTION
This is a fix for https://github.com/Metaswitch/clearwater-issues/issues/2152

The problem is that the poll_cassandra script now (correctly) polls the local cassandra process, where it used to poll the cassandra hostname. When creating a deployment in Chef, the DNS record isn't added until after the nodes are created.

Previously, this meant that the poll_cassandra script would block the schema addition until the DNS record existed, so that when the cqlsh command was run it could find the cassandra hostname.

With the change to the poll_cassandra script, it unblocks as soon as cassandra is running but before the DNS record exists. This means that the cqlsh command is unable to connect as the hostname can't be resolved.

The fix is just to connect to the local cassandra instance, since the node running the homestead-cassandra debian package is the same one running cassandra.

(There are equivalent PRs for the other schema addition scripts too, but they're the same as this so I've not sent them for review).

Tested live that this resolves the problem.