### PR TITLE
(Reviewer:Ellie) PPR Functionality to inform sprout

### DIFF
--- a/include/handlers.h
+++ b/include/handlers.h
@@ -589,17 +589,20 @@ public:
   {
     Config(Cache* _cache,
            Cx::Dictionary* _dict,
+	   SproutConnection* _sprout_conn,
            int _impu_cache_ttl = 0,
            int _hss_reregistration_time = 3600,
            int _record_ttl = 7200) :
       cache(_cache),
       dict(_dict),
+      sprout_conn(_sprout_conn),
       impu_cache_ttl(_impu_cache_ttl),
       hss_reregistration_time(_hss_reregistration_time),
       record_ttl(_record_ttl) {}
 
     Cache* cache;
     Cx::Dictionary* dict;
+    SproutConnection* sprout_conn;
     int impu_cache_ttl;
     int hss_reregistration_time;
     int record_ttl;

--- a/include/handlers.h
+++ b/include/handlers.h
@@ -591,7 +591,7 @@ public:
   {
     Config(Cache* _cache,
            Cx::Dictionary* _dict,
-	   SproutConnection* _sprout_conn,
+           SproutConnection* _sprout_conn,
            int _impu_cache_ttl = 0,
            int _hss_reregistration_time = 3600,
            int _record_ttl = 7200) :

--- a/include/sproutconnection.h
+++ b/include/sproutconnection.h
@@ -38,7 +38,6 @@ public:
 private:
   std::string create_body(const std::vector<std::string>& default_public_ids,
                           const std::vector<std::string>& impis);
-//  std::string change_ids_create_body(const std::vector<std::string>& impus);
 
   HttpConnection* _http;
 };

--- a/include/sproutconnection.h
+++ b/include/sproutconnection.h
@@ -25,7 +25,7 @@ public:
                                        const std::vector<std::string>& impis,
                                        SAS::TrailId trail);
   virtual HTTPCode change_associated_identities(const std::string& default_id,
-						const std::vector<std::string>& impus,
+						const std::string& user_data_xml,
 						SAS::TrailId trail);
 
 
@@ -38,7 +38,7 @@ public:
 private:
   std::string create_body(const std::vector<std::string>& default_public_ids,
                           const std::vector<std::string>& impis);
-  std::string change_ids_create_body(const std::vector<std::string>& impus);
+//  std::string change_ids_create_body(const std::vector<std::string>& impus);
 
   HttpConnection* _http;
 };

--- a/include/sproutconnection.h
+++ b/include/sproutconnection.h
@@ -33,12 +33,12 @@ public:
   static const std::string JSON_REGISTRATIONS;
   static const std::string JSON_PRIMARY_IMPU;
   static const std::string JSON_IMPI;
-  static const std::string JSON_ASSOCIATED_IDENTITIES;
+  static const std::string JSON_USER_DATA_XML;
 
 private:
-  std::string create_body(const std::vector<std::string>& default_public_ids,
-                          const std::vector<std::string>& impis);
-
+  std::string rtr_create_body(const std::vector<std::string>& default_public_ids,
+                              const std::vector<std::string>& impis);
+  std::string ppr_create_body(const std::string& user_data);
   HttpConnection* _http;
 };
 #endif

