### PR TITLE
[No Reviewer] parse-ip-target moved to Utils

### DIFF
--- a/src/ut/cache_test.cpp
+++ b/src/ut/cache_test.cpp
@@ -131,7 +131,7 @@ public:
   AddrInfo create_target(std::string address)
   {
     AddrInfo ai;
-    BaseResolver::parse_ip_target(address, ai.address);
+    Utils::parse_ip_target(address, ai.address);
     ai.port = 1;
     ai.transport = IPPROTO_TCP;
     return ai;


### PR DESCRIPTION
Follow on from Metaswitch/cpp-common#676