### PR TITLE
[Reviewer: EM] Add grace period to poll_homestead script

### DIFF
--- a/homestead.root/usr/share/clearwater/bin/poll_homestead.sh
+++ b/homestead.root/usr/share/clearwater/bin/poll_homestead.sh
@@ -9,7 +9,18 @@
 # Otherwise no rights are granted except for those provided to you by
 # Metaswitch Networks in a separate written agreement.
 
+# If the process has not been running for at least the grace period, the script
+# returns zero. This is to allow the process some time to initialize.
+GRACE_PERIOD=20
+
+
 . /etc/clearwater/config
 http_ip=$(/usr/share/clearwater/bin/bracket-ipv6-address $local_ip)
 /usr/share/clearwater/bin/poll-http $http_ip:8888
-exit $?
+rc=$?
+if /usr/share/clearwater/bin/is-stable /var/run/homestead/homestead.pid $GRACE_PERIOD; then
+  exit $rc
+else
+  echo -n " (failure ($rc) ignored - in grace period) " >&2
+  exit 0
+fi

--- a/homestead.root/usr/share/clearwater/bin/poll_homestead.sh
+++ b/homestead.root/usr/share/clearwater/bin/poll_homestead.sh
@@ -15,7 +15,7 @@
 # least the grace period, the script returns zero. This is to allow the process
 # some time to initialize.
 
-GRACE_PERIOD = 20
+GRACE_PERIOD=20
 
 # Determine the HTTP IP, poll it, and handle the result according to whether or
 # not we are in the grace period.

--- a/homestead.root/usr/share/clearwater/bin/poll_homestead.sh
+++ b/homestead.root/usr/share/clearwater/bin/poll_homestead.sh
@@ -2,7 +2,7 @@
 
 # @file poll_homestead.sh
 #
-# Copyright (C) Metaswitch Networks 2016
+# Copyright (C) Metaswitch Networks 2017
 # If license terms are provided to you in a COPYING file in the root directory
 # of the source code repository by which you are accessing this code, then
 # the license outlined in that COPYING file applies to your use.

--- a/homestead.root/usr/share/clearwater/bin/poll_homestead.sh
+++ b/homestead.root/usr/share/clearwater/bin/poll_homestead.sh
@@ -9,15 +9,21 @@
 # Otherwise no rights are granted except for those provided to you by
 # Metaswitch Networks in a separate written agreement.
 
-# If the process has not been running for at least the grace period, the script
-# returns zero. This is to allow the process some time to initialize.
-GRACE_PERIOD=20
-
-
 . /etc/clearwater/config
+
+# Set the length of the grace period. If the process has not been running for at
+# least the grace period, the script returns zero. This is to allow the process
+# some time to initialize.
+
+GRACE_PERIOD = 20
+
+# Determine the HTTP IP, poll it, and handle the result according to whether or
+# not we are in the grace period.
+
 http_ip=$(/usr/share/clearwater/bin/bracket-ipv6-address $local_ip)
 /usr/share/clearwater/bin/poll-http $http_ip:8888
 rc=$?
+
 if /usr/share/clearwater/bin/is-stable /var/run/homestead/homestead.pid $GRACE_PERIOD; then
   exit $rc
 else


### PR DESCRIPTION
This change adds a 20 second grace period after Homestead restarts during which failures of the poll_homestead script will be ignored. This avoids the case where Homestead is repeatedly killed by Monit if the HTTP interface takes a while to come up.

The cost of this change is that it will take Monit 20s longer to kill Homestead if it fails to start.