### PR TITLE
[Reviewer: Richard] Improve cache latency

### DIFF
--- a/include/base_hss_cache.h
+++ b/include/base_hss_cache.h
@@ -31,12 +31,13 @@ public:
   // Deletes several registration sets
   // Used for an RTR when we have several registration sets to delete
   virtual Store::Status delete_implicit_registration_sets(const std::vector<ImplicitRegistrationSet*>& irss,
+                                                          progress_callback progress_cb,
                                                           SAS::TrailId trail);
 
 protected:
   virtual Store::Status get_implicit_registration_sets_for_impi(const std::string& impi,
-                                                                                                                              SAS::TrailId trail,
-                                                                                                                              std::vector<ImplicitRegistrationSet*>& result);
+                                                                SAS::TrailId trail,
+                                                                std::vector<ImplicitRegistrationSet*>& result);
 
   virtual Store::Status get_impus_for_impi(const std::string& impi,
                                            SAS::TrailId trail,

--- a/include/base_hss_cache.h
+++ b/include/base_hss_cache.h
@@ -28,12 +28,6 @@ public:
                                                                  SAS::TrailId trail,
                                                                  std::vector<ImplicitRegistrationSet*>& result);
 
-  // Deletes several registration sets
-  // Used for an RTR when we have several registration sets to delete
-  virtual Store::Status delete_implicit_registration_sets(const std::vector<ImplicitRegistrationSet*>& irss,
-                                                          progress_callback progress_cb,
-                                                          SAS::TrailId trail);
-
 protected:
   virtual Store::Status get_implicit_registration_sets_for_impi(const std::string& impi,
                                                                 SAS::TrailId trail,

--- a/include/diameter_handlers.h
+++ b/include/diameter_handlers.h
@@ -72,6 +72,7 @@ private:
 
   void get_registration_sets_success(std::vector<ImplicitRegistrationSet*> reg_sets);
   void get_registration_sets_failure(Store::Status rc);
+  void delete_reg_sets_progress();
   void delete_reg_sets_success();
   void delete_reg_sets_failure(Store::Status rc);
 
@@ -137,6 +138,7 @@ private:
   void on_get_ims_sub_success(ImsSubscription* ims_sub);
   void on_get_ims_sub_failure(Store::Status rc);
 
+  void on_save_ims_sub_progress();
   void on_save_ims_sub_success();
   void on_save_ims_sub_failure(Store::Status rc);
 

--- a/include/hss_cache.h
+++ b/include/hss_cache.h
@@ -18,6 +18,7 @@
 #include "ims_subscription.h"
 #include "implicit_reg_set.h"
 
+// The purpose of the progress_callback is explained in hss_cache_processor.h
 typedef std::function<void()> progress_callback;
 
 class HssCache

--- a/include/hss_cache.h
+++ b/include/hss_cache.h
@@ -12,10 +12,13 @@
 #define HSS_CACHE_H_
 
 #include "store.h"
+#include <functional>
 #include <vector>
 #include <string>
 #include "ims_subscription.h"
 #include "implicit_reg_set.h"
+
+typedef std::function<void()> progress_callback;
 
 class HssCache
 {
@@ -51,15 +54,18 @@ public:
   // Save the IRS in the cache
   // Must include updating the impi mapping table if impis have been added
   virtual Store::Status put_implicit_registration_set(ImplicitRegistrationSet* irs,
+                                                      progress_callback progress_cb,
                                                       SAS::TrailId trail) = 0;
 
   // Used for de-registration
   virtual Store::Status delete_implicit_registration_set(ImplicitRegistrationSet* irs,
+                                                         progress_callback progress_cb,
                                                          SAS::TrailId trail) = 0;
 
   // Deletes several registration sets
   // Used for an RTR when we have several registration sets to delete
   virtual Store::Status delete_implicit_registration_sets(const std::vector<ImplicitRegistrationSet*>& irss,
+                                                          progress_callback progress_cb,
                                                           SAS::TrailId trail) = 0;
 
   // Gets the whole IMS subscription for this impi
@@ -71,6 +77,7 @@ public:
 
   // This is used to save the state that we changed in the PPR
   virtual Store::Status put_ims_subscription(ImsSubscription* subscription,
+                                             progress_callback progress_cb,
                                              SAS::TrailId trail) = 0;
 };
 

--- a/include/hss_cache_processor.h
+++ b/include/hss_cache_processor.h
@@ -20,7 +20,6 @@ typedef std::function<void(Store::Status)> failure_callback;
 typedef std::function<void(ImplicitRegistrationSet*)> irs_success_callback;
 typedef std::function<void(std::vector<ImplicitRegistrationSet*>)> irs_vector_success_callback;
 typedef std::function<void()> void_success_cb;
-typedef std::function<void()> progress_callback;
 typedef std::function<void(ImsSubscription*)> ims_sub_success_cb;
 
 class HssCacheProcessor

--- a/include/http_handlers.h
+++ b/include/http_handlers.h
@@ -230,8 +230,10 @@ public:
   void process_received_reg_data();
   void send_server_assignment_request(Cx::ServerAssignmentType type);
   void on_sar_response(const HssConnection::ServerAssignmentAnswer& saa);
+  void on_put_reg_data_progress();
   void on_put_reg_data_success();
   void on_put_reg_data_failure(Store::Status rc);
+  void on_del_impu_progress();
   void on_del_impu_success();
   void on_del_impu_benign(bool not_found);
   void on_del_impu_failure(Store::Status rc);

--- a/include/memcached_cache.h
+++ b/include/memcached_cache.h
@@ -324,6 +324,11 @@ public:
                                                          progress_callback progress_cb,
                                                          SAS::TrailId trail) override;
 
+  // Used for RTRs
+  virtual Store::Status delete_implicit_registration_sets(const std::vector<ImplicitRegistrationSet*>& irss,
+                                                          progress_callback progress_cb,
+                                                          SAS::TrailId trail) override;
+
   // Gets the whole IMS subscription for this impi
   // This is used when we get a PPR, and we have to update charging functions
   // as we'll need to updated every IRS that we've stored
@@ -354,22 +359,24 @@ private:
 
   // Per Store IRS methods
 
-  typedef Store::Status (MemcachedCache::*irs_store_action)(MemcachedImplicitRegistrationSet*,
-                                                            SAS::TrailId,
-                                                            ImpuStore*);
+  typedef std::function<Store::Status(ImpuStore*)> store_action;
 
-  Store::Status perform(irs_store_action action,
-                        MemcachedImplicitRegistrationSet*,
-                        progress_callback progress_cb,
-                        SAS::TrailId trail);
+  // Performs the action on each store, calling the progress_cb once the action
+  // has been performed on the local store
+  Store::Status perform(store_action action,
+                        progress_callback progress_cb);
 
