### PR TITLE
[Reviewer: Richard] Don't blind write UNREGISTERED data to the cache

### DIFF
--- a/include/impu_store.h
+++ b/include/impu_store.h
@@ -251,7 +251,15 @@ public:
 
   }
 
+  // Sets the IMPU in the store without checking the CAS value, overwriting any
+  // data already present.
   Store::Status set_impu_without_cas(Impu* impu, SAS::TrailId trail);
+
+  // Attempts to set the IMPU in the store without checking the CAS value. If
+  // any non-tombstone data is found, doesn't retry and just returns OK
+  Store::Status add_impu_without_cas(Impu* impu, SAS::TrailId trail);
+
+  // Sets the IMPU using CAS
   Store::Status set_impu(Impu* impu, SAS::TrailId trail);
 
   Impu* get_impu(const std::string& impu, SAS::TrailId trail);

--- a/include/impu_store.h
+++ b/include/impu_store.h
@@ -255,9 +255,9 @@ public:
   // data already present.
   Store::Status set_impu_without_cas(Impu* impu, SAS::TrailId trail);
 
-  // Attempts to set the IMPU in the store without checking the CAS value. If
-  // any non-tombstone data is found, doesn't retry and just returns OK
-  Store::Status add_impu_without_cas(Impu* impu, SAS::TrailId trail);
+  // Attempts to add an IMPU that doesn't already exist in the store.
+  // Fails with DATA_CONTENTION if an IMPU is already present.
+  Store::Status add_impu(Impu* impu, SAS::TrailId trail);
 
   // Sets the IMPU using CAS
   Store::Status set_impu(Impu* impu, SAS::TrailId trail);

--- a/src/impu_store.cpp
+++ b/src/impu_store.cpp
@@ -539,8 +539,8 @@ Store::Status ImpuStore::set_impu_without_cas(ImpuStore::Impu* impu,
   return status;
 }
 
-Store::Status ImpuStore::add_impu_without_cas(ImpuStore::Impu* impu,
-                                              SAS::TrailId trail)
+Store::Status ImpuStore::add_impu(ImpuStore::Impu* impu,
+                                  SAS::TrailId trail)
 {
   std::string data;
 
@@ -559,18 +559,9 @@ Store::Status ImpuStore::add_impu_without_cas(ImpuStore::Impu* impu,
                               impu->expiry - now,
                               trail,
                               false);
-
-    if (status == Store::Status::DATA_CONTENTION)
-    {
-      // Just ignore the error
-      TRC_DEBUG("Ignoring data contention error attempting to store IMPU for %s",
-                impu->impu.c_str());
-      status = Store::Status::OK;
-    }
   }
 
   return status;
-
 }
 
 Store::Status ImpuStore::set_impu(ImpuStore::Impu* impu,

--- a/src/impu_store.cpp
+++ b/src/impu_store.cpp
@@ -539,6 +539,38 @@ Store::Status ImpuStore::set_impu_without_cas(ImpuStore::Impu* impu,
   return status;
 }
 
+Store::Status ImpuStore::add_impu_without_cas(ImpuStore::Impu* impu,
+                                              SAS::TrailId trail)
+{
+  std::string data;
+
+  Store::Status status = impu->to_data(data);
+
+  if (status == Store::Status::OK)
+  {
+    int now = time(0);
+
+    // Set the data with a CAS of 0, which will fail if there's data already
+    // present
+    status = _store->set_data("impu",
+                              impu->impu,
+                              data,
+                              0,
+                              impu->expiry - now,
+                              trail,
+                              false);
+
+    if (status == Store::Status::DATA_CONTENTION)
+    {
+      // Just ignore the error
+      status = Store::Status::OK;
+    }
+  }
+
+  return status;
+
+}
+
 Store::Status ImpuStore::set_impu(ImpuStore::Impu* impu,
                                   SAS::TrailId trail)
 {

--- a/src/impu_store.cpp
+++ b/src/impu_store.cpp
@@ -563,6 +563,8 @@ Store::Status ImpuStore::add_impu_without_cas(ImpuStore::Impu* impu,
     if (status == Store::Status::DATA_CONTENTION)
     {
       // Just ignore the error
+      TRC_DEBUG("Ignoring data contention error attempting to store IMPU for %s",
+                impu->impu.c_str());
       status = Store::Status::OK;
     }
   }

--- a/src/memcached_cache.cpp
+++ b/src/memcached_cache.cpp
@@ -616,14 +616,27 @@ Store::Status MemcachedCache::update_irs_associated_impus(MemcachedImplicitRegis
 }
 
 // Create an IMPU from an IRS and set it in the store.
-// This is used when we think that the IMPU is new.
+// This is used when we failed to find the IMPU in the store, and have therefore
+// created a new record for it.
 // The behaviour depends on the registration state of the IMPU we're trying to
 // store:
 //  - if we're storing an IMPU in state REGISTERED, then we just blind write to
 //    the store. This is because we only do this when we've got a new
 //    registration, so we've just communicated with the HSS and the data we have
 //    is authoritative. We therefore want to overwrite anything that's been put
-//    in the store since then
+//    in the store since then.
+//    This is safe because either:
+//      (a) The data in the store is from a registration at the same time, and
+//          hence matches what we have (or is equivalently valid), so we can
+//          just write over it.
+//      (b) The data in the store is from an UNREGISTERED request at the same
+//          time, but that is now out of date as we have just registered on the
+//          HSS.
+//    Note that we aren't resolving any differing additional IMPUs or IMPIs.
+//    These should have been subject to a PPR, and will expire anyway. This very
+//    narrow race (multiple SAA and HSS changes happening simultaneously for a
+//    single IMPU) isn't worth resolving given the additional latency required,
+//    and it's not clear which one should win anyway.
 //
 //  - if we're storing an IMPU in state UNREGISTERED, then we want to attempt to
 //    write to the store. However, if there's any data already in the store, we
@@ -646,11 +659,22 @@ Store::Status MemcachedCache::create_irs_impu(MemcachedImplicitRegistrationSet* 
 
   if (impu->registration_state == RegistrationState::REGISTERED)
   {
+    TRC_DEBUG("Storing REGISTERED IMPU %s without checking CAS value",
+              impu->impu.c_str());
     status = store->set_impu_without_cas(impu, trail);
   }
   else
   {
-    status = store->add_impu_without_cas(impu, trail);
+    TRC_DEBUG("Attempting to add UNREGISTERED IMPU %s", impu->impu.c_str());
+    status = store->add_impu(impu, trail);
+
+    if (status == Store::Status::DATA_CONTENTION)
+    {
+      // Just ignore the error
+      TRC_DEBUG("Ignoring data contention error attempting to add IMPU for %s",
+                impu->impu.c_str());
+      status = Store::Status::OK;
+    }
   }
 
   delete impu;


### PR DESCRIPTION
This is a fix for: https://github.com/Metaswitch/clearwater-issues/issues/2616

As discussed, this changes our writing to the cache so that we don't blind write data with reg-state UNREGISTERED to the cache.

I've put a fairly in-depth comment as to why we're doing this in the code.

I've added a UT for this race window, which fails before the fix and passes after. I've not attempted to replicate the race in live testing, as that didn't seem worth the effort.

At the moment we just ignore DATA_CONTENTION (writing a debug log, but nothing else). Does that sound sensible, or should we be SAS logging?