### PR TITLE
PPR should update with only a charging address

### DIFF
--- a/include/cache.h
+++ b/include/cache.h
@@ -575,6 +575,30 @@ public:
     return new DissociateImplicitRegistrationSetFromImpi(impus, impis, timestamp);
   }
 
+  class DeleteIMPUs : public CassandraStore::Operation
+  {
+  public:
+    /// Delete several public IDs from the cache.
+    /// @param public_ids the public IDs to delete.
+    DeleteIMPUs(const std::vector<std::string>& public_ids,
+                int64_t timestamp);
+
+    virtual ~DeleteIMPUs();
+
+  protected:
+    std::vector<std::string> _public_ids;
+    int64_t _timestamp;
+
+    bool perform(CassandraStore::Client* client, SAS::TrailId trail);
+  };
+
+  virtual DeleteIMPUs* create_DeleteIMPUs(const std::vector<std::string>& public_ids,
+					  const int64_t timestamp)
+  {
+    return new DeleteIMPUs(public_ids,
+                           timestamp);
+  }
+
   /// List the IMPUs for which Homestead has data in its cache.
   ///
   /// -  When an HSS is in use, this lists all subscribers for which homestead

--- a/include/handlers.h
+++ b/include/handlers.h
@@ -627,6 +627,7 @@ private:
   std::string _impi;
   std::vector<std::string> _impus;
   std::vector<std::string> _default_impus;
+  std::vector<std::string> _further_impus;
 
   void on_get_impus_success(CassandraStore::Operation* op);
   void on_get_impus_failure(CassandraStore::Operation* op,
@@ -637,6 +638,11 @@ private:
                                     CassandraStore::ResultCode error,
                                     std::string& text);
   void update_reg_data();
+  void further_update_reg_data();
+  void further_update_reg_data_success(CassandraStore::Operation* op);
+  void further_update_reg_data_failure(CassandraStore::Operation* op,
+                                       CassandraStore::ResultCode error,
+                                       std::string& text);
   void update_reg_data_success(CassandraStore::Operation* op);
   void update_reg_data_failure(CassandraStore::Operation* op,
                                CassandraStore::ResultCode error,

--- a/include/handlers.h
+++ b/include/handlers.h
@@ -635,26 +635,27 @@ private:
   RegistrationState _reg_state;
   ChargingAddresses _reg_charging_addrs;
 
-  void update_reg_data();
-  void update_reg_data_success(CassandraStore::Operation* op);
-  void update_reg_data_failure(CassandraStore::Operation* op,
-                               CassandraStore::ResultCode error,
-                               std::string& text);
+
+  void on_get_primary_impus_success(CassandraStore::Operation* op);
+  void on_get_primary_impus_failure(CassandraStore::Operation* op,
+                                    CassandraStore::ResultCode error,
+                                    std::string& text);
   void get_irs();
   void on_get_irs_success(CassandraStore::Operation* op);
   void on_get_irs_failure(CassandraStore::Operation* op,
                                       CassandraStore::ResultCode error,
                                       std::string& text);
-  void on_get_primary_impus_success(CassandraStore::Operation* op);
-  void on_get_primary_impus_failure(CassandraStore::Operation* op,
-                                    CassandraStore::ResultCode error,
-                                    std::string& text);
   inline bool is_first_irs()
   {
     return (_default_public_id == _first_default_impu);
   }
   bool default_impus_match();
   void ims_sub_get_ids();
+  void update_reg_data();
+  void update_reg_data_success(CassandraStore::Operation* op);
+  void update_reg_data_failure(CassandraStore::Operation* op,
+                               CassandraStore::ResultCode error,
+                               std::string& text);
   void find_impus_to_delete();
   void delete_impus();
   bool any_new_impus();

--- a/include/handlers.h
+++ b/include/handlers.h
@@ -629,6 +629,10 @@ private:
   std::string _first_default_id;
   std::vector<std::string> _impus;
   std::vector<std::string> _default_impus;
+  std::vector<std::string> _irs_impus;
+  std::vector<std::string> _impus_to_delete;
+  RegistrationState _reg_state;
+  ChargingAddresses _reg_charging_addrs;
 
   void update_reg_data();
   void update_reg_data_success(CassandraStore::Operation* op);
@@ -644,9 +648,18 @@ private:
   void on_get_primary_impus_failure(CassandraStore::Operation* op,
                                     CassandraStore::ResultCode error,
                                     std::string& text);
+  // Return true if the default ID is the first to be updated.
+  // Else return false (if updating a further registration set.)
+  inline bool check_if_first()
+  {
+  return (_default_public_id == _first_default_id);
+  }
   void ims_sub_compare_default_ids();
   void ims_sub_get_ids();
   void no_ims_set_first_default();
+  void find_impus_to_delete();
+  void delete_impus();
+  bool check_impus_added();
   void decide_if_send_ppa();
   void send_ppa(const std::string result_code);
 };

--- a/include/handlers.h
+++ b/include/handlers.h
@@ -626,8 +626,8 @@ private:
   ChargingAddresses _charging_addrs;
   std::string _impi;
   std::string _default_public_id;
-  std::string _first_default_id;
-  std::string _new_default_id;
+  std::string _first_default_impu;
+  std::string _new_default_impu;
   std::vector<std::string> _impus;
   std::vector<std::string> _default_impus;
   std::vector<std::string> _irs_impus;
@@ -640,9 +640,9 @@ private:
   void update_reg_data_failure(CassandraStore::Operation* op,
                                CassandraStore::ResultCode error,
                                std::string& text);
-  void get_registration_set();
-  void on_get_registration_set_success(CassandraStore::Operation* op);
-  void on_get_registration_set_failure(CassandraStore::Operation* op,
+  void get_irs();
+  void on_get_irs_success(CassandraStore::Operation* op);
+  void on_get_irs_failure(CassandraStore::Operation* op,
                                       CassandraStore::ResultCode error,
                                       std::string& text);
   void on_get_primary_impus_success(CassandraStore::Operation* op);
@@ -651,15 +651,13 @@ private:
                                     std::string& text);
   inline bool is_first_irs()
   {
-    return (_default_public_id == _first_default_id);
+    return (_default_public_id == _first_default_impu);
   }
-  bool default_ids_match();
-  void no_default_id_match_send_failure();
+  bool default_impus_match();
   void ims_sub_get_ids();
-  void no_ims_set_first_default();
   void find_impus_to_delete();
   void delete_impus();