-  Store::Status put_implicit_registration_set(MemcachedImplicitRegistrationSet* irs,
-                                              SAS::TrailId trail,
-                                              ImpuStore* store);
+  Store::Status put_irs_action(MemcachedImplicitRegistrationSet* irs,
+                               SAS::TrailId trail,
+                               ImpuStore* store);
 
-  Store::Status delete_implicit_registration_set(MemcachedImplicitRegistrationSet* irs,
-                                                 SAS::TrailId trail,
-                                                 ImpuStore* store);
+  Store::Status delete_irs_action(MemcachedImplicitRegistrationSet* irs,
+                                  SAS::TrailId trail,
+                                  ImpuStore* store);
+
+  Store::Status delete_irss_action(const std::vector<ImplicitRegistrationSet*>& irss,
+                                   SAS::TrailId trail,
+                                   ImpuStore* store);
 
   // IRS IMPU handling methods
 

--- a/include/memcached_cache.h
+++ b/include/memcached_cache.h
@@ -311,27 +311,30 @@ public:
   // Get the IRS for a given IMPU
   virtual Store::Status get_implicit_registration_set_for_impu(const std::string& impu,
                                                                SAS::TrailId trail,
-                                                               ImplicitRegistrationSet*& result);
+                                                               ImplicitRegistrationSet*& result) override;
 
   // Save the IRS in the cache
   // Must include updating the impi mapping table if impis have been added
   virtual Store::Status put_implicit_registration_set(ImplicitRegistrationSet* irs,
-                                                      SAS::TrailId trail);
+                                                      progress_callback progress_cb,
+                                                      SAS::TrailId trail) override;
 
   // Used for de-registration
   virtual Store::Status delete_implicit_registration_set(ImplicitRegistrationSet* irs,
-                                                         SAS::TrailId trail);
+                                                         progress_callback progress_cb,
+                                                         SAS::TrailId trail) override;
 
   // Gets the whole IMS subscription for this impi
   // This is used when we get a PPR, and we have to update charging functions
   // as we'll need to updated every IRS that we've stored
   virtual Store::Status get_ims_subscription(const std::string& impi,
                                              SAS::TrailId trail,
-                                             ImsSubscription*& result);
+                                             ImsSubscription*& result) override;
 
   // This is used to save the state that we changed in the PPR
   virtual Store::Status put_ims_subscription(ImsSubscription* subscription,
-                                             SAS::TrailId trail);
+                                             progress_callback progress_cb,
+                                             SAS::TrailId trail) override;
 
 protected:
   // Base HSS Cache methods
@@ -357,6 +360,7 @@ private:
 
   Store::Status perform(irs_store_action action,
                         MemcachedImplicitRegistrationSet*,
+                        progress_callback progress_cb,
                         SAS::TrailId trail);
 
   Store::Status put_implicit_registration_set(MemcachedImplicitRegistrationSet* irs,

--- a/include/memcached_cache.h
+++ b/include/memcached_cache.h
@@ -378,6 +378,10 @@ private:
                                    SAS::TrailId trail,
                                    ImpuStore* store);
 