--- a/include/sproutconnection.h
+++ b/include/sproutconnection.h
@@ -1,5 +1,5 @@
 /**
- * @file sproutconnection.h 
+ * @file sproutconnection.h
  *
  * Copyright (C) Metaswitch Networks 2014
  * If license terms are provided to you in a COPYING file in the root directory
@@ -24,15 +24,21 @@ public:
                                        const std::vector<std::string>& default_public_ids,
                                        const std::vector<std::string>& impis,
                                        SAS::TrailId trail);
+  virtual HTTPCode change_associated_identities(const std::string& default_id,
+						const std::vector<std::string>& impus,
+						SAS::TrailId trail);
+
 
   // JSON string constants
   static const std::string JSON_REGISTRATIONS;
   static const std::string JSON_PRIMARY_IMPU;
   static const std::string JSON_IMPI;
- 
+  static const std::string JSON_ASSOCIATED_IDENTITIES;
+
 private:
   std::string create_body(const std::vector<std::string>& default_public_ids,
                           const std::vector<std::string>& impis);
+  std::string change_ids_create_body(const std::vector<std::string>& impus);
 
   HttpConnection* _http;
 };

--- a/include/sproutconnection.h
+++ b/include/sproutconnection.h
@@ -25,8 +25,8 @@ public:
                                        const std::vector<std::string>& impis,
                                        SAS::TrailId trail);
   virtual HTTPCode change_associated_identities(const std::string& default_id,
-						const std::string& user_data_xml,
-						SAS::TrailId trail);
+                                                const std::string& user_data_xml,
+                                                SAS::TrailId trail);
 
 
   // JSON string constants

--- a/src/handlers.cpp
+++ b/src/handlers.cpp
@@ -2552,41 +2552,40 @@ void PushProfileTask::update_reg_data()
   if (_ims_sub_present && is_first_irs())
   {
     find_impus_to_delete();
-    if (!_impus_to_delete.empty() || any_new_impus())
+
+    TRC_DEBUG("Going to inform sprout of user data");
+
+    ret_code = _cfg->sprout_conn->change_associated_identities(_default_public_id,
+	       			 	   	               _ims_subscription,
+							       this->trail());
+    TRC_DEBUG("Informed Sprout");
+    switch (ret_code)
     {
-      TRC_DEBUG("Identities have changed, going to inform sprout");
-      ret_code = _cfg->sprout_conn->change_associated_identities(_default_public_id,
-    							         _impus,
-								 this->trail());
-      TRC_DEBUG("Informed Sprout");
-      switch (ret_code)
-      {
-      case HTTP_OK:
-      {
-        TRC_DEBUG("NOTIFY sent from Sprout");
-      }
-      break;
+    case HTTP_OK:
+    {
+      TRC_DEBUG("NOTIFY sent from Sprout");
+    }
+    break;
 
-      case HTTP_BADMETHOD:
-      case HTTP_BAD_REQUEST:
-      case HTTP_SERVER_ERROR:
-      {
-        TRC_DEBUG("Send Push Profile answer indicating failure");
-        send_ppa(DIAMETER_REQ_FAILURE);
-	delete this;
-	return;
-      }
-      break;
+    case HTTP_BADMETHOD:
+    case HTTP_BAD_REQUEST:
+    case HTTP_SERVER_ERROR:
+    {
+      TRC_DEBUG("Sprout return Code %d, Send Push Profile answer indicating failure", ret_code);
+      send_ppa(DIAMETER_REQ_FAILURE);
+      delete this;
+      return;
+    }
+    break;
 
-      default:
-      {
-        TRC_ERROR("Unexpected HTTP return code, send Push Profile answer indicating failure");
-	send_ppa(DIAMETER_REQ_FAILURE);
-        delete this;
-        return;
-      }
-      break;
-      }
+    default:
+    {
+      TRC_ERROR("Unexpected HTTP return code, send Push Profile answer indicating failure");
+      send_ppa(DIAMETER_REQ_FAILURE);
+      delete this;
+      return;
+    }
+    break;
     }
   }
 

--- a/src/handlers.cpp
+++ b/src/handlers.cpp
@@ -2556,8 +2556,8 @@ void PushProfileTask::update_reg_data()
     find_impus_to_delete();
 
     rc = _cfg->sprout_conn->change_associated_identities(_default_public_id,
-	       			 	   	               _ims_subscription,
-							       this->trail());
+                                                         _ims_subscription,
+                                                         this->trail());
 
     if (rc == HTTP_OK)
     {
@@ -2701,7 +2701,7 @@ void PushProfileTask::delete_impus()
 {
   CassandraStore::Operation* delete_IMPU =
     _cfg->cache->create_DeleteIMPUs(_impus_to_delete,
-			       Cache::generate_timestamp());
+                                    Cache::generate_timestamp());
   CassandraStore::Transaction* tsx = new CacheTransaction;
   _cfg->cache->do_async(delete_IMPU, tsx);
 }

--- a/src/handlers.cpp
+++ b/src/handlers.cpp
@@ -2561,12 +2561,11 @@ void PushProfileTask::update_reg_data()
     ret_code = _cfg->sprout_conn->change_associated_identities(_default_public_id,
 	       			 	   	               _ims_subscription,
 							       this->trail());
-    TRC_DEBUG("Informed Sprout");
     switch (ret_code)
     {
     case HTTP_OK:
     {
-      TRC_DEBUG("NOTIFY sent from Sprout");
+      TRC_DEBUG("Informed Sprout, return code %d", ret_code);
     }
     break;
 
@@ -2583,7 +2582,7 @@ void PushProfileTask::update_reg_data()
 
     default:
     {
-      TRC_ERROR("Unexpected HTTP return code, send Push Profile answer indicating failure");
+      TRC_ERROR("Unexpected HTTP return code from Sprout, send Push Profile answer indicating failure");
       send_ppa(DIAMETER_REQ_FAILURE);
       delete this;
       return;

--- a/src/handlers.cpp
+++ b/src/handlers.cpp
@@ -2559,13 +2559,9 @@ void PushProfileTask::update_reg_data()
                                                          _ims_subscription,
                                                          this->trail());
 
-    if (rc == HTTP_OK)
+    if (rc != HTTP_OK)
     {
-      TRC_DEBUG("Informed Sprout, return code %d", rc);
-    }
-    else
-    {
-      TRC_DEBUG("Sprout return Code %d, Send Push Profile answer indicating failure", rc);
+      TRC_DEBUG("Failed to update Sprout (return code: %d), sending negative PPA", rc);
       send_ppa(DIAMETER_REQ_FAILURE);
       delete this;
       return;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -791,6 +791,7 @@ int main(int argc, char**argv)
                                                          options.hss_reregistration_time);
     ppr_config = new PushProfileTask::Config(cache,
                                              dict,
+					     sprout_conn,
                                              options.impu_cache_ttl,
                                              options.hss_reregistration_time,
                                              record_ttl);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -799,7 +799,7 @@ int main(int argc, char**argv)
                                                          options.hss_reregistration_time);
     ppr_config = new PushProfileTask::Config(cache,
                                              dict,
-					     sprout_conn,
+                                             sprout_conn,
                                              options.impu_cache_ttl,
                                              options.hss_reregistration_time,
                                              record_ttl);

--- a/src/sproutconnection.cpp
+++ b/src/sproutconnection.cpp
@@ -98,8 +98,8 @@ std::string SproutConnection::rtr_create_body(const std::vector<std::string>& de
 }
 
 HTTPCode SproutConnection::change_associated_identities(const std::string& default_id,
-							const std::string& user_data,
-							SAS::TrailId trail)
+                                                        const std::string& user_data,
+                                                        SAS::TrailId trail)
 {
   std::string path = "/registrations/" + default_id;
   std::string body = ppr_create_body(user_data);

--- a/src/sproutconnection.cpp
+++ b/src/sproutconnection.cpp
@@ -19,7 +19,7 @@
 const std::string SproutConnection::JSON_REGISTRATIONS = "registrations";
 const std::string SproutConnection::JSON_PRIMARY_IMPU = "primary-impu";
 const std::string SproutConnection::JSON_IMPI = "impi";
-const std::string SproutConnection::JSON_ASSOCIATED_IDENTITIES = "associated-identities";
+const std::string SproutConnection::JSON_USER_DATA_XML = "user-data-xml";
 
 SproutConnection::SproutConnection(HttpConnection* http) : _http(http)
 {
@@ -39,15 +39,15 @@ HTTPCode SproutConnection::deregister_bindings(const bool& send_notifications,
   std::string path = "/registrations?send-notifications=";
   path += send_notifications ? "true" : "false";
 
-  std::string body = create_body(default_public_ids, impis);
+  std::string body = rtr_create_body(default_public_ids, impis);
 
   HTTPCode ret_code = _http->send_delete(path, trail, body);
   TRC_DEBUG("HTTP return code from Sprout: %d", ret_code);
   return ret_code;
 }
 
-std::string SproutConnection::create_body(const std::vector<std::string>& default_public_ids,
-                                          const std::vector<std::string>& impis)
+std::string SproutConnection::rtr_create_body(const std::vector<std::string>& default_public_ids,
+                                              const std::vector<std::string>& impis)
 {
   // Utility function to create HTTP body to send to Sprout when the HSS has
   // sent a Registration-Termination request.
@@ -102,8 +102,24 @@ HTTPCode SproutConnection::change_associated_identities(const std::string& defau
 							SAS::TrailId trail)
 {
   std::string path = "/registrations/" + default_id;
-  std::string body = user_data;
+  std::string body = ppr_create_body(user_data);
   HTTPCode ret_code = _http->send_put(path, body, trail);
   TRC_DEBUG("HTTP return code from Sprout: %d", ret_code);
   return ret_code;
+}
+
+std::string SproutConnection::ppr_create_body(const std::string& user_data)
+{
+  // Utility function to create HTTP body to send to Sprout when the HSS has
+  // sent a Push Profile Request.
+  rapidjson::StringBuffer sb;
+  rapidjson::Writer<rapidjson::StringBuffer> writer(sb);
+
+  writer.StartObject();
+  {
+    writer.String(JSON_USER_DATA_XML.c_str());
+    writer.String(user_data.c_str());
+  }
+  writer.EndObject();
+  return sb.GetString();
 }

--- a/src/sproutconnection.cpp
+++ b/src/sproutconnection.cpp
@@ -98,36 +98,12 @@ std::string SproutConnection::create_body(const std::vector<std::string>& defaul
 }
 
 HTTPCode SproutConnection::change_associated_identities(const std::string& default_id,
-							const std::vector<std::string>& impus,
+							const std::string& user_data,
 							SAS::TrailId trail)
 {
   std::string path = "/registrations/" + default_id;
-  std::string body = change_ids_create_body(impus);
-  TRC_DEBUG("JSON Body is %s", body.c_str());
-  HTTPCode ret_code = _http->send_post(path, body, trail);
+  std::string body = user_data;
+  HTTPCode ret_code = _http->send_put(path, body, trail);
   TRC_DEBUG("HTTP return code from Sprout: %d", ret_code);
   return ret_code;
 }
-
-std::string SproutConnection::change_ids_create_body(const std::vector<std::string>& impus)
-{
-  // Utility function to create HTTP body to send to Sprout
-  rapidjson::StringBuffer sb;
-  rapidjson::Writer<rapidjson::StringBuffer> writer(sb);
-
-  writer.StartObject();
-  {
-    writer.String(JSON_ASSOCIATED_IDENTITIES.c_str());
-    writer.StartArray();
-    for (std::vector<std::string>::const_iterator i = impus.begin();
-	 i != impus.end();
-         i++)
-    {
-      writer.String((*i).c_str());
-    }
-    writer.EndArray();
-  }
-  writer.EndObject();
-  return sb.GetString();
-}
-

--- a/src/sproutconnection.cpp
+++ b/src/sproutconnection.cpp
@@ -104,7 +104,6 @@ HTTPCode SproutConnection::change_associated_identities(const std::string& defau
   std::string path = "/registrations/" + default_id;
   std::string body = ppr_create_body(user_data);
   HTTPCode ret_code = _http->send_put(path, body, trail);
-  TRC_DEBUG("HTTP return code from Sprout: %d", ret_code);
   return ret_code;
 }
 
@@ -121,5 +120,6 @@ std::string SproutConnection::ppr_create_body(const std::string& user_data)
     writer.String(user_data.c_str());
   }
   writer.EndObject();
+
   return sb.GetString();
 }

--- a/src/sproutconnection.cpp
+++ b/src/sproutconnection.cpp
@@ -19,6 +19,7 @@
 const std::string SproutConnection::JSON_REGISTRATIONS = "registrations";
 const std::string SproutConnection::JSON_PRIMARY_IMPU = "primary-impu";
 const std::string SproutConnection::JSON_IMPI = "impi";
+const std::string SproutConnection::JSON_ASSOCIATED_IDENTITIES = "associated-identities";
 
 SproutConnection::SproutConnection(HttpConnection* http) : _http(http)
 {
@@ -95,3 +96,38 @@ std::string SproutConnection::create_body(const std::vector<std::string>& defaul
   writer.EndObject();
   return sb.GetString();
 }
+
+HTTPCode SproutConnection::change_associated_identities(const std::string& default_id,
+							const std::vector<std::string>& impus,
+							SAS::TrailId trail)
+{
+  std::string path = "/registrations/" + default_id;
+  std::string body = change_ids_create_body(impus);
+  TRC_DEBUG("JSON Body is %s", body.c_str());
+  HTTPCode ret_code = _http->send_post(path, body, trail);
+  TRC_DEBUG("HTTP return code from Sprout: %d", ret_code);
+  return ret_code;
+}
+
+std::string SproutConnection::change_ids_create_body(const std::vector<std::string>& impus)
+{
+  // Utility function to create HTTP body to send to Sprout
+  rapidjson::StringBuffer sb;
+  rapidjson::Writer<rapidjson::StringBuffer> writer(sb);
+
+  writer.StartObject();
+  {
+    writer.String(JSON_ASSOCIATED_IDENTITIES.c_str());
+    writer.StartArray();
+    for (std::vector<std::string>::const_iterator i = impus.begin();
+	 i != impus.end();
+         i++)
+    {
+      writer.String((*i).c_str());
+    }
+    writer.EndArray();
+  }
+  writer.EndObject();
+  return sb.GetString();
+}
+

--- a/src/ut/handlers_test.cpp
+++ b/src/ut/handlers_test.cpp
@@ -135,7 +135,6 @@ public:
   static const std::string DEREG_BODY_LIST;
   static const std::string DEREG_BODY_LIST2;
   static const std::string DEREG_BODY_LIST3;
-  static const std::string PUSH_PROFILE_BODY;
   static const std::deque<std::string> NO_CFS;
   static const std::deque<std::string> CCFS;
   static const std::deque<std::string> ECFS;
@@ -1580,7 +1579,7 @@ public:
 
   void ppr_sprout_connection(std::string impu, std::string body, HTTPCode http_ret_code)
   {
-    // Expect a post to be sent to Sprout.
+    // Expect a PUT to be sent to Sprout.
     std::string http_path = "/registrations/" + impu;
     EXPECT_CALL(*_mock_http_conn, send_put(http_path, body, _))
       .Times(1)
@@ -1912,7 +1911,6 @@ const std::string HandlersTest::DEREG_BODY_PAIRINGS5 = "{\"registrations\":[{\"p
                                                                        "\"},{\"primary-impu\":\"" + IMPU3 + "\",\"impi\":\"" + IMPI +
                                                                        "\"},{\"primary-impu\":\"" + IMPU3 + "\",\"impi\":\"" + ASSOCIATED_IDENTITY1 +
                                                                        "\"},{\"primary-impu\":\"" + IMPU3 + "\",\"impi\":\"" + ASSOCIATED_IDENTITY2 + "\"}]}";
-const std::string HandlersTest::PUSH_PROFILE_BODY = "{\"associated-identities\":[\"" + IMPU + "\",\"" + IMPU4 + "\"]}";
 const std::string HandlersTest::SCHEME_DIGEST = "SIP Digest";
 const std::string HandlersTest::SCHEME_AKA = "Digest-AKAv1-MD5";
 const std::string HandlersTest::SCHEME_AKAV2 = "Digest-AKAv2-SHA-256";

--- a/src/ut/handlers_test.cpp
+++ b/src/ut/handlers_test.cpp
@@ -1577,10 +1577,12 @@ public:
     EXPECT_DO_ASYNC(*_cache, *mock_op);
   }
 
-  void ppr_sprout_connection(std::string impu, std::string body, HTTPCode http_ret_code)
+  void ppr_sprout_connection(std::string impu, std::string user_data, HTTPCode http_ret_code)
   {
     // Expect a PUT to be sent to Sprout.
     std::string http_path = "/registrations/" + impu;
+    std::string body =_sprout_conn->ppr_create_body(user_data);
+
     EXPECT_CALL(*_mock_http_conn, send_put(http_path, body, _))
       .Times(1)
       .WillOnce(Return(http_ret_code));

--- a/src/ut/handlers_test.cpp
+++ b/src/ut/handlers_test.cpp
@@ -1470,17 +1470,17 @@ public:
 
   // PPR function templates
   void ppr_setup(PushProfileTask** ptask,
-		 PushProfileTask::Config** pcfg,
+                 PushProfileTask::Config** pcfg,
                  std::string impi,
                  std::string ims_subscription,
                  ChargingAddresses charging_addresses)
   {
     Cx::PushProfileRequest ppr(_cx_dict,
                                 _mock_stack,
-		                impi,
+                                impi,
                                 ims_subscription,
-              			charging_addresses,
-                   		AUTH_SESSION_STATE);
+                                charging_addresses,
+                                AUTH_SESSION_STATE);
 
     // The free_on_delete flag controls whether we want to free the underlying
     // fd_msg structure when we delete this PPR. We don't, since this will be
@@ -1520,8 +1520,8 @@ public:
   }
 
   void ppr_get_reg_data(MockCache::MockGetRegData* mock_op,
-			std::string ims_subscription,
-			RegistrationState reg_state,
+                        std::string ims_subscription,
+                        RegistrationState reg_state,
                         ChargingAddresses charging_addresses,
                         std::vector<std::string> impis)
   {
@@ -1538,11 +1538,11 @@ public:
   }
 
   void ppr_put_reg_data(std::vector<std::string> impus,
-			std::string default_impu,
+                        std::string default_impu,
                         MockCache::MockPutRegData* mock_op,
-			std::string ims_subscription,
-		        ChargingAddresses charging_addresses,
-			RegistrationState reg_state = RegistrationState::UNCHANGED)
+                        std::string ims_subscription,
+                        ChargingAddresses charging_addresses,
+                        RegistrationState reg_state = RegistrationState::UNCHANGED)
   {
     // Put reg data against list of impus in reg set impus, with default
     // identity default_impu. Put ims_subscription, charging_addresses and
@@ -4742,44 +4742,6 @@ TEST_F(HandlersTest, PushProfileChangeIDsServerError)
   ppr_send_ppa(DIAMETER_UNABLE_TO_COMPLY);
   ppr_tear_down(pcfg);
 }
-
-TEST_F(HandlersTest, PushProfileUnexpectedReturnCode)
-{
-  PushProfileTask* task = NULL;
-  PushProfileTask::Config* pcfg = NULL;
-  ppr_setup(&task, &pcfg, IMPI, IMPU_IMS_SUBSCRIPTION, FULL_CHARGING_ADDRESSES);
-
-  MockCache::MockGetAssociatedPrimaryPublicIDs mock_op;
-  ppr_expect_get_default_ids(&mock_op, IMPI);
-
-  task->run();
-
-  CassandraStore::Transaction* t = mock_op.get_trx();
-  ASSERT_FALSE(t == NULL);
-  ppr_get_default_ids(&mock_op, IMPU_IN_VECTOR);
-  ppr_sprout_connection(IMPU, IMPU_IMS_SUBSCRIPTION, 300);
-
-  MockCache::MockGetRegData mock_op2;
-  ppr_expect_get_reg_data(&mock_op2, IMPU);
-
-  t->on_success(&mock_op);
-  t = mock_op2.get_trx();
-  ASSERT_FALSE(t == NULL);
-
-  ppr_get_reg_data(&mock_op2,
-                   IMPU_IMS_SUBSCRIPTION2,
-                   RegistrationState::REGISTERED,
-                   FULL_CHARGING_ADDRESSES,
-                   IMPI_IN_VECTOR);
-
-  ppr_expect_ppa();
-
-  t->on_success(&mock_op2);
-
-  ppr_send_ppa(DIAMETER_UNABLE_TO_COMPLY);
-  ppr_tear_down(pcfg);
-}
-
 
 // This PPR has a charging address but no IMS Sub. There is one IRS.
 // The update is successful.

--- a/src/ut/mockhttpconnection.hpp
+++ b/src/ut/mockhttpconnection.hpp
@@ -24,6 +24,7 @@ public:
   virtual ~MockHttpConnection() {};
 
   MOCK_METHOD3(send_delete, long(const std::string& path, SAS::TrailId trail, const std::string& body));
+  MOCK_METHOD3(send_post, long(const std::string& path, const std::string& body, SAS::TrailId trail));
 };
 
 #endif

--- a/src/ut/mockhttpconnection.hpp
+++ b/src/ut/mockhttpconnection.hpp
@@ -25,6 +25,8 @@ public:
 
   MOCK_METHOD3(send_delete, long(const std::string& path, SAS::TrailId trail, const std::string& body));
   MOCK_METHOD3(send_post, long(const std::string& path, const std::string& body, SAS::TrailId trail));
+  MOCK_METHOD3(send_put, long(const std::string& path, const std::string& body, SAS::TrailId trail));
+
 };
 
 #endif

--- a/src/ut/mockhttpconnection.hpp
+++ b/src/ut/mockhttpconnection.hpp
@@ -24,7 +24,6 @@ public:
   virtual ~MockHttpConnection() {};
 
   MOCK_METHOD3(send_delete, long(const std::string& path, SAS::TrailId trail, const std::string& body));
-  MOCK_METHOD3(send_post, long(const std::string& path, const std::string& body, SAS::TrailId trail));
   MOCK_METHOD3(send_put, long(const std::string& path, const std::string& body, SAS::TrailId trail));
 
 };


### PR DESCRIPTION
Upon receiving a PPR with a user-data element, Homestead will inform Sprout, via a HTTP PUT. It will send the XML, for Sprout to decode in order such that it can send any NOTIFYs about changed associated URIs.

If it receives a successful return code from sprout it will continue to update its store. 
If it receives a failure, it will send a failed PPA.  

This is unit tested and make full_test passes. 
This is live tested in the mainline case. 