-  bool check_impus_added();
+  bool any_new_impus();
   inline bool should_send_ppa()
   {
     return is_first_irs();

--- a/include/handlers.h
+++ b/include/handlers.h
@@ -625,28 +625,29 @@ private:
   bool _charging_addrs_present;
   ChargingAddresses _charging_addrs;
   std::string _impi;
+  std::string _default_public_id;
+  std::string _first_default_id;
   std::vector<std::string> _impus;
   std::vector<std::string> _default_impus;
-  std::vector<std::string> _further_impus;
 
-  void on_get_impus_success(CassandraStore::Operation* op);
-  void on_get_impus_failure(CassandraStore::Operation* op,
-                            CassandraStore::ResultCode error,
-                            std::string& text);
-  void on_get_primary_impus_success(CassandraStore::Operation* op);
-  void on_get_primary_impus_failure(CassandraStore::Operation* op,
-                                    CassandraStore::ResultCode error,
-                                    std::string& text);
   void update_reg_data();
-  void further_update_reg_data();
-  void further_update_reg_data_success(CassandraStore::Operation* op);
-  void further_update_reg_data_failure(CassandraStore::Operation* op,
-                                       CassandraStore::ResultCode error,
-                                       std::string& text);
   void update_reg_data_success(CassandraStore::Operation* op);
   void update_reg_data_failure(CassandraStore::Operation* op,
                                CassandraStore::ResultCode error,
                                std::string& text);
+  void get_registration_set();
+  void on_get_registration_set_success(CassandraStore::Operation* op);
+  void on_get_registration_set_failure(CassandraStore::Operation* op,
+                                      CassandraStore::ResultCode error,
+                                      std::string& text);
+  void on_get_primary_impus_success(CassandraStore::Operation* op);
+  void on_get_primary_impus_failure(CassandraStore::Operation* op,
+                                    CassandraStore::ResultCode error,
+                                    std::string& text);
+  void ims_sub_compare_default_ids();
+  void ims_sub_get_ids();
+  void no_ims_set_first_default();
+  void decide_if_send_ppa();
   void send_ppa(const std::string result_code);
 };
 

--- a/include/handlers.h
+++ b/include/handlers.h
@@ -627,6 +627,7 @@ private:
   std::string _impi;
   std::string _default_public_id;
   std::string _first_default_id;
+  std::string _new_default_id;
   std::vector<std::string> _impus;
   std::vector<std::string> _default_impus;
   std::vector<std::string> _irs_impus;
@@ -648,19 +649,21 @@ private:
   void on_get_primary_impus_failure(CassandraStore::Operation* op,
                                     CassandraStore::ResultCode error,
                                     std::string& text);
-  // Return true if the default ID is the first to be updated.
-  // Else return false (if updating a further registration set.)
-  inline bool check_if_first()
+  inline bool is_first_irs()
   {
-  return (_default_public_id == _first_default_id);
+    return (_default_public_id == _first_default_id);
   }
-  void ims_sub_compare_default_ids();
+  bool default_ids_match();
+  void no_default_id_match_send_failure();
   void ims_sub_get_ids();
   void no_ims_set_first_default();
   void find_impus_to_delete();
   void delete_impus();
   bool check_impus_added();
-  void decide_if_send_ppa();
+  inline bool should_send_ppa()
+  {
+    return is_first_irs();
+  }
   void send_ppa(const std::string result_code);
 };
 

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -983,10 +983,7 @@ bool Cache::DissociateImplicitRegistrationSetFromImpi::perform(CassandraStore::C
 }
 
 
-//
 // Delete IMPUs methods for PPRs