+  Store::Status put_ims_sub_action(ImsSubscription* subscription,
+                                   SAS::TrailId trail,
+                                   ImpuStore* store);
+
   // IRS IMPU handling methods
 
   Store::Status create_irs_impu(MemcachedImplicitRegistrationSet* irs,

--- a/src/base_hss_cache.cpp
+++ b/src/base_hss_cache.cpp
@@ -108,24 +108,3 @@ Store::Status BaseHssCache::get_implicit_registration_sets_for_impis(const std::
 
   return status;
 }
-
-Store::Status BaseHssCache::delete_implicit_registration_sets(const std::vector<ImplicitRegistrationSet*>& irss,
-                                                              progress_callback progress_cb,
-                                                              SAS::TrailId trail)
-{
-  Store::Status status = Store::Status::OK;
-
-  for (ImplicitRegistrationSet* irs : irss)
-  {
-    Store::Status inner_status = delete_implicit_registration_set(irs, progress_cb, trail);
-
-    if (inner_status != Store::Status::OK &&
-        inner_status != Store::Status::NOT_FOUND)
-    {
-      status = inner_status;
-      break;
-    }
-  }
-
-  return status;
-}

--- a/src/base_hss_cache.cpp
+++ b/src/base_hss_cache.cpp
@@ -69,8 +69,8 @@ Store::Status BaseHssCache::get_implicit_registration_sets_for_impus(const std::
 }
 
 Store::Status BaseHssCache::get_implicit_registration_sets_for_impis(const std::vector<std::string>& impis,
-                                                                 SAS::TrailId trail,
-                                                                 std::vector<ImplicitRegistrationSet*>& result)
+                                                                     SAS::TrailId trail,
+                                                                     std::vector<ImplicitRegistrationSet*>& result)
 {
   Store::Status status = Store::Status::OK;
 
@@ -110,13 +110,14 @@ Store::Status BaseHssCache::get_implicit_registration_sets_for_impis(const std::
 }
 
 Store::Status BaseHssCache::delete_implicit_registration_sets(const std::vector<ImplicitRegistrationSet*>& irss,
-                                                          SAS::TrailId trail)
+                                                              progress_callback progress_cb,
+                                                              SAS::TrailId trail)
 {
   Store::Status status = Store::Status::OK;
 
   for (ImplicitRegistrationSet* irs : irss)
   {
-    Store::Status inner_status = delete_implicit_registration_set(irs, trail);
+    Store::Status inner_status = delete_implicit_registration_set(irs, progress_cb, trail);
 
     if (inner_status != Store::Status::OK &&
         inner_status != Store::Status::NOT_FOUND)

--- a/src/hss_cache_processor.cpp
+++ b/src/hss_cache_processor.cpp
@@ -142,6 +142,7 @@ void HssCacheProcessor::get_implicit_registration_sets_for_impus(irs_vector_succ
 }
 
 void HssCacheProcessor::put_implicit_registration_set(void_success_cb success_cb,
+                                                      progress_callback progress_cb,
                                                       failure_callback failure_cb,
                                                       ImplicitRegistrationSet* irs,
                                                       SAS::TrailId trail)
@@ -166,6 +167,7 @@ void HssCacheProcessor::put_implicit_registration_set(void_success_cb success_cb
 }
 
 void HssCacheProcessor::delete_implicit_registration_set(void_success_cb success_cb,
+                                                         progress_callback progress_cb,
                                                          failure_callback failure_cb,
                                                          ImplicitRegistrationSet* irs,
                                                          SAS::TrailId trail)
@@ -190,6 +192,7 @@ void HssCacheProcessor::delete_implicit_registration_set(void_success_cb success
 }
 
 void HssCacheProcessor::delete_implicit_registration_sets(void_success_cb success_cb,
+                                                          progress_callback progress_cb,
                                                           failure_callback failure_cb,
                                                           std::vector<ImplicitRegistrationSet*> irss,
                                                           SAS::TrailId trail)
@@ -239,6 +242,7 @@ void HssCacheProcessor::get_ims_subscription(ims_sub_success_cb success_cb,
 }
 
 void HssCacheProcessor::put_ims_subscription(void_success_cb success_cb,
+                                             progress_callback progress_cb,
                                              failure_callback failure_cb,
                                              ImsSubscription* subscription,
                                              SAS::TrailId trail)

--- a/src/hss_cache_processor.cpp
+++ b/src/hss_cache_processor.cpp
@@ -149,8 +149,8 @@ void HssCacheProcessor::put_implicit_registration_set(void_success_cb success_cb
 {
   // Create a work item that can run on the thread pool, capturing required
   // variables to complete the work
-  std::function<void()> work = [this, irs, trail, success_cb, failure_cb]()->void {
-    Store::Status rc = _cache->put_implicit_registration_set(irs, trail);
+  std::function<void()> work = [this, irs, trail, success_cb, progress_cb, failure_cb]()->void {
+    Store::Status rc = _cache->put_implicit_registration_set(irs, progress_cb, trail);
 
     if (rc == Store::Status::OK)
     {
@@ -174,8 +174,8 @@ void HssCacheProcessor::delete_implicit_registration_set(void_success_cb success
 {
   // Create a work item that can run on the thread pool, capturing required
   // variables to complete the work
-  std::function<void()> work = [this, irs, trail, success_cb, failure_cb]()->void {
-    Store::Status rc = _cache->delete_implicit_registration_set(irs, trail);
+  std::function<void()> work = [this, irs, trail, success_cb, progress_cb, failure_cb]()->void {
+    Store::Status rc = _cache->delete_implicit_registration_set(irs, progress_cb, trail);
 
     if (rc == Store::Status::OK)
     {
@@ -199,8 +199,8 @@ void HssCacheProcessor::delete_implicit_registration_sets(void_success_cb succes
 {
   // Create a work item that can run on the thread pool, capturing required
   // variables to complete the work
-  std::function<void()> work = [this, irss, trail, success_cb, failure_cb]()->void {
-    Store::Status rc = _cache->delete_implicit_registration_sets(irss, trail);
+  std::function<void()> work = [this, irss, trail, success_cb, progress_cb, failure_cb]()->void {
+    Store::Status rc = _cache->delete_implicit_registration_sets(irss, progress_cb, trail);
 
     if (rc == Store::Status::OK)
     {
@@ -249,8 +249,8 @@ void HssCacheProcessor::put_ims_subscription(void_success_cb success_cb,
 {
   // Create a work item that can run on the thread pool, capturing required
   // variables to complete the work
-  std::function<void()> work = [this, subscription, trail, success_cb, failure_cb]()->void {
-    Store::Status rc = _cache->put_ims_subscription(subscription, trail);
+  std::function<void()> work = [this, subscription, trail, success_cb, progress_cb, failure_cb]()->void {
+    Store::Status rc = _cache->put_ims_subscription(subscription, progress_cb, trail);
 
     if (rc == Store::Status::OK)
     {

--- a/src/hss_cache_processor.cpp
+++ b/src/hss_cache_processor.cpp
@@ -67,7 +67,8 @@ void HssCacheProcessor::get_implicit_registration_set_for_impu(irs_success_callb
 {
   // Create a work item that can run on the thread pool, capturing required
   // variables to complete the work
-  std::function<void()> work = [this, impu, trail, success_cb, failure_cb]()->void {
+  std::function<void()> work = [this, impu, trail, success_cb, failure_cb]()->void
+  {
     ImplicitRegistrationSet* result = NULL;
     Store::Status rc = _cache->get_implicit_registration_set_for_impu(impu,
                                                                       trail,
@@ -94,7 +95,8 @@ void HssCacheProcessor::get_implicit_registration_sets_for_impis(irs_vector_succ
 {
   // Create a work item that can run on the thread pool, capturing required
   // variables to complete the work
-  std::function<void()> work = [this, impis, trail, success_cb, failure_cb]()->void {
+  std::function<void()> work = [this, impis, trail, success_cb, failure_cb]()->void
+  {
     std::vector<ImplicitRegistrationSet*> result;
     Store::Status rc = _cache->get_implicit_registration_sets_for_impis(impis,
                                                                         trail,
@@ -121,7 +123,8 @@ void HssCacheProcessor::get_implicit_registration_sets_for_impus(irs_vector_succ
 {
   // Create a work item that can run on the thread pool, capturing required
   // variables to complete the work
-  std::function<void()> work = [this, impus, trail, success_cb, failure_cb]()->void {
+  std::function<void()> work = [this, impus, trail, success_cb, failure_cb]()->void
+  {
     std::vector<ImplicitRegistrationSet*> result;
     Store::Status rc = _cache->get_implicit_registration_sets_for_impus(impus,
                                                                         trail,
@@ -149,7 +152,8 @@ void HssCacheProcessor::put_implicit_registration_set(void_success_cb success_cb
 {
   // Create a work item that can run on the thread pool, capturing required
   // variables to complete the work
-  std::function<void()> work = [this, irs, trail, success_cb, progress_cb, failure_cb]()->void {
+  std::function<void()> work = [this, irs, trail, success_cb, progress_cb, failure_cb]()->void
+  {
     Store::Status rc = _cache->put_implicit_registration_set(irs, progress_cb, trail);
 
     if (rc == Store::Status::OK)
@@ -174,7 +178,8 @@ void HssCacheProcessor::delete_implicit_registration_set(void_success_cb success
 {
   // Create a work item that can run on the thread pool, capturing required
   // variables to complete the work
-  std::function<void()> work = [this, irs, trail, success_cb, progress_cb, failure_cb]()->void {
+  std::function<void()> work = [this, irs, trail, success_cb, progress_cb, failure_cb]()->void
+  {
     Store::Status rc = _cache->delete_implicit_registration_set(irs, progress_cb, trail);
 
     if (rc == Store::Status::OK)
@@ -199,7 +204,8 @@ void HssCacheProcessor::delete_implicit_registration_sets(void_success_cb succes
 {
   // Create a work item that can run on the thread pool, capturing required
   // variables to complete the work
-  std::function<void()> work = [this, irss, trail, success_cb, progress_cb, failure_cb]()->void {
+  std::function<void()> work = [this, irss, trail, success_cb, progress_cb, failure_cb]()->void
+  {
     Store::Status rc = _cache->delete_implicit_registration_sets(irss, progress_cb, trail);
 
     if (rc == Store::Status::OK)
@@ -223,7 +229,8 @@ void HssCacheProcessor::get_ims_subscription(ims_sub_success_cb success_cb,
 {
   // Create a work item that can run on the thread pool, capturing required
   // variables to complete the work
-  std::function<void()> work = [this, impi, trail, success_cb, failure_cb]()->void {
+  std::function<void()> work = [this, impi, trail, success_cb, failure_cb]()->void
+  {
     ImsSubscription* result = NULL;
     Store::Status rc = _cache->get_ims_subscription(impi, trail, result);
 
@@ -249,7 +256,8 @@ void HssCacheProcessor::put_ims_subscription(void_success_cb success_cb,
 {
   // Create a work item that can run on the thread pool, capturing required
   // variables to complete the work
-  std::function<void()> work = [this, subscription, trail, success_cb, progress_cb, failure_cb]()->void {
+  std::function<void()> work = [this, subscription, trail, success_cb, progress_cb, failure_cb]()->void
+  {
     Store::Status rc = _cache->put_ims_subscription(subscription, progress_cb, trail);
 
     if (rc == Store::Status::OK)

--- a/src/memcached_cache.cpp
+++ b/src/memcached_cache.cpp
@@ -400,6 +400,12 @@ Store::Status MemcachedCache::put_implicit_registration_set(ImplicitRegistration
   {
     status = perform(&MemcachedCache::put_implicit_registration_set, mirs, progress_cb, trail);
   }
+  else
+  {
+    // This is treated as success, so call the progress callback as if we'd
+    // successfully deleted it
+    progress_cb();
+  }
 
   return status;
 }
@@ -768,7 +774,12 @@ Store::Status MemcachedCache::delete_implicit_registration_set(ImplicitRegistrat
   }
   else
   {
-    TRC_WARNING("Attempted to delete IRS which hadn't been created: %s", irs->get_default_impu().c_str());
+    TRC_WARNING("Attempted to delete IRS which hadn't been created: %s",
+                irs->get_default_impu().c_str());
+
+    // This is treated as success, so call the progress callback as if we'd
+    // successfully deleted it
+    progress_cb();
   }
 
   return status;

--- a/src/memcached_cache.cpp
+++ b/src/memcached_cache.cpp
@@ -859,13 +859,13 @@ Store::Status MemcachedCache::put_ims_sub_action(ImsSubscription* subscription,
 {
   Store::Status status = Store::Status::OK;
 
-    BaseImsSubscription* mis = (BaseImsSubscription*)subscription;
+  BaseImsSubscription* mis = (BaseImsSubscription*)subscription;
 
-    for (BaseImsSubscription::Irs::value_type& irs : mis->get_irs())
-    {
-      MemcachedImplicitRegistrationSet* mirs = (MemcachedImplicitRegistrationSet*)irs.second;
-      put_irs_action(mirs, trail, store);
-    }
+  for (BaseImsSubscription::Irs::value_type& irs : mis->get_irs())
+  {
+    MemcachedImplicitRegistrationSet* mirs = (MemcachedImplicitRegistrationSet*)irs.second;
+    put_irs_action(mirs, trail, store);
+  }
 
-    return status;
+  return status;
 }

--- a/src/memcached_cache.cpp
+++ b/src/memcached_cache.cpp
@@ -847,14 +847,25 @@ Store::Status MemcachedCache::put_ims_subscription(ImsSubscription* subscription
                                                    progress_callback progress_cb,
                                                    SAS::TrailId trail)
 {
+  store_action action =
+    std::bind(&MemcachedCache::put_ims_sub_action, this, subscription, trail, _1);
+  Store::Status status = perform(action, progress_cb);
+  return status;
+}
+
+Store::Status MemcachedCache::put_ims_sub_action(ImsSubscription* subscription,
+                                                 SAS::TrailId trail,
+                                                 ImpuStore* store)
+{
   Store::Status status = Store::Status::OK;
 
-  BaseImsSubscription* mis = (BaseImsSubscription*)subscription;
+    BaseImsSubscription* mis = (BaseImsSubscription*)subscription;
 
-  for (BaseImsSubscription::Irs::value_type& irs : mis->get_irs())
-  {
-    put_implicit_registration_set(irs.second, progress_cb, trail);
-  }
+    for (BaseImsSubscription::Irs::value_type& irs : mis->get_irs())
+    {
+      MemcachedImplicitRegistrationSet* mirs = (MemcachedImplicitRegistrationSet*)irs.second;
+      put_irs_action(mirs, trail, store);
+    }
 
-  return status;
+    return status;
 }

--- a/src/ut/diameter_handlers_test.cpp
+++ b/src/ut/diameter_handlers_test.cpp
@@ -259,8 +259,8 @@ public:
         .WillOnce(Return(http_ret_code)).RetiresOnSaturation();
 
       // Expect deletions for each IRS
-      EXPECT_CALL(*_cache, delete_implicit_registration_sets(_, _, irss, FAKE_TRAIL_ID))
-        .WillOnce(InvokeArgument<0>());
+      EXPECT_CALL(*_cache, delete_implicit_registration_sets(_, _, _, irss, FAKE_TRAIL_ID))
+        .WillOnce(DoAll(InvokeArgument<1>(), InvokeArgument<0>()));
     }
     else
     {
@@ -529,8 +529,8 @@ TEST_F(DiameterHandlersTest, RTRIncludesBarredImpus)
     .WillOnce(Return(200)).RetiresOnSaturation();
 
   // Expect deletions for each IRS
-  EXPECT_CALL(*_cache, delete_implicit_registration_sets(_, _, irss, FAKE_TRAIL_ID))
-    .WillOnce(InvokeArgument<0>());
+  EXPECT_CALL(*_cache, delete_implicit_registration_sets(_, _, _, irss, FAKE_TRAIL_ID))
+    .WillOnce(DoAll(InvokeArgument<1>(), InvokeArgument<0>()));
 
   task->run();
 
@@ -594,8 +594,8 @@ TEST_F(DiameterHandlersTest, RTRIncludesBarringIndication)
     .WillOnce(Return(200)).RetiresOnSaturation();
 
   // Expect deletions for each IRS
-  EXPECT_CALL(*_cache, delete_implicit_registration_sets(_, _, irss, FAKE_TRAIL_ID))
-    .WillOnce(InvokeArgument<0>());
+  EXPECT_CALL(*_cache, delete_implicit_registration_sets(_, _, _, irss, FAKE_TRAIL_ID))
+    .WillOnce(DoAll(InvokeArgument<1>(), InvokeArgument<0>()));
 
   task->run();
 
@@ -732,8 +732,8 @@ TEST_F(DiameterHandlersTest, PPRMainline)
     .Times(1);
 
   // We'll then save the ImsSubscription in the cache
-  EXPECT_CALL(*_cache, put_ims_subscription(_, _, sub, FAKE_TRAIL_ID))
-    .WillOnce(InvokeArgument<0>());
+  EXPECT_CALL(*_cache, put_ims_subscription(_, _, _, sub, FAKE_TRAIL_ID))
+    .WillOnce(DoAll(InvokeArgument<1>(), InvokeArgument<0>()));
 
   // And notify Sprout
   ppr_sprout_connection(IMPU, IMS_SUBSCRIPTION, HTTP_OK);
@@ -784,8 +784,8 @@ TEST_F(DiameterHandlersTest, PPRChangeIDs)
   ppr_sprout_connection(IMPU, IMPU_IMS_SUBSCRIPTION, HTTP_OK);
 
   // We'll then save the ImsSubscription in the cache
-  EXPECT_CALL(*_cache, put_ims_subscription(_, _, sub, FAKE_TRAIL_ID))
-    .WillOnce(InvokeArgument<0>());
+  EXPECT_CALL(*_cache, put_ims_subscription(_, _, _, sub, FAKE_TRAIL_ID))
+    .WillOnce(DoAll(InvokeArgument<1>(), InvokeArgument<0>()));
 
   ppr_expect_ppa();
 
@@ -868,8 +868,8 @@ TEST_F(DiameterHandlersTest, PPRChargingAddrs)
     .Times(1);
 
   // We'll then save the ImsSubscription in the cache
-  EXPECT_CALL(*_cache, put_ims_subscription(_, _, sub, FAKE_TRAIL_ID))
-    .WillOnce(InvokeArgument<0>());
+  EXPECT_CALL(*_cache, put_ims_subscription(_, _, _, sub, FAKE_TRAIL_ID))
+    .WillOnce(DoAll(InvokeArgument<1>(), InvokeArgument<0>()));
 
   ppr_expect_ppa();
 
@@ -906,8 +906,8 @@ TEST_F(DiameterHandlersTest, PPRImsSub)
   ppr_sprout_connection(IMPU, IMS_SUBSCRIPTION, HTTP_OK);
 
   // We'll then save the ImsSubscription in the cache
-  EXPECT_CALL(*_cache, put_ims_subscription(_, _, sub, FAKE_TRAIL_ID))
-    .WillOnce(InvokeArgument<0>());
+  EXPECT_CALL(*_cache, put_ims_subscription(_, _, _, sub, FAKE_TRAIL_ID))
+    .WillOnce(DoAll(InvokeArgument<1>(), InvokeArgument<0>()));
 
   ppr_expect_ppa();
 
@@ -952,8 +952,8 @@ TEST_F(DiameterHandlersTest, PPRIMSSubNoSIPURI)
   ppr_sprout_connection(TEL_URI, TEL_URIS_IMS_SUBSCRIPTION, HTTP_OK);
 
   // We'll then save the ImsSubscription in the cache
-  EXPECT_CALL(*_cache, put_ims_subscription(_, _, sub, FAKE_TRAIL_ID))
-    .WillOnce(InvokeArgument<0>());
+  EXPECT_CALL(*_cache, put_ims_subscription(_, _, _, sub, FAKE_TRAIL_ID))
+    .WillOnce(DoAll(InvokeArgument<1>(), InvokeArgument<0>()));
 
   ppr_expect_ppa();
 
@@ -998,8 +998,8 @@ TEST_F(DiameterHandlersTest, PPRCacheFailure)
   ppr_sprout_connection(IMPU, IMS_SUBSCRIPTION, HTTP_OK);
 
   // We'll then save the ImsSubscription in the cache, which will give an error
-  EXPECT_CALL(*_cache, put_ims_subscription(_, _, sub, FAKE_TRAIL_ID))
-    .WillOnce(InvokeArgument<1>(Store::Status::ERROR));
+  EXPECT_CALL(*_cache, put_ims_subscription(_, _, _, sub, FAKE_TRAIL_ID))
+    .WillOnce(InvokeArgument<2>(Store::Status::ERROR));
 
   ppr_expect_ppa();
 

--- a/src/ut/http_handlers_test.cpp
+++ b/src/ut/http_handlers_test.cpp
@@ -1493,12 +1493,12 @@ TEST_F(HTTPHandlersTest, ImpuRegDataInitialReg)
     .WillOnce(InvokeArgument<0>(ByRef(answer)));
 
   // We now expect it to be put in the cache with an updated TTL and state REGISTERED
-  EXPECT_CALL(*_cache, put_implicit_registration_set(_, _,
+  EXPECT_CALL(*_cache, put_implicit_registration_set(_, _, _,
     AllOf(Property(&ImplicitRegistrationSet::get_reg_state, RegistrationState::REGISTERED),
           Property(&ImplicitRegistrationSet::get_ttl, 7200),
           Property(&ImplicitRegistrationSet::get_associated_impis, IMPI_IN_VECTOR)),
     FAKE_TRAIL_ID))
-    .WillOnce(InvokeArgument<0>());
+    .WillOnce(DoAll(InvokeArgument<1>(), InvokeArgument<0>()));
 
   // Expect 200 response
   EXPECT_CALL(*_httpstack, send_reply(_, 200, _));
@@ -1543,11 +1543,11 @@ TEST_F(HTTPHandlersTest, ImpuRegDataInitialRegNoServerName)
     .WillOnce(InvokeArgument<0>(ByRef(answer)));
 
   // We now expect it to be put in the cache with an updated TTL and state REGISTERED
-  EXPECT_CALL(*_cache, put_implicit_registration_set(_, _,
+  EXPECT_CALL(*_cache, put_implicit_registration_set(_, _, _,
     AllOf(Property(&ImplicitRegistrationSet::get_reg_state, RegistrationState::REGISTERED),
           Property(&ImplicitRegistrationSet::get_ttl, 7200)),
     FAKE_TRAIL_ID))
-    .WillOnce(InvokeArgument<0>());
+    .WillOnce(DoAll(InvokeArgument<1>(), InvokeArgument<0>()));
 
   // Expect 200 response
   EXPECT_CALL(*_httpstack, send_reply(_, 200, _));
@@ -1595,11 +1595,11 @@ TEST_F(HTTPHandlersTest, ImpuRegDataInitialRegCacheGetNotFound)
 
 
   // We now expect it to be put in the cache with an updated TTL and state REGISTERED
-  EXPECT_CALL(*_cache, put_implicit_registration_set(_, _,
+  EXPECT_CALL(*_cache, put_implicit_registration_set(_, _, _,
     AllOf(Property(&ImplicitRegistrationSet::get_reg_state, RegistrationState::REGISTERED),
           Property(&ImplicitRegistrationSet::get_ttl, 7200)),
     FAKE_TRAIL_ID))
-    .WillOnce(InvokeArgument<0>());
+    .WillOnce(DoAll(InvokeArgument<1>(), InvokeArgument<0>()));
 
   // Expect 200 response
   EXPECT_CALL(*_httpstack, send_reply(_, 200, _));
@@ -1664,11 +1664,11 @@ TEST_F(HTTPHandlersTest, ImpuRegDataInitialRegCachePutError)
     .WillOnce(InvokeArgument<0>(ByRef(answer)));
 
   // We simulate a cache error when trying to cache it
-  EXPECT_CALL(*_cache, put_implicit_registration_set(_, _,
+  EXPECT_CALL(*_cache, put_implicit_registration_set(_, _, _,
     AllOf(Property(&ImplicitRegistrationSet::get_reg_state, RegistrationState::REGISTERED),
           Property(&ImplicitRegistrationSet::get_ttl, 7200)),
     FAKE_TRAIL_ID))
-    .WillOnce(InvokeArgument<1>(Store::Status::ERROR));
+    .WillOnce(InvokeArgument<2>(Store::Status::ERROR));
 
   // Expect 503 response
   EXPECT_CALL(*_httpstack, send_reply(_, 503, _));
@@ -1714,11 +1714,11 @@ TEST_F(HTTPHandlersTest, ImpuRegDataReReg)
     .WillOnce(InvokeArgument<0>(ByRef(answer)));
 
   // We now expect it to be put in the cache with an updated TTL and state REGISTERED
-  EXPECT_CALL(*_cache, put_implicit_registration_set(_, _,
+  EXPECT_CALL(*_cache, put_implicit_registration_set(_, _, _,
     AllOf(Property(&ImplicitRegistrationSet::get_reg_state, RegistrationState::REGISTERED),
           Property(&ImplicitRegistrationSet::get_ttl, 7200)),
     FAKE_TRAIL_ID))
-    .WillOnce(InvokeArgument<0>());
+    .WillOnce(DoAll(InvokeArgument<1>(), InvokeArgument<0>()));
 
   // Expect 200 response
   EXPECT_CALL(*_httpstack, send_reply(_, 200, _));
@@ -1766,11 +1766,11 @@ TEST_F(HTTPHandlersTest, ImpuRegDataReRegNoCache)
     .WillOnce(InvokeArgument<0>(ByRef(answer)));
 
   // We now expect it to be put in the cache with an updated TTL and state REGISTERED
-  EXPECT_CALL(*_cache, put_implicit_registration_set(_, _,
+  EXPECT_CALL(*_cache, put_implicit_registration_set(_, _, _,
     AllOf(Property(&ImplicitRegistrationSet::get_reg_state, RegistrationState::REGISTERED),
           Property(&ImplicitRegistrationSet::get_ttl, 7200)),
     FAKE_TRAIL_ID))
-    .WillOnce(InvokeArgument<0>());
+    .WillOnce(DoAll(InvokeArgument<1>(), InvokeArgument<0>()));
 
   // Expect 200 response
   EXPECT_CALL(*_httpstack, send_reply(_, 200, _));
@@ -1847,11 +1847,11 @@ TEST_F(HTTPHandlersTest, ImpuRegDataReRegNewBinding)
     .WillOnce(InvokeArgument<0>(ByRef(answer)));
 
   // We now expect it to be put in the cache with an updated TTL and state REGISTERED
-  EXPECT_CALL(*_cache, put_implicit_registration_set(_, _,
+  EXPECT_CALL(*_cache, put_implicit_registration_set(_, _, _,
     AllOf(Property(&ImplicitRegistrationSet::get_reg_state, RegistrationState::REGISTERED),
           Property(&ImplicitRegistrationSet::get_ttl, 7200)),
     FAKE_TRAIL_ID))
-    .WillOnce(InvokeArgument<0>());
+    .WillOnce(DoAll(InvokeArgument<1>(), InvokeArgument<0>()));
 
   // Expect 200 response
   EXPECT_CALL(*_httpstack, send_reply(_, 200, _));
@@ -1898,11 +1898,11 @@ TEST_F(HTTPHandlersTest, ImpuRegDataRegIncludesBarring)
     .WillOnce(InvokeArgument<0>(ByRef(answer)));
 
   // We now expect it to be put in the cache with an updated TTL and state REGISTERED
-  EXPECT_CALL(*_cache, put_implicit_registration_set(_, _,
+  EXPECT_CALL(*_cache, put_implicit_registration_set(_, _, _,
     AllOf(Property(&ImplicitRegistrationSet::get_reg_state, RegistrationState::REGISTERED),
           Property(&ImplicitRegistrationSet::get_ttl, 7200)),
     FAKE_TRAIL_ID))
-    .WillOnce(InvokeArgument<0>());
+    .WillOnce(DoAll(InvokeArgument<1>(), InvokeArgument<0>()));
 
   // Expect 200 response
   EXPECT_CALL(*_httpstack, send_reply(_, 200, _));
@@ -2227,11 +2227,11 @@ TEST_F(HTTPHandlersTest, ImpuRegDataCallNewUnregisteredService)
     .WillOnce(InvokeArgument<0>(ByRef(answer)));
 
   // Data is cached with state UNREGISTERED
-  EXPECT_CALL(*_cache, put_implicit_registration_set(_, _,
+  EXPECT_CALL(*_cache, put_implicit_registration_set(_, _, _,
     AllOf(Property(&ImplicitRegistrationSet::get_reg_state, RegistrationState::UNREGISTERED),
           Property(&ImplicitRegistrationSet::get_ttl, 7200)),
     FAKE_TRAIL_ID))
-    .WillOnce(InvokeArgument<0>());
+    .WillOnce(DoAll(InvokeArgument<1>(), InvokeArgument<0>()));
 
   // Check the response
   EXPECT_CALL(*_httpstack, send_reply(_, 200, _));
@@ -2277,10 +2277,10 @@ TEST_F(HTTPHandlersTest, ImpuRegDataDeregUser)
   // Data is deleted from cache
   // Check that the deletion request is using the correct service profile (as
   // that's how the cache knows what to delete)
-  EXPECT_CALL(*_cache, delete_implicit_registration_set(_, _,
+  EXPECT_CALL(*_cache, delete_implicit_registration_set(_, _, _,
     Property(&ImplicitRegistrationSet::get_ims_sub_xml, IMPU_IMS_SUBSCRIPTION),
     FAKE_TRAIL_ID))
-    .WillOnce(InvokeArgument<0>());
+    .WillOnce(DoAll(InvokeArgument<1>(), InvokeArgument<0>()));
 
   // Check the response
   EXPECT_CALL(*_httpstack, send_reply(_, 200, _));
@@ -2326,10 +2326,10 @@ TEST_F(HTTPHandlersTest, ImpuRegDataDeregTimeout)
   // Data is deleted from cache
   // Check that the deletion request is using the correct service profile (as
   // that's how the cache knows what to delete)
-  EXPECT_CALL(*_cache, delete_implicit_registration_set(_, _,
+  EXPECT_CALL(*_cache, delete_implicit_registration_set(_, _, _,
     Property(&ImplicitRegistrationSet::get_ims_sub_xml, IMPU_IMS_SUBSCRIPTION),
     FAKE_TRAIL_ID))
-    .WillOnce(InvokeArgument<0>());
+    .WillOnce(DoAll(InvokeArgument<1>(), InvokeArgument<0>()));
 
   // Check the response
   EXPECT_CALL(*_httpstack, send_reply(_, 200, _));
@@ -2375,10 +2375,10 @@ TEST_F(HTTPHandlersTest, ImpuRegDataDeregAdmin)
   // Data is deleted from cache
   // Check that the deletion request is using the correct service profile (as
   // that's how the cache knows what to delete)
-  EXPECT_CALL(*_cache, delete_implicit_registration_set(_, _,
+  EXPECT_CALL(*_cache, delete_implicit_registration_set(_, _, _,
     Property(&ImplicitRegistrationSet::get_ims_sub_xml, IMPU_IMS_SUBSCRIPTION),
     FAKE_TRAIL_ID))
-    .WillOnce(InvokeArgument<0>());
+    .WillOnce(DoAll(InvokeArgument<1>(), InvokeArgument<0>()));
 
   // Check the response
   EXPECT_CALL(*_httpstack, send_reply(_, 200, _));
@@ -2425,10 +2425,10 @@ TEST_F(HTTPHandlersTest, ImpuRegDataDeregNoIMPI)
   // Data is deleted from cache
   // Check that the deletion request is using the correct service profile (as
   // that's how the cache knows what to delete)
-  EXPECT_CALL(*_cache, delete_implicit_registration_set(_, _,
+  EXPECT_CALL(*_cache, delete_implicit_registration_set(_, _, _,
     Property(&ImplicitRegistrationSet::get_ims_sub_xml, IMPU_IMS_SUBSCRIPTION),
     FAKE_TRAIL_ID))
-    .WillOnce(InvokeArgument<0>());
+    .WillOnce(DoAll(InvokeArgument<1>(), InvokeArgument<0>()));
 
   // Check the response
   EXPECT_CALL(*_httpstack, send_reply(_, 200, _));
@@ -2474,10 +2474,10 @@ TEST_F(HTTPHandlersTest, ImpuRegDataDeregCacheError)
   // Data is deleted from cache
   // Check that the deletion request is using the correct service profile (as
   // that's how the cache knows what to delete)
-  EXPECT_CALL(*_cache, delete_implicit_registration_set(_, _,
+  EXPECT_CALL(*_cache, delete_implicit_registration_set(_, _, _,
     Property(&ImplicitRegistrationSet::get_ims_sub_xml, IMPU_IMS_SUBSCRIPTION),
     FAKE_TRAIL_ID))
-    .WillOnce(InvokeArgument<1>(Store::Status::ERROR));
+    .WillOnce(InvokeArgument<2>(Store::Status::ERROR));
 
   // Check the response
   EXPECT_CALL(*_httpstack, send_reply(_, 503, _));
@@ -2523,10 +2523,10 @@ TEST_F(HTTPHandlersTest, ImpuRegDataDeregCacheNotFound)
   // Cache delete gives a NOT_FOUND error
   // Check that the deletion request is using the correct service profile (as
   // that's how the cache knows what to delete)
-  EXPECT_CALL(*_cache, delete_implicit_registration_set(_, _,
+  EXPECT_CALL(*_cache, delete_implicit_registration_set(_, _, _,
     Property(&ImplicitRegistrationSet::get_ims_sub_xml, IMPU_IMS_SUBSCRIPTION),
     FAKE_TRAIL_ID))
-    .WillOnce(InvokeArgument<1>(Store::Status::NOT_FOUND));
+    .WillOnce(InvokeArgument<2>(Store::Status::NOT_FOUND));
 
   // Check the response
   EXPECT_CALL(*_httpstack, send_reply(_, 200, _));
@@ -2572,10 +2572,10 @@ TEST_F(HTTPHandlersTest, ImpuRegDataDeregUnregSub)
   // Data is deleted from cache
   // Check that the deletion request is using the correct service profile (as
   // that's how the cache knows what to delete)
-  EXPECT_CALL(*_cache, delete_implicit_registration_set(_, _,
+  EXPECT_CALL(*_cache, delete_implicit_registration_set(_, _, _,
     Property(&ImplicitRegistrationSet::get_ims_sub_xml, IMPU_IMS_SUBSCRIPTION),
     FAKE_TRAIL_ID))
-    .WillOnce(InvokeArgument<0>());
+    .WillOnce(DoAll(InvokeArgument<1>(), InvokeArgument<0>()));
 
   // Check the response
   EXPECT_CALL(*_httpstack, send_reply(_, 200, _));

--- a/src/ut/memcachedcache_test.cpp
+++ b/src/ut/memcachedcache_test.cpp
@@ -168,6 +168,18 @@ static const std::string SERVICE_PROFILE_3 =
 static const uint64_t CAS = 1L;
 static const uint64_t CAS_2 = 2L;
 
+// Allows us to check that progress callbacks are called
+class MockProgressCallback
+{
+public:
+  virtual ~MockProgressCallback() {};
+  MOCK_METHOD0(progress_callback, void());
+};
+
+static MockProgressCallback* _mock_progress_cb;
+static progress_callback _progress_callback = []() {
+  _mock_progress_cb->progress_callback();
+};
 
 class MemcachedImplicitRegistrationSetTest : public ControlTimeTest
 {
@@ -649,10 +661,12 @@ public:
     _remote_stores = { _remote_store };
     _memcached_cache = new MemcachedCache(_local_store,
                                           _remote_stores);
+    _mock_progress_cb = new MockProgressCallback();
   }
 
   virtual void TearDown() override
   {
+    delete _mock_progress_cb;
     delete _memcached_cache;
     delete _remote_store;
     delete _rls;
@@ -962,8 +976,9 @@ TEST_F(MemcachedCacheTest, PutIrs)
   irs->set_ims_sub_xml(SERVICE_PROFILE);
   irs->set_reg_state(RegistrationState::REGISTERED);
 
-  EXPECT_EQ(Store::Status::OK,
-            _memcached_cache->put_implicit_registration_set(irs, 0L));
+  EXPECT_CALL(*_mock_progress_cb, progress_callback());
+  Store::Status status = _memcached_cache->put_implicit_registration_set(irs, _progress_callback, 0L);
+  EXPECT_EQ(Store::Status::OK, status);
 
   delete irs;
 }
@@ -1003,8 +1018,9 @@ TEST_F(MemcachedCacheTest, PutIrsWithExistingUnrefreshed)
 
   irs->add_associated_impi(IMPI);
 
-  EXPECT_EQ(Store::Status::OK,
-            _memcached_cache->put_implicit_registration_set(irs, 0L));
+  EXPECT_CALL(*_mock_progress_cb, progress_callback());
+  Store::Status status = _memcached_cache->put_implicit_registration_set(irs, _progress_callback, 0L);
+  EXPECT_EQ(Store::Status::OK, status);
 
   delete irs;
 }
@@ -1044,8 +1060,9 @@ TEST_F(MemcachedCacheTest, PutIrsWithExistingNotRefreshedConflictAssociated)
     delete ai;
   }
 
+  // Errors don't trigger the progress_callback
   EXPECT_EQ(Store::Status::ERROR,
-            _memcached_cache->put_implicit_registration_set(irs, 0L));
+            _memcached_cache->put_implicit_registration_set(irs, _progress_callback, 0L));
 
   delete irs;
 }
@@ -1090,8 +1107,9 @@ TEST_F(MemcachedCacheTest, PutIrsWithExistingRefreshedConflictAssociated)
     delete ai;
   }
 
-  EXPECT_EQ(Store::Status::OK,
-            _memcached_cache->put_implicit_registration_set(irs, 0L));
+  EXPECT_CALL(*_mock_progress_cb, progress_callback());
+  Store::Status status = _memcached_cache->put_implicit_registration_set(irs, _progress_callback, 0L);
+  EXPECT_EQ(Store::Status::OK, status);
 
   delete irs;
 }
@@ -1194,8 +1212,9 @@ TEST_F(MemcachedCacheTest, PutIrsWithExistingRefreshed)
   irs->delete_associated_impi(IMPI_2);
   irs->add_associated_impi(IMPI_3);
 
-  EXPECT_EQ(Store::Status::OK,
-            _memcached_cache->put_implicit_registration_set(irs, 0L));
+  EXPECT_CALL(*_mock_progress_cb, progress_callback());
+  Store::Status status = _memcached_cache->put_implicit_registration_set(irs, _progress_callback, 0L);
+  EXPECT_EQ(Store::Status::OK, status);
 
   delete irs;
 }
@@ -1209,8 +1228,9 @@ TEST_F(MemcachedCacheTest, DeleteIrsNotAdded)
   irs->set_ims_sub_xml(SERVICE_PROFILE);
   irs->set_reg_state(RegistrationState::REGISTERED);
 
-  EXPECT_EQ(Store::Status::OK,
-            _memcached_cache->delete_implicit_registration_set(irs, 0L));
+  EXPECT_CALL(*_mock_progress_cb, progress_callback());
+  Store::Status status = _memcached_cache->delete_implicit_registration_set(irs, _progress_callback, 0L);
+  EXPECT_EQ(Store::Status::OK, status);
 
   delete irs;
 }
@@ -1238,8 +1258,9 @@ TEST_F(MemcachedCacheTest, DeleteIrsAddedRemote)
 
   std::vector<ImplicitRegistrationSet*> irss = {irs};
 
-  EXPECT_EQ(Store::Status::OK,
-            _memcached_cache->delete_implicit_registration_sets(irss, 0L));
+  EXPECT_CALL(*_mock_progress_cb, progress_callback());
+  Store::Status status = _memcached_cache->delete_implicit_registration_set(irs, _progress_callback, 0L);
+  EXPECT_EQ(Store::Status::OK, status);
 
   delete irs;
 }
@@ -1269,8 +1290,9 @@ TEST_F(MemcachedCacheTest, DeleteIrsAddedLocalStoreFail)
 
   _lls->force_delete_error();
 
+  // The progress_callback is not called on error
   EXPECT_EQ(Store::Status::ERROR,
-            _memcached_cache->delete_implicit_registration_sets(irss, 0L));
+            _memcached_cache->delete_implicit_registration_sets(irss, _progress_callback, 0L));
 
   delete irs;
 }
@@ -1296,8 +1318,9 @@ TEST_F(MemcachedCacheTest, DeleteIrss)
 
   _memcached_cache->get_implicit_registration_set_for_impu(IMPU, 0L, irs);
 
-  EXPECT_EQ(Store::Status::OK,
-            _memcached_cache->delete_implicit_registration_set(irs, 0L));
+  EXPECT_CALL(*_mock_progress_cb, progress_callback());
+  Store::Status status = _memcached_cache->delete_implicit_registration_set(irs, _progress_callback, 0L);
+  EXPECT_EQ(Store::Status::OK, status);
 
   delete irs;
 }
@@ -1454,8 +1477,11 @@ TEST_F(MemcachedCacheTest, PutImsSubscription)
 
   subscription->set_charging_addrs(CHARGING_ADDRESSES_2);
 
+
+  EXPECT_CALL(*_mock_progress_cb, progress_callback());
   Store::Status status =
     _memcached_cache->put_ims_subscription(subscription,
+                                           _progress_callback,
                                            0L);
 
   EXPECT_EQ(Store::Status::OK, status);

--- a/src/ut/mockhsscacheprocessor.hpp
+++ b/src/ut/mockhsscacheprocessor.hpp
@@ -42,20 +42,23 @@ public:
                     std::vector<std::string> impus,
                     SAS::TrailId trail));
 
-  MOCK_METHOD4(put_implicit_registration_set,
+  MOCK_METHOD5(put_implicit_registration_set,
                void(void_success_cb success_cb,
+                    progress_callback progress_cb,
                     failure_callback failure_cb,
                     ImplicitRegistrationSet* irs,
                     SAS::TrailId trail));
 
-  MOCK_METHOD4(delete_implicit_registration_set,
+  MOCK_METHOD5(delete_implicit_registration_set,
                void(void_success_cb success_cb,
+                    progress_callback progress_cb,
                     failure_callback failure_cb,
                     ImplicitRegistrationSet* irs,
                     SAS::TrailId trail));
 
-  MOCK_METHOD4(delete_implicit_registration_sets,
+  MOCK_METHOD5(delete_implicit_registration_sets,
                void(void_success_cb success_cb,
+                    progress_callback progress_cb,
                     failure_callback failure_cb,
                     std::vector<ImplicitRegistrationSet*> irss,
                     SAS::TrailId trail));
@@ -66,8 +69,9 @@ public:
                     std::string impi,
                     SAS::TrailId trail));
 
-  MOCK_METHOD4(put_ims_subscription,
+  MOCK_METHOD5(put_ims_subscription,
                void(void_success_cb success_cb,
+                    progress_callback progress_cb,
                     failure_callback failure_cb,
                     ImsSubscription* subscription,
                     SAS::TrailId trail));


### PR DESCRIPTION
Cache latency was too high when writing to remote sites because we were performing all the writes synchronously before returning a response to the request that caused us to perform a write.

This resolves that by allowing the `MemcachedCache` to write to the local site first, then call a progress callback (which tells the handler that it has succeeded in writing to the local site), and then continue to write to the remote sites once the handler has processed the local success.

This is done by:
  * passing a `progress_callback` through the `HssCacheProcessor` to the `HssCache` for all put/delete operations
  * changing the `BaseHssCache` to no longer treat a bulk delete as several deletes in a row (since it needs to perform the delete for all IRSs in the local site first, then call the progress callback, then do remote sites)
  * Changing the `MemcachedCache::store_action` to be a `std::function` that captures the data it needs and performs the action
  * using this to allow us to have new actions which delete/put multiple IRSs, used for the RTR/PPR handling
* Changing the handlers' success callbacks to just delete the handler, and moving what was the success callback into a new progress callback

I've confirmed `make full_test` passes, and live tested with 2 sites and confirmed that the remote site writes are happening after the response has been sent.