### PR TITLE
[Reviewer: Adam] Allow homestead_http_threads to be configured

### DIFF
--- a/debian/homestead.init.d
+++ b/debian/homestead.init.d
@@ -88,6 +88,11 @@ get_settings()
 
         . /etc/clearwater/config
 
+        if [ -n "$homestead_http_threads" ];
+        then
+          num_http_threads="$homestead_http_threads"
+        fi
+
         # Derive server_name and sprout_http_name from other settings
         if [ -n "$scscf_uri" ]
         then


### PR DESCRIPTION
Adam,

Hopefully an uncontroversial change to allow homestead's HTTP threads to be configured independently.

I've tested setting `homestead_http_threads` on a Chef deployment and checking that they get picked up.

The equivalent of `sprout_worker_threads`, `homestead_cache_threads` is already standalone.