### PR TITLE
[Reviewer: AJH] Add watchdog timer config option

### DIFF
--- a/homestead.root/usr/share/clearwater/infrastructure/scripts/homestead
+++ b/homestead.root/usr/share/clearwater/infrastructure/scripts/homestead
@@ -22,6 +22,12 @@ then
     hs_listen_port=$hss_port
 fi
 
+# If homestead_tw_timer is not set, default to the minimum of 6s
+if [[ -z "$homestead_tw_timer" ]]
+then
+  homestead_tw_timer=6
+fi
+
 # Allow a specific FQDN for Homestead to be set (in case this is an
 # all-in-one node running both ralf and homestead Diameter stacks).
 # Otherwise, fall back to the public hostname.
@@ -38,5 +44,5 @@ then
   # Strip any characters not valid in an FQDN out of hs_hostname (for
   # example, it might be an IPv6 address)
   realm=$(echo $hs_hostname | sed -e 's/:[^:]*$//g' | sed -e 's/^\[//g' | sed -e 's/\]$//g')
-  /usr/share/clearwater/bin/generic_create_diameterconf homestead $identity $realm $hs_listen_port $hs_secure_listen_port $acl_required $check_destination_host
+  /usr/share/clearwater/bin/generic_create_diameterconf homestead $identity $realm $hs_listen_port $hs_secure_listen_port $acl_required $check_destination_host $homestead_tw_timer
 fi

--- a/homestead.root/usr/share/clearwater/infrastructure/scripts/homestead
+++ b/homestead.root/usr/share/clearwater/infrastructure/scripts/homestead
@@ -13,6 +13,7 @@ hss_port=3868
 hs_secure_listen_port=5658
 acl_required=false
 check_destination_host=true
+homestead_diameter_watchdog_timer=6
 . /etc/clearwater/config
 
 # If we don't have a hs_listen_port set, fall back to hss_port (for
@@ -20,12 +21,6 @@ check_destination_host=true
 if [[ -z "$hs_listen_port" ]]
 then
     hs_listen_port=$hss_port
-fi
-
-# If homestead_tw_timer is not set, default to the minimum of 6s
-if [[ -z "$homestead_tw_timer" ]]
-then
-  homestead_tw_timer=6
 fi
 
 # Allow a specific FQDN for Homestead to be set (in case this is an
@@ -44,5 +39,5 @@ then
   # Strip any characters not valid in an FQDN out of hs_hostname (for
   # example, it might be an IPv6 address)
   realm=$(echo $hs_hostname | sed -e 's/:[^:]*$//g' | sed -e 's/^\[//g' | sed -e 's/\]$//g')
-  /usr/share/clearwater/bin/generic_create_diameterconf homestead $identity $realm $hs_listen_port $hs_secure_listen_port $acl_required $check_destination_host $homestead_tw_timer
+  /usr/share/clearwater/bin/generic_create_diameterconf homestead $identity $realm $hs_listen_port $hs_secure_listen_port $acl_required $check_destination_host $homestead_diameter_watchdog_timer
 fi


### PR DESCRIPTION
Introduces a shared config option to set the delay between watchdog messages in freeDiameter, defaulting to 6s.

The script has undergone very basic live testing, with more to come.