### PR TITLE
[Reviewer: Seb] Don't SAS log compressed bodies

### DIFF
--- a/src/impu_store.cpp
+++ b/src/impu_store.cpp
@@ -491,7 +491,12 @@ ImpuStore::Impu* ImpuStore::get_impu(const std::string& impu,
   std::string data;
   uint64_t cas;
 
-  Store::Status status = _store->get_data("impu", impu, data, cas, trail);
+  Store::Status status = _store->get_data("impu",
+                                          impu,
+                                          data,
+                                          cas,
+                                          trail,
+                                          false);
 
   if (status == Store::Status::OK)
   {

--- a/src/impu_store.cpp
+++ b/src/impu_store.cpp
@@ -518,7 +518,8 @@ Store::Status ImpuStore::set_impu_without_cas(ImpuStore::Impu* impu,
                                           impu->impu,
                                           data,
                                           impu->expiry - now,
-                                          trail);
+                                          trail,
+                                          false);
   }
 
   return status;
@@ -543,7 +544,8 @@ Store::Status ImpuStore::set_impu(ImpuStore::Impu* impu,
                               data,
                               impu->cas,
                               impu->expiry - now,
-                              trail);
+                              trail,
+                              false);
   }
 
   TRC_DEBUG("Wrote %s to store (SAS Trail: %lu) with result: %u",


### PR DESCRIPTION
Logging compressed bodies is pretty pointless, so this change stops us doing it.

The change is fairly simple because most of the change is in cpp-common - see https://github.com/Metaswitch/cpp-common/compare/sas_log_body