-//
-
 
 Cache::DeleteIMPUs::
 DeleteIMPUs(const std::vector<std::string>& public_ids,
@@ -996,8 +993,7 @@ DeleteIMPUs(const std::vector<std::string>& public_ids,
   _timestamp(timestamp)
 {}
 
-Cache::DeleteIMPUs::
-~DeleteIMPUs()
+Cache::DeleteIMPUs::~DeleteIMPUs()
 {}
 
 bool Cache::DeleteIMPUs::perform(CassandraStore::Client* client,

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -524,6 +524,7 @@ bool Cache::GetAssociatedPublicIDs::perform(CassandraStore::Client* client,
                                     ASSOC_PUBLIC_ID_COLUMN_PREFIX,
                                     columns,
                                     trail);
+   
   }
   catch(CassandraStore::RowNotFoundException& rnfe)
   {
@@ -537,6 +538,7 @@ bool Cache::GetAssociatedPublicIDs::perform(CassandraStore::Client* client,
       key_it != columns.end();
       ++key_it)
   {
+        
     for(std::vector<ColumnOrSuperColumn>::const_iterator column = key_it->second.begin();
         column != key_it->second.end();
         ++column)

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -523,7 +523,6 @@ bool Cache::GetAssociatedPublicIDs::perform(CassandraStore::Client* client,
                                     ASSOC_PUBLIC_ID_COLUMN_PREFIX,
                                     columns,
                                     trail);
-
   }
   catch(CassandraStore::RowNotFoundException& rnfe)
   {
@@ -537,7 +536,6 @@ bool Cache::GetAssociatedPublicIDs::perform(CassandraStore::Client* client,
       key_it != columns.end();
       ++key_it)
   {
-
     for(std::vector<ColumnOrSuperColumn>::const_iterator column = key_it->second.begin();
         column != key_it->second.end();
         ++column)

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -386,25 +386,25 @@ bool Cache::GetRegData::perform(CassandraStore::Client* client,
       else if ((it->column.name == PRIMARY_CCF_COLUMN_NAME) && (it->column.value != ""))
       {
         _charging_addrs.ccfs.push_front(it->column.value);
-        TRC_DEBUG("Retrived primary_ccf column with value %s",
+        TRC_DEBUG("Retrieved primary_ccf column with value %s",
                   it->column.value.c_str());
       }
       else if ((it->column.name == SECONDARY_CCF_COLUMN_NAME) && (it->column.value != ""))
       {
         _charging_addrs.ccfs.push_back(it->column.value);
-        TRC_DEBUG("Retrived secondary_ccf column with value %s",
+        TRC_DEBUG("Retrieved secondary_ccf column with value %s",
                   it->column.value.c_str());
       }
       else if ((it->column.name == PRIMARY_ECF_COLUMN_NAME) && (it->column.value != ""))
       {
         _charging_addrs.ecfs.push_front(it->column.value);
-        TRC_DEBUG("Retrived primary_ecf column with value %s",
+        TRC_DEBUG("Retrieved primary_ecf column with value %s",
                   it->column.value.c_str());
       }
       else if ((it->column.name == SECONDARY_ECF_COLUMN_NAME) && (it->column.value != ""))
       {
         _charging_addrs.ecfs.push_back(it->column.value);
-        TRC_DEBUG("Retrived secondary_ecf column with value %s",
+        TRC_DEBUG("Retrieved secondary_ecf column with value %s",
                   it->column.value.c_str());
       }
     }
@@ -513,7 +513,7 @@ bool Cache::GetAssociatedPublicIDs::perform(CassandraStore::Client* client,
   std::map<std::string, std::vector<ColumnOrSuperColumn> > columns;
   std::set<std::string> public_ids;
 
-  TRC_DEBUG("Looking for public IDs for private ID %s and %d others",
+  TRC_DEBUG("Looking for public IDs for private ID %s out of a total %d private IDs.",
             _private_ids.front().c_str(),
             _private_ids.size());
   try
@@ -585,7 +585,7 @@ bool Cache::GetAssociatedPrimaryPublicIDs::perform(CassandraStore::Client* clien
   std::set<std::string> public_ids_set;
   std::map<std::string, std::vector<ColumnOrSuperColumn> > columns;
 
-  TRC_DEBUG("Looking for primary public IDs for private ID %s and %d others", _private_ids.front().c_str(), _private_ids.size());
+  TRC_DEBUG("Looking for primary public IDs for private ID %s out of a total %d private IDs", _private_ids.front().c_str(), _private_ids.size());
   try
   {
     ha_multiget_columns_with_prefix(client,

--- a/src/cx.cpp
+++ b/src/cx.cpp
@@ -777,6 +777,13 @@ void ServerAssignmentAnswer::charging_addrs(ChargingAddresses& charging_addrs) c
 {
   Diameter::AVP::iterator charging_information_avp =
                          begin(((Cx::Dictionary*)dict())->CHARGING_INFORMATION);
+
+  // charging_addrs is going to be pushed back to popualate it, so need to make sure it is empty
+  // first, to avoid populating it incorrectly and duplicating charging addresses.
+
+  charging_addrs.ccfs.clear();
+  charging_addrs.ecfs.clear();
+
   if (charging_information_avp != end())
   {
     Diameter::AVP::iterator primary_ccf_name_avp =
@@ -1019,6 +1026,13 @@ bool PushProfileRequest::charging_addrs(ChargingAddresses& charging_addrs) const
 
   Diameter::AVP::iterator charging_information_avp =
                          begin(((Cx::Dictionary*)dict())->CHARGING_INFORMATION);
+
+  // charging_addrs is going to be pushed back to populate it, so need to make sure it is empty
+  // first, to avoid populating it incorrectly and duplicating charging addresses.
+
+  charging_addrs.ccfs.clear();
+  charging_addrs.ecfs.clear();
+
   if (charging_information_avp != end())
   {
     found_charging_info = true;

--- a/src/cx.cpp
+++ b/src/cx.cpp
@@ -777,10 +777,8 @@ void ServerAssignmentAnswer::charging_addrs(ChargingAddresses& charging_addrs) c
 {
   Diameter::AVP::iterator charging_information_avp =
                          begin(((Cx::Dictionary*)dict())->CHARGING_INFORMATION);
-
-  // charging_addrs is going to be pushed back to popualate it, so need to make sure it is empty
+  // charging_addrs is going to be pushed back to populate it, so need to make sure it is empty
   // first, to avoid populating it incorrectly and duplicating charging addresses.
-
   charging_addrs.ccfs.clear();
   charging_addrs.ecfs.clear();
 
@@ -1029,7 +1027,6 @@ bool PushProfileRequest::charging_addrs(ChargingAddresses& charging_addrs) const
 
   // charging_addrs is going to be pushed back to populate it, so need to make sure it is empty
   // first, to avoid populating it incorrectly and duplicating charging addresses.
-
   charging_addrs.ccfs.clear();
   charging_addrs.ecfs.clear();
 

--- a/src/handlers.cpp
+++ b/src/handlers.cpp
@@ -2326,7 +2326,6 @@ void PushProfileTask::run()
   _ims_sub_present = _ppr.user_data(_ims_subscription);
   _charging_addrs_present = _ppr.charging_addrs(_charging_addrs);
 
-
   // If we have no charging addresses or IMS subscription, no actions need to be
   // taken, so send a PPA saying the PPR was successfully handled.
 
@@ -2472,7 +2471,6 @@ void PushProfileTask::ims_sub_get_ids()
   // Obtain the first default impu, then remove from the vector, and place at
   // the end, since the last item in the vector is the first to be considered
   // in obtaining the IRS.
-
   XmlUtils::get_default_id(_ims_subscription, _default_public_id);
   _first_default_impu = _default_public_id;
   _default_impus.erase(std::remove(_default_impus.begin(),

--- a/src/handlers.cpp
+++ b/src/handlers.cpp
@@ -2386,7 +2386,7 @@ void PushProfileTask::update_reg_data()
       SAS::report_event(event);
     }
   }
-}
+
 
   // Get the default public id from the ims subscription if it is present.
   // If the ims subscription is not present, take the first of the default ifcs

--- a/src/handlers.cpp
+++ b/src/handlers.cpp
@@ -2383,7 +2383,11 @@ void PushProfileTask::update_reg_data()
     TRC_INFO("Updating IMS subscription from PPR");
     put_reg_data->with_xml(_ims_subscription);
     event.add_compressed_param(_ims_subscription, &SASEvent::PROFILE_SERVICE_PROFILE);
+    // Find if any IMPUs have been deleted from the registration set and delete from
+    // cache accordingly.
     find_impus_to_delete();
+    // Find if any IMPUs have been added, and if so, also put the registration state
+    // and charging information.
     if (check_impus_added())
     {
       TRC_INFO("Updating registration state");
@@ -2394,6 +2398,7 @@ void PushProfileTask::update_reg_data()
       }
     }
   }
+  // If first time round and no IMS subscription was present.
   else if (check_if_first())
   {
     event.add_compressed_param("IMS subscription unchanged", &SASEvent::PROFILE_SERVICE_PROFILE);

--- a/src/handlers.cpp
+++ b/src/handlers.cpp
@@ -2361,9 +2361,7 @@ void PushProfileTask::update_reg_data()
 {
   // If we don't have any public IDs yet, we need to get them
   // out of the IMS subscription.
-   if (_ims_sub_present) {
-   if (_impus.empty())
-  {
+   if ((_ims_sub_present) && (_impus.empty())) {
     _impus = XmlUtils::get_public_ids(_ims_subscription);
 
     // We should check the IRS contains a SIP URI and throw an error log if
@@ -2452,7 +2450,6 @@ void PushProfileTask::update_reg_data()
   _cfg->cache->do_async(op, tsx);
 
    SAS::report_event(event);
-
 }
 
 

--- a/src/ut/cache_test.cpp
+++ b/src/ut/cache_test.cpp
@@ -899,6 +899,26 @@ TEST_F(CacheRequestTest, DeleteMultiPublicIds)
   execute_trx(op, trx);
 }
 
+TEST_F(CacheRequestTest, DeleteIMPUs)
+{
+  std::vector<std::string> ids;
+  ids.push_back("kermit");
+  ids.push_back("gonzo");
+  ids.push_back("miss piggy");
+
+  TestTransaction *trx = make_trx();
+  CassandraStore::Operation* op =
+    _cache.create_DeleteIMPUs(ids, 1000);
+
+  // The "kermit", "gonzo" and "miss piggy" IMPU rows should be deleted entirely
+  EXPECT_CALL(_client, remove("kermit", _, 1000, _));
+  EXPECT_CALL(_client, remove("gonzo", _, 1000, _));
+  EXPECT_CALL(_client, remove("miss piggy", _, 1000, _));
+
+  EXPECT_CALL(*trx, on_success(_));
+
+  execute_trx(op, trx);
+}
 
 TEST_F(CacheRequestTest, DeletePrivateId)
 {

--- a/src/ut/handlers_test.cpp
+++ b/src/ut/handlers_test.cpp
@@ -97,16 +97,21 @@ public:
   static const std::string IMPU2;
   static const std::string IMPU3;
   static const std::string IMPU4;
+  static const std::string IMPU5;
+  static const std::string IMPU6;
   static std::vector<std::string> IMPU_TEST;
   static std::vector<std::string> IMPUS;
-  static std::vector<std::string> MANY_IMPUS;
+  static std::vector<std::string> THREE_DEFAULT_IMPUS;
+  static std::vector<std::string> THREE_DEFAULT_IMPUS2;
   static std::vector<std::string> ASSOCIATED_IDENTITY1_IN_VECTOR;
   static std::vector<std::string> IMPU_REG_SET;
   static std::vector<std::string> IMPU_REG_SET2;
   static std::vector<std::string> IMPU3_REG_SET;
+  static std::vector<std::string> IMPU5_REG_SET;
   static const std::string IMPU_IMS_SUBSCRIPTION;
   static const std::string IMPU_IMS_SUBSCRIPTION_INVALID;
   static const std::string IMPU3_IMS_SUBSCRIPTION;
+  static const std::string IMPU5_IMS_SUBSCRIPTION;
   static const std::string IMPU_IMS_SUBSCRIPTION_WITH_BARRING;
   static const std::string IMPU_IMS_SUBSCRIPTION_WITH_BARRING2;
   static const std::string IMPU_IMS_SUBSCRIPTION_WITH_BARRING3;
@@ -1686,6 +1691,8 @@ const std::string HandlersTest::IMPU = "sip:impu@example.com";
 const std::string HandlersTest::IMPU2 = "sip:impu2@example.com";
 const std::string HandlersTest::IMPU3 = "sip:impu3@example.com";
 const std::string HandlersTest::IMPU4 = "sip:impu4@example.com";
+const std::string HandlersTest::IMPU5 = "sip:impu5@example.com";
+const std::string HandlersTest::IMPU6 = "sip:impu6@example.com";
 const std::string HandlersTest::IMS_SUBSCRIPTION = "<?xml version=\"1.0\"?><IMSSubscription><PrivateID>" + IMPI + "</PrivateID><ServiceProfile><PublicIdentity><Identity>" + IMPU + "</Identity></PublicIdentity></ServiceProfile></IMSSubscription>";
 const std::string HandlersTest::REGDATA_RESULT = "<ClearwaterRegData>\n\t<RegistrationState>REGISTERED</RegistrationState>\n\t<IMSSubscription>\n\t\t<PrivateID>" + IMPI + "</PrivateID>\n\t\t<ServiceProfile>\n\t\t\t<PublicIdentity>\n\t\t\t\t<Identity>" + IMPU + "</Identity>\n\t\t\t</PublicIdentity>\n\t\t\t<PublicIdentity>\n\t\t\t\t<Identity>" + IMPU4 + "</Identity>\n\t\t\t</PublicIdentity>\n\t\t</ServiceProfile>\n\t</IMSSubscription>\n</ClearwaterRegData>\n\n";
 const std::string HandlersTest::REGDATA_RESULT_INCLUDES_BARRING = "<ClearwaterRegData>\n\t<RegistrationState>REGISTERED</RegistrationState>\n\t<IMSSubscription>\n\t\t<PrivateID>" + IMPI + "</PrivateID>\n\t\t<ServiceProfile>\n\t\t\t<PublicIdentity>\n\t\t\t\t<Identity>" + IMPU + "</Identity>\n\t\t\t\t<BarringIndication>1</BarringIndication>\n\t\t\t</PublicIdentity>\n\t\t\t<PublicIdentity>\n\t\t\t\t<Identity>" + IMPU2 + "</Identity>\n\t\t\t</PublicIdentity>\n\t\t</ServiceProfile>\n\t</IMSSubscription>\n</ClearwaterRegData>\n\n";
@@ -1707,7 +1714,8 @@ const std::string HandlersTest::ASSOCIATED_IDENTITY2 = "associated_identity2@exa
 std::vector<std::string> HandlersTest::ASSOCIATED_IDENTITIES = {ASSOCIATED_IDENTITY1, ASSOCIATED_IDENTITY2};
 std::vector<std::string> HandlersTest::IMPU_TEST = {IMPU};
 std::vector<std::string> HandlersTest::IMPUS = {IMPU, IMPU2};
-std::vector<std::string> HandlersTest::MANY_IMPUS = {IMPU, IMPU2, IMPU3};
+std::vector<std::string> HandlersTest::THREE_DEFAULT_IMPUS = {IMPU, IMPU2, IMPU3};
+std::vector<std::string> HandlersTest::THREE_DEFAULT_IMPUS2 = {IMPU, IMPU3, IMPU5};
 std::vector<std::string> HandlersTest::IMPU_IN_VECTOR = {IMPU};
 std::vector<std::string> HandlersTest::IMPU2_IN_VECTOR = {IMPU2};
 std::vector<std::string> HandlersTest::IMPU3_IN_VECTOR = {IMPU3};
@@ -1716,9 +1724,11 @@ std::vector<std::string> HandlersTest::ASSOCIATED_IDENTITY1_IN_VECTOR = {ASSOCIA
 std::vector<std::string> HandlersTest::IMPU_REG_SET = {IMPU, IMPU4};
 std::vector<std::string> HandlersTest::IMPU_REG_SET2 = {IMPU, IMPU2};
 std::vector<std::string> HandlersTest::IMPU3_REG_SET = {IMPU3, IMPU2};
+std::vector<std::string> HandlersTest::IMPU5_REG_SET = {IMPU5, IMPU6};
 const std::string HandlersTest::IMPU_IMS_SUBSCRIPTION = "<?xml version=\"1.0\"?><IMSSubscription><PrivateID>" + IMPI + "</PrivateID><ServiceProfile><PublicIdentity><Identity>" + IMPU + "</Identity></PublicIdentity><PublicIdentity><Identity>" + IMPU4 + "</Identity></PublicIdentity></ServiceProfile></IMSSubscription>";
 const std::string HandlersTest::IMPU_IMS_SUBSCRIPTION_INVALID = "<?xml version=\"1.0\"?><IMSSubscriptio></IMSSubscriptio>";
 const std::string HandlersTest::IMPU3_IMS_SUBSCRIPTION = "<?xml version=\"1.0\"?><IMSSubscription><PrivateID>" + IMPI + "</PrivateID><ServiceProfile><PublicIdentity><Identity>" + IMPU3 + "</Identity></PublicIdentity><PublicIdentity><Identity>" + IMPU2 + "</Identity></PublicIdentity></ServiceProfile></IMSSubscription>";
+const std::string HandlersTest::IMPU5_IMS_SUBSCRIPTION = "<?xml version=\"1.0\"?><IMSSubscription><PrivateID>" + IMPI + "</PrivateID><ServiceProfile><PublicIdentity><Identity>" + IMPU5 + "</Identity></PublicIdentity><PublicIdentity><Identity>" + IMPU6 + "</Identity></PublicIdentity></ServiceProfile></IMSSubscription>";
 const std::string HandlersTest::IMPU_IMS_SUBSCRIPTION_WITH_BARRING = "<?xml version=\"1.0\"?><IMSSubscription><PrivateID>" + IMPI + "</PrivateID><ServiceProfile><PublicIdentity><Identity>" + IMPU + "</Identity><BarringIndication>1</BarringIndication></PublicIdentity><PublicIdentity><Identity>" + IMPU2 + "</Identity></PublicIdentity></ServiceProfile></IMSSubscription>";
 const std::string HandlersTest::IMPU_IMS_SUBSCRIPTION_WITH_BARRING2 = "<?xml version=\"1.0\"?><IMSSubscription><PrivateID>" + IMPI + "</PrivateID><ServiceProfile><PublicIdentity><Identity>" + IMPU + "</Identity><BarringIndication>1</BarringIndication></PublicIdentity><PublicIdentity><Identity>" + IMPU4 + "</Identity></PublicIdentity></ServiceProfile></IMSSubscription>";
 const std::string HandlersTest::IMPU_IMS_SUBSCRIPTION_WITH_BARRING3 = "<?xml version=\"1.0\"?><IMSSubscription><PrivateID>" + IMPI + "</PrivateID><ServiceProfile><PublicIdentity><Identity>" + IMPU + "</Identity></PublicIdentity><PublicIdentity><Identity>" + IMPU4 + "</Identity><BarringIndication>1</BarringIndication></PublicIdentity></ServiceProfile></IMSSubscription>";
@@ -4540,19 +4550,38 @@ TEST_F(HandlersTest, PushProfileChargingAddrs)
   EXPECT_CALL(mock_op, get_result(_))
     .WillRepeatedly(SetArgReferee<0>(IMPU_IN_VECTOR));
 
-  // Next we expect to try and update the charging addresses (but not the IMS
-  // subscription) in the cache.
-  MockCache::MockPutRegData mock_op2;
-  EXPECT_CALL(*_cache, create_PutRegData(IMPU_TEST, IMPU, _, 7200))
-    .Times(1)
+  // Next, expect to obtain the other public identities in the IRS
+  MockCache::MockGetRegData mock_op2;
+  EXPECT_CALL(*_cache, create_GetRegData(IMPU))
     .WillOnce(Return(&mock_op2));
-  EXPECT_CALL(mock_op2, with_charging_addrs(_))
-    .WillOnce(ReturnRef(mock_op2));
   EXPECT_DO_ASYNC(*_cache, mock_op2);
 
   t->on_success(&mock_op);
 
   t = mock_op2.get_trx();
+  ASSERT_FALSE(t == NULL);
+  EXPECT_CALL(mock_op2, get_xml(_, _))
+    .WillRepeatedly(SetArgReferee<0>(IMPU_IMS_SUBSCRIPTION));
+  EXPECT_CALL(mock_op2, get_registration_state(_, _))
+    .WillRepeatedly(Return());
+  EXPECT_CALL(mock_op2, get_charging_addrs(_))
+    .WillRepeatedly(Return());
+  EXPECT_CALL(mock_op2, get_associated_impis(_))
+    .WillRepeatedly(Return());
+
+  // Next we expect to try and update the charging addresses (but not the IMS
+  // subscription) in the cache.
+  MockCache::MockPutRegData mock_op3;
+  EXPECT_CALL(*_cache, create_PutRegData(IMPU_REG_SET, IMPU, _, 7200))
+    .Times(1)
+    .WillOnce(Return(&mock_op3));
+  EXPECT_CALL(mock_op3, with_charging_addrs(_))
+    .WillOnce(ReturnRef(mock_op3));
+  EXPECT_DO_ASYNC(*_cache, mock_op3);
+
+  t->on_success(&mock_op2);
+
+  t = mock_op3.get_trx();
   ASSERT_FALSE(t == NULL);
 
   // Finally we expect a PPA.
@@ -4560,7 +4589,7 @@ TEST_F(HandlersTest, PushProfileChargingAddrs)
     .Times(1)
     .WillOnce(WithArgs<0>(Invoke(store_msg)));
 
-  t->on_success(&mock_op2);
+  t->on_success(&mock_op3);
 
   // Turn the caught Diameter msg structure into a PPA and confirm its contents.
   Diameter::Message msg(_cx_dict, _caught_fd_msg, _mock_stack);
@@ -4785,7 +4814,7 @@ TEST_F(HandlersTest, PushProfileMultipleIRS)
     Cx::PushProfileRequest ppr(_cx_dict,
                              _mock_stack,
                              IMPI,
-                             IMS_SUBSCRIPTION,
+                             IMPU3_IMS_SUBSCRIPTION,
                              FULL_CHARGING_ADDRESSES,
                              AUTH_SESSION_STATE);
 
@@ -4811,19 +4840,21 @@ TEST_F(HandlersTest, PushProfileMultipleIRS)
 
   task->run();
 
-   // The cache successfully returns a list of default public identities from
-  // each IRS the IMPI is associated with.
+  // The cache successfully returns a list of default public identities from
+  // each IRS the IMPI is associated with. It will return a list of
+  // three default IMPUs, and the one in the IMS subscription element on the
+  // PPR is the second.
   CassandraStore::Transaction* t = mock_op.get_trx();
   ASSERT_FALSE(t == NULL);
   EXPECT_CALL(mock_op, get_result(_))
-    .WillRepeatedly(SetArgReferee<0>(MANY_IMPUS));
+    .WillRepeatedly(SetArgReferee<0>(THREE_DEFAULT_IMPUS2));
 
   // Then expect an attempt to update the IMS subscription of the charging
   // addresses in the cache.
   MockCache::MockPutRegData mock_op2;
-  EXPECT_CALL(*_cache, create_PutRegData(IMPU_IN_VECTOR, IMPU, _, 7200))
+  EXPECT_CALL(*_cache, create_PutRegData(IMPU3_REG_SET, IMPU3, _, 7200))
     .WillOnce(Return(&mock_op2));
-  EXPECT_CALL(mock_op2, with_xml(IMS_SUBSCRIPTION))
+  EXPECT_CALL(mock_op2, with_xml(IMPU3_IMS_SUBSCRIPTION))
     .WillOnce(ReturnRef(mock_op2));
   EXPECT_CALL(mock_op2, with_charging_addrs(_))
     .WillOnce(ReturnRef(mock_op2));
@@ -4834,25 +4865,58 @@ TEST_F(HandlersTest, PushProfileMultipleIRS)
   t = mock_op2.get_trx();
   ASSERT_FALSE(t == NULL);
 
-  // we expect a PPA.
+  // Next, we expect a PPA.
   EXPECT_CALL(*_mock_stack, send(_, FAKE_TRAIL_ID))
     .Times(1)
     .WillOnce(WithArgs<0>(Invoke(store_msg)));
 
-  //expect an attempt to update the charging addresses for the other default IMPUs.
-  MockCache::MockPutRegData mock_op3;
-  EXPECT_CALL(*_cache, create_PutRegData(IMPU3_IN_VECTOR, IMPU3, _, 7200))
+  // Next, expect to obtain the other public identities in the IRS
+  // for the next default ID
+  MockCache::MockGetRegData mock_op3;
+  EXPECT_CALL(*_cache, create_GetRegData(IMPU5))
     .WillOnce(Return(&mock_op3));
-  EXPECT_CALL(mock_op3, with_charging_addrs(_))
-    .WillOnce(ReturnRef(mock_op3));
   EXPECT_DO_ASYNC(*_cache, mock_op3);
 
+  EXPECT_CALL(mock_op3, get_xml(_, _))
+    .WillRepeatedly(SetArgReferee<0>(IMPU5_IMS_SUBSCRIPTION));
+  EXPECT_CALL(mock_op3, get_registration_state(_, _))
+    .WillRepeatedly(Return());
+  EXPECT_CALL(mock_op3, get_charging_addrs(_))
+    .WillRepeatedly(Return());
+  EXPECT_CALL(mock_op3, get_associated_impis(_))
+    .WillRepeatedly(Return());
+
+  //expect an attempt to update the charging addresses for this default IMPU.
   MockCache::MockPutRegData mock_op4;
-  EXPECT_CALL(*_cache, create_PutRegData(IMPU2_IN_VECTOR, IMPU2, _, 7200))
+  EXPECT_CALL(*_cache, create_PutRegData(IMPU5_REG_SET, IMPU5, _, 7200))
     .WillOnce(Return(&mock_op4));
   EXPECT_CALL(mock_op4, with_charging_addrs(_))
     .WillOnce(ReturnRef(mock_op4));
   EXPECT_DO_ASYNC(*_cache, mock_op4);
+
+  // Next, expect to obtain the other public identities in the IRS
+  // for the final default ID
+  MockCache::MockGetRegData mock_op5;
+  EXPECT_CALL(*_cache, create_GetRegData(IMPU))
+    .WillOnce(Return(&mock_op5));
+  EXPECT_DO_ASYNC(*_cache, mock_op5);
+
+  EXPECT_CALL(mock_op5, get_xml(_, _))
+    .WillRepeatedly(SetArgReferee<0>(IMPU_IMS_SUBSCRIPTION));
+  EXPECT_CALL(mock_op5, get_registration_state(_, _))
+    .WillRepeatedly(Return());
+  EXPECT_CALL(mock_op5, get_charging_addrs(_))
+    .WillRepeatedly(Return());
+  EXPECT_CALL(mock_op5, get_associated_impis(_))
+    .WillRepeatedly(Return());
+
+  //expect an attempt to update the charging addresses for this default IMPU.
+  MockCache::MockPutRegData mock_op6;
+  EXPECT_CALL(*_cache, create_PutRegData(IMPU_REG_SET, IMPU, _, 7200))
+    .WillOnce(Return(&mock_op6));
+  EXPECT_CALL(mock_op6, with_charging_addrs(_))
+    .WillOnce(ReturnRef(mock_op6));
+  EXPECT_DO_ASYNC(*_cache, mock_op6);
 
   t->on_success(&mock_op2);
 
@@ -4872,6 +4936,17 @@ TEST_F(HandlersTest, PushProfileMultipleIRS)
   ASSERT_FALSE(t == NULL);
 
   t->on_success(&mock_op4);
+
+  t = mock_op5.get_trx();
+  ASSERT_FALSE(t == NULL);
+
+  t->on_success(&mock_op5);
+
+  t = mock_op6.get_trx();
+  ASSERT_FALSE(t == NULL);
+
+  t->on_success(&mock_op6);
+
 }
 
 
@@ -4911,47 +4986,102 @@ TEST_F(HandlersTest, PushProfileChargingAddrsMultipleIRS)
   task->run();
 
   // The cache successfully returns a list of default public identities.
+  // It will return a list of 3 default identities.
   CassandraStore::Transaction* t = mock_op.get_trx();
   ASSERT_FALSE(t == NULL);
   EXPECT_CALL(mock_op, get_result(_))
-    .WillRepeatedly(SetArgReferee<0>(MANY_IMPUS));
+    .WillRepeatedly(SetArgReferee<0>(THREE_DEFAULT_IMPUS2));
 
-  // Next we expect to try and update the charging addresses (but not the IMS
-  // subscription) in the cache.
-  MockCache::MockPutRegData mock_op2;
-  EXPECT_CALL(*_cache, create_PutRegData(IMPU_IN_VECTOR, IMPU, _, 7200))
-    .Times(1)
+  // Next, expect to obtain the other public identities in the IRS
+  // for the first default ID
+  MockCache::MockGetRegData mock_op2;
+  EXPECT_CALL(*_cache, create_GetRegData(IMPU5))
     .WillOnce(Return(&mock_op2));
-  EXPECT_CALL(mock_op2, with_charging_addrs(_))
-    .WillOnce(ReturnRef(mock_op2));
   EXPECT_DO_ASYNC(*_cache, mock_op2);
+
+  EXPECT_CALL(mock_op2, get_xml(_, _))
+    .WillRepeatedly(SetArgReferee<0>(IMPU5_IMS_SUBSCRIPTION));
+  EXPECT_CALL(mock_op2, get_registration_state(_, _))
+    .WillRepeatedly(Return());
+  EXPECT_CALL(mock_op2, get_charging_addrs(_))
+    .WillRepeatedly(Return());
+  EXPECT_CALL(mock_op2, get_associated_impis(_))
+    .WillRepeatedly(Return());
 
   t->on_success(&mock_op);
 
   t = mock_op2.get_trx();
   ASSERT_FALSE(t == NULL);
 
-  // we expect a PPA.
-  EXPECT_CALL(*_mock_stack, send(_, FAKE_TRAIL_ID))
-    .Times(1)
-    .WillOnce(WithArgs<0>(Invoke(store_msg)));
 
-  //expect an attempt to update the charging addresses for the other default IMPUs.
+  // Next we expect to try and update the charging addresses in the cache.
   MockCache::MockPutRegData mock_op3;
-  EXPECT_CALL(*_cache, create_PutRegData(IMPU3_IN_VECTOR, IMPU3, _, 7200))
+  EXPECT_CALL(*_cache, create_PutRegData(IMPU5_REG_SET, IMPU5, _, 7200))
+    .Times(1)
     .WillOnce(Return(&mock_op3));
   EXPECT_CALL(mock_op3, with_charging_addrs(_))
     .WillOnce(ReturnRef(mock_op3));
   EXPECT_DO_ASYNC(*_cache, mock_op3);
 
-  MockCache::MockPutRegData mock_op4;
-  EXPECT_CALL(*_cache, create_PutRegData(IMPU2_IN_VECTOR, IMPU2, _, 7200))
+  t->on_success(&mock_op2);
+
+  t = mock_op3.get_trx();
+  ASSERT_FALSE(t == NULL);
+
+  // Next, we expect a PPA.
+  EXPECT_CALL(*_mock_stack, send(_, FAKE_TRAIL_ID))
+    .Times(1)
+    .WillOnce(WithArgs<0>(Invoke(store_msg)));
+
+  // Next, expect to obtain the other public identities in the IRS
+  // for the next default ID
+  MockCache::MockGetRegData mock_op4;
+  EXPECT_CALL(*_cache, create_GetRegData(IMPU3))
     .WillOnce(Return(&mock_op4));
-  EXPECT_CALL(mock_op4, with_charging_addrs(_))
-    .WillOnce(ReturnRef(mock_op4));
   EXPECT_DO_ASYNC(*_cache, mock_op4);
 
-  t->on_success(&mock_op2);
+  EXPECT_CALL(mock_op4, get_xml(_, _))
+    .WillRepeatedly(SetArgReferee<0>(IMPU3_IMS_SUBSCRIPTION));
+  EXPECT_CALL(mock_op4, get_registration_state(_, _))
+    .WillRepeatedly(Return());
+  EXPECT_CALL(mock_op4, get_charging_addrs(_))
+    .WillRepeatedly(Return());
+  EXPECT_CALL(mock_op4, get_associated_impis(_))
+    .WillRepeatedly(Return());
+
+  // Expect an attempt to update the charging addresses for this default IMPU.
+  MockCache::MockPutRegData mock_op5;
+  EXPECT_CALL(*_cache, create_PutRegData(IMPU3_REG_SET, IMPU3, _, 7200))
+    .WillOnce(Return(&mock_op5));
+  EXPECT_CALL(mock_op5, with_charging_addrs(_))
+    .WillOnce(ReturnRef(mock_op5));
+  EXPECT_DO_ASYNC(*_cache, mock_op5);
+
+  // Next, expect to obtain the other public identities in the IRS
+  // for the final default ID
+  MockCache::MockGetRegData mock_op6;
+  EXPECT_CALL(*_cache, create_GetRegData(IMPU))
+    .WillOnce(Return(&mock_op6));
+  EXPECT_DO_ASYNC(*_cache, mock_op6);
+
+  EXPECT_CALL(mock_op6, get_xml(_, _))
+    .WillRepeatedly(SetArgReferee<0>(IMPU_IMS_SUBSCRIPTION));
+  EXPECT_CALL(mock_op6, get_registration_state(_, _))
+    .WillRepeatedly(Return());
+  EXPECT_CALL(mock_op6, get_charging_addrs(_))
+    .WillRepeatedly(Return());
+  EXPECT_CALL(mock_op6, get_associated_impis(_))
+    .WillRepeatedly(Return());
+
+  // Expect an attempt to update the charging addresses for this default IMPU.
+  MockCache::MockPutRegData mock_op7;
+  EXPECT_CALL(*_cache, create_PutRegData(IMPU_REG_SET, IMPU, _, 7200))
+    .WillOnce(Return(&mock_op7));
+  EXPECT_CALL(mock_op7, with_charging_addrs(_))
+    .WillOnce(ReturnRef(mock_op7));
+  EXPECT_DO_ASYNC(*_cache, mock_op7);
+
+  t->on_success(&mock_op3);
 
   // Turn the caught Diameter msg structure into a PPA and confirm its contents.
   Diameter::Message msg(_cx_dict, _caught_fd_msg, _mock_stack);
@@ -4960,15 +5090,25 @@ TEST_F(HandlersTest, PushProfileChargingAddrsMultipleIRS)
   EXPECT_EQ(DIAMETER_SUCCESS, test_i32);
   EXPECT_EQ(AUTH_SESSION_STATE, ppa.auth_session_state());
 
-  t = mock_op3.get_trx();
-  ASSERT_FALSE(t == NULL);
-
-  t->on_success(&mock_op3);
-
   t = mock_op4.get_trx();
   ASSERT_FALSE(t == NULL);
 
   t->on_success(&mock_op4);
+
+  t = mock_op5.get_trx();
+  ASSERT_FALSE(t == NULL);
+
+  t->on_success(&mock_op5);
+
+  t = mock_op6.get_trx();
+  ASSERT_FALSE(t == NULL);
+
+  t->on_success(&mock_op6);
+
+  t = mock_op7.get_trx();
+  ASSERT_FALSE(t == NULL);
+
+  t->on_success(&mock_op7);
 }
 
 

--- a/src/ut/handlers_test.cpp
+++ b/src/ut/handlers_test.cpp
@@ -1481,7 +1481,6 @@ public:
               			charging_addresses,
                    		AUTH_SESSION_STATE);
 
-
     // The free_on_delete flag controls whether we want to free the underlying
     // fd_msg structure when we delete this PPR. We don't, since this will be
     // freed when the answer is freed later in the test. If we leave this flag set

--- a/src/ut/handlers_test.cpp
+++ b/src/ut/handlers_test.cpp
@@ -1474,7 +1474,7 @@ public:
                  std::string ims_subscription,
                  ChargingAddresses charging_addresses)
   {
-     Cx::PushProfileRequest ppr(_cx_dict,
+    Cx::PushProfileRequest ppr(_cx_dict,
                                 _mock_stack,
 		                impi,
                                 ims_subscription,
@@ -1498,6 +1498,7 @@ public:
 
   void ppr_expect_get_default_ids(MockCache::MockGetAssociatedPrimaryPublicIDs* mock_op, std::string impi)
   {
+    // Get Default IDs for impi
     EXPECT_CALL(*_cache, create_GetAssociatedPrimaryPublicIDs(impi))
       .WillOnce(Return(mock_op));
     EXPECT_DO_ASYNC(*_cache, *mock_op);
@@ -1505,12 +1506,14 @@ public:
 
   void ppr_get_default_ids(MockCache::MockGetAssociatedPrimaryPublicIDs* mock_op, std::vector<std::string> impus)
   {
+    // Get Default IDs will return impus
     EXPECT_CALL(*mock_op, get_result(_))
       .WillRepeatedly(SetArgReferee<0>(impus));
   }
 
   void ppr_expect_get_reg_data(MockCache::MockGetRegData* mock_op, std::string impu)
   {
+    // Get reg data for impu
     EXPECT_CALL(*_cache, create_GetRegData(impu))
       .WillOnce(Return(mock_op));
     EXPECT_DO_ASYNC(*_cache, *mock_op);
@@ -1522,6 +1525,8 @@ public:
                         ChargingAddresses charging_addresses,
                         std::vector<std::string> impis)
   {
+    // Get reg data will return ims_subscription, reg_state, charging_addresses
+    // and impis
     EXPECT_CALL(*mock_op, get_xml(_, _))
       .WillRepeatedly(SetArgReferee<0>(ims_subscription));
     EXPECT_CALL(*mock_op, get_registration_state(_, _))
@@ -1539,6 +1544,9 @@ public:
 		        ChargingAddresses charging_addresses,
 			RegistrationState reg_state = RegistrationState::UNCHANGED)
   {
+    // Put reg data against list of impus in reg set impus, with default
+    // identity default_impu. Put ims_subscription, charging_addresses and
+    // reg_state, if they are provided.
     EXPECT_CALL(*_cache, create_PutRegData(impus, default_impu, _, 7200))
       .Times(1)
       .WillOnce(Return(mock_op));
@@ -1562,6 +1570,7 @@ public:
 
   void ppr_delete_IMPUs(MockCache::MockDeleteIMPUs* mock_op, std::vector<std::string> impus)
   {
+    // Delete the IMPUs from cache in vector impus.
     EXPECT_CALL(*_cache, create_DeleteIMPUs(impus, _))
       .Times(1)
       .WillOnce(Return(mock_op));
@@ -1577,6 +1586,7 @@ public:
 
   void ppr_send_ppa(int success_or_failure)
   {
+    // Send a PPA indicating success or failure.
     Diameter::Message msg(_cx_dict, _caught_fd_msg, _mock_stack);
     Cx::PushProfileAnswer ppa(msg);
     EXPECT_TRUE(ppa.result_code(test_i32));

--- a/src/ut/mockcache.hpp
+++ b/src/ut/mockcache.hpp
@@ -97,6 +97,9 @@ public:
                DissociateImplicitRegistrationSetFromImpi*(const std::vector<std::string>& impus,
                                                           const std::vector<std::string>& impis,
                                                           int64_t timestamp));
+  MOCK_METHOD2(create_DeleteIMPUs,
+               DeleteIMPUs*(const std::vector<std::string>& public_ids,
+                            int64_t timestamp));
   MOCK_METHOD0(create_ListImpus, ListImpus*());
 
   // Mock request objects.
@@ -211,6 +214,12 @@ public:
   {
     MockDissociateImplicitRegistrationSetFromImpi() : DissociateImplicitRegistrationSetFromImpi({}, "", 0) {}
     virtual ~MockDissociateImplicitRegistrationSetFromImpi() {}
+  };
+
+  class MockDeleteIMPUs : public DeleteIMPUs, public MockOperationMixin
+  {
+    MockDeleteIMPUs() : DeleteIMPUs({}, 0) {}
+    virtual ~MockDeleteIMPUs() {}
   };
 
   class MockListImpus : public ListImpus, public MockOperationMixin


### PR DESCRIPTION
PPR was failing to update the charging address when there was no IMS subscription element present. It should be able to update without this. Was previously failing to find any associated public IDs, since this function is only used when subscribers are locally provisioned. Changed such that it can correctly find the default IDs, then uses the Default ID to identify the Implicit Registration Set in order to update the charging address, rather than obtaining a list of all IDs. 

Tested for a simple subscription, with only one IMPI and one IMPU and it updates the charging information correctly. It also appears to update correctly with an IMPI and one implicit registration set, containing multiple IMPUs, although further testing is required. 