### PR TITLE
[No Reviewer] Use common code to calculate diameter timeout

### DIFF
--- a/debian/homestead.init.d
+++ b/debian/homestead.init.d
@@ -124,16 +124,6 @@ get_daemon_args()
           dest_realm="--dest-realm=$hss_realm"
         fi
 
-        # Default the diameter timeout to twice the target latency if not
-        # already overridden (rounding up).  Note that the former is expressed
-        # in milliseconds and the latter in microseconds, hence division by 500
-        # (i.e. multiplication by 2/1000).
-        if [ -z $diameter_timeout_ms ] && [ ! -z $target_latency_us ]
-        then
-          diameter_timeout_ms=$(( ($target_latency_us + 499)/500 ))
-        fi
-
-
         [ "$sas_use_signaling_interface" != "Y" ] || sas_signaling_if_arg="--sas-use-signaling-interface"
         [ "$request_shared_ifcs" != "Y" ] || request_shared_ifcs_arg="--request-shared-ifcs"
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -265,6 +265,7 @@ int init_options(int argc, char**argv, struct options& options)
 {
   int opt;
   int long_opt_ind;
+  bool diameter_timeout_set = false;
 
   optind = 0;
   while ((opt = getopt_long(argc, argv, options_description.c_str(), long_opt, &long_opt_ind)) != -1)
@@ -388,6 +389,7 @@ int init_options(int argc, char**argv, struct options& options)
 
     case DIAMETER_TIMEOUT_MS:
       TRC_INFO("Diameter timeout: %s", optarg);
+      diameter_timeout_set = true;
       options.diameter_timeout_ms = atoi(optarg);
       break;
 
@@ -488,6 +490,12 @@ int init_options(int argc, char**argv, struct options& options)
       TRC_ERROR("Unknown option. Run with --help for options.\n");
       return -1;
     }
+  }
+
+  if (!diameter_timeout_set)
+  {
+    Utils::calculate_diameter_timeout(options.target_latency_us,
+                                      options.diameter_timeout_ms);
   }
 
   return 0;


### PR DESCRIPTION
Follow on change from Metaswitch/cpp-common#664.