### PR TITLE
[Reviewer: Richard] Reinstate the CACHE_PUT_REG_DATA sas log

### DIFF
--- a/include/charging_addresses.h
+++ b/include/charging_addresses.h
@@ -39,7 +39,7 @@ public:
   inline bool empty() const { return (ccfs.empty()) && (ecfs.empty()); }
 
   /// Convert the charging functions into a string to display in logs
-  std::string log_string()
+  std::string log_string() const
   {
     std::string log_str;
 

--- a/include/http_handlers.h
+++ b/include/http_handlers.h
@@ -267,12 +267,6 @@ protected:
   std::string _impu;
   std::string _type_param;
   RequestType _type;
-  RegistrationState _original_state;
-
-  // These are now in the ImplicitRegistrationSet*
-  std::string _xml;
-  RegistrationState _new_state;
-  ChargingAddresses _charging_addrs;
 
   ImplicitRegistrationSet* _irs = NULL;
 

--- a/src/http_handlers.cpp
+++ b/src/http_handlers.cpp
@@ -1106,15 +1106,17 @@ void ImpuRegDataTask::put_in_cache()
       }
     }
 
-    SAS::Event event(this->trail(), SASEvent::CACHE_PUT_REG_DATA, 0);
-    std::string public_ids_str = boost::algorithm::join(public_ids, ", ");
-    event.add_var_param(public_ids_str);
-    event.add_compressed_param(_irs->get_ims_sub_xml(), &SASEvent::PROFILE_SERVICE_PROFILE);
-    event.add_static_param(_irs->get_reg_state());
-    std::string associated_private_ids_str = boost::algorithm::join(_irs->get_associated_impis(), ", ");
-    event.add_var_param(associated_private_ids_str);
-    event.add_var_param(_irs->get_charging_addresses().log_string());
-    SAS::report_event(event);
+    {
+      SAS::Event event(this->trail(), SASEvent::CACHE_PUT_REG_DATA, 0);
+      std::string public_ids_str = boost::algorithm::join(public_ids, ", ");
+      event.add_var_param(public_ids_str);
+      event.add_compressed_param(_irs->get_ims_sub_xml(), &SASEvent::PROFILE_SERVICE_PROFILE);
+      event.add_static_param(_irs->get_reg_state());
+      std::string associated_private_ids_str = boost::algorithm::join(_irs->get_associated_impis(), ", ");
+      event.add_var_param(associated_private_ids_str);
+      event.add_var_param(_irs->get_charging_addresses().log_string());
+      SAS::report_event(event);
+    }
 
     // Create the callbacks
     void_success_cb success_cb =

--- a/src/http_handlers.cpp
+++ b/src/http_handlers.cpp
@@ -1037,7 +1037,7 @@ void ImpuRegDataTask::send_reply()
     else
     {
       SAS::Event event(this->trail(), SASEvent::REG_DATA_HSS_INVALID, 0);
-      event.add_compressed_param(_xml, &SASEvent::PROFILE_SERVICE_PROFILE);
+      event.add_compressed_param(_irs->get_ims_sub_xml(), &SASEvent::PROFILE_SERVICE_PROFILE);
       SAS::report_event(event);
     }
   }
@@ -1100,11 +1100,21 @@ void ImpuRegDataTask::put_in_cache()
         // LCOV_EXCL_START - This is essentially tested in the PPR UTs
         TRC_ERROR("No SIP URI in Implicit Registration Set");
         SAS::Event event(this->trail(), SASEvent::NO_SIP_URI_IN_IRS, 0);
-        event.add_compressed_param(_xml, &SASEvent::PROFILE_SERVICE_PROFILE);
+        event.add_compressed_param(_irs->get_ims_sub_xml(), &SASEvent::PROFILE_SERVICE_PROFILE);
         SAS::report_event(event);
         // LCOV_EXCL_STOP
       }
     }
+
+    SAS::Event event(this->trail(), SASEvent::CACHE_PUT_REG_DATA, 0);
+    std::string public_ids_str = boost::algorithm::join(public_ids, ", ");
+    event.add_var_param(public_ids_str);
+    event.add_compressed_param(_irs->get_ims_sub_xml(), &SASEvent::PROFILE_SERVICE_PROFILE);
+    event.add_static_param(_irs->get_reg_state());
+    std::string associated_private_ids_str = boost::algorithm::join(_irs->get_associated_impis(), ", ");
+    event.add_var_param(associated_private_ids_str);
+    event.add_var_param(_irs->get_charging_addresses().log_string());
+    SAS::report_event(event);
 
     // Create the callbacks
     void_success_cb success_cb =


### PR DESCRIPTION
Also tidy up some unused variables, and fix cases where they were erroneously used

I've tested live that this SAS log appears correctly