### PR TITLE
[No reviewer] Clamp memory usage to 40%

### DIFF
--- a/homestead.root/usr/share/clearwater/infrastructure/scripts/homestead.monit
+++ b/homestead.root/usr/share/clearwater/infrastructure/scripts/homestead.monit
@@ -24,7 +24,7 @@ check process homestead_process with pidfile /var/run/homestead/homestead.pid
 
   # Check the service's resource usage, and abort the process if it's too high. This will
   # generate a core file and trigger diagnostics collection.
-  if memory > 80% then exec "/bin/bash -c '/usr/share/clearwater/bin/issue-alarm monit 1500.3; /etc/init.d/homestead abort'"
+  if memory > 40% then exec "/bin/bash -c '/usr/share/clearwater/bin/issue-alarm monit 1500.3; /etc/init.d/homestead abort'"
 
 # Clear any alarms if the process has been running long enough.
 check program homestead_uptime with path /usr/share/clearwater/infrastructure/monit_uptime/check-homestead-uptime


### PR DESCRIPTION
Following discussions with @eleanor-merry, we are going to clamp homestead's memory usage to 40% as it shares the node with Ralf on dime nodes.