### PR TITLE
[Reviewer: Richard] Check result of getting an ImpiMapping before using it

### DIFF
--- a/include/impu_store.h
+++ b/include/impu_store.h
@@ -268,7 +268,10 @@ public:
 
   Store::Status set_impi_mapping(ImpiMapping* mapping, SAS::TrailId trail);
 
-  ImpiMapping* get_impi_mapping(const std::string impi, SAS::TrailId trail);
+  // Get the ImpiMapping for this impi.
+  // If successful, set the pointer out_mapping to be the retrieved ImpiMapping
+  // If not, does not alter mapping
+  Store::Status get_impi_mapping(const std::string impi, ImpiMapping*& out_mapping, SAS::TrailId trail);
 
   Store::Status delete_impi_mapping(ImpiMapping* mapping, SAS::TrailId trail);
 

--- a/include/impu_store.h
+++ b/include/impu_store.h
@@ -264,7 +264,9 @@ public:
   // Sets the IMPU using CAS
   virtual Store::Status set_impu(Impu* impu, SAS::TrailId trail);
 
-  virtual Impu* get_impu(const std::string& impu, SAS::TrailId trail);
+  virtual Store::Status get_impu(const std::string& impu,
+                                 Impu*& out_impu,
+                                 SAS::TrailId trail);
 
   virtual Store::Status delete_impu(Impu* impu, SAS::TrailId trail);
 

--- a/include/impu_store.h
+++ b/include/impu_store.h
@@ -246,6 +246,8 @@ public:
     std::vector<std::string> _default_impus;
   };
 
+  virtual ~ImpuStore() {};
+
   ImpuStore(Store* store) : _store(store)
   {
 
@@ -253,27 +255,27 @@ public:
 
   // Sets the IMPU in the store without checking the CAS value, overwriting any
   // data already present.
-  Store::Status set_impu_without_cas(Impu* impu, SAS::TrailId trail);
+  virtual Store::Status set_impu_without_cas(Impu* impu, SAS::TrailId trail);
 
   // Attempts to add an IMPU that doesn't already exist in the store.
   // Fails with DATA_CONTENTION if an IMPU is already present.
-  Store::Status add_impu(Impu* impu, SAS::TrailId trail);
+  virtual Store::Status add_impu(Impu* impu, SAS::TrailId trail);
 
   // Sets the IMPU using CAS
-  Store::Status set_impu(Impu* impu, SAS::TrailId trail);
+  virtual Store::Status set_impu(Impu* impu, SAS::TrailId trail);
 
-  Impu* get_impu(const std::string& impu, SAS::TrailId trail);
+  virtual Impu* get_impu(const std::string& impu, SAS::TrailId trail);
 
-  Store::Status delete_impu(Impu* impu, SAS::TrailId trail);
+  virtual Store::Status delete_impu(Impu* impu, SAS::TrailId trail);
 
-  Store::Status set_impi_mapping(ImpiMapping* mapping, SAS::TrailId trail);
+  virtual Store::Status set_impi_mapping(ImpiMapping* mapping, SAS::TrailId trail);
 
   // Get the ImpiMapping for this impi.
   // If successful, set the pointer out_mapping to be the retrieved ImpiMapping
   // If not, does not alter mapping
-  Store::Status get_impi_mapping(const std::string impi, ImpiMapping*& out_mapping, SAS::TrailId trail);
+  virtual Store::Status get_impi_mapping(const std::string impi, ImpiMapping*& out_mapping, SAS::TrailId trail);
 
-  Store::Status delete_impi_mapping(ImpiMapping* mapping, SAS::TrailId trail);
+  virtual Store::Status delete_impi_mapping(ImpiMapping* mapping, SAS::TrailId trail);
 
 private:
   Store* _store;

--- a/include/memcached_cache.h
+++ b/include/memcached_cache.h
@@ -367,12 +367,17 @@ private:
   std::vector<ImpuStore*> _remote_stores;
   FunctorThreadPool _thread_pool;
 
-  ImpuStore::Impu* get_impu_for_impu_gr(const std::string& impu,
-                                        SAS::TrailId trail);
+  // Get the Impu for this impu, by first checking the local store and then any
+  // remote stores if no Impu is found in the local store.
+  // If successful, sets the pointer out_impu to be the retrieved Impu.
+  // If not, does not alter out_impu.
+  Store::Status get_impu_for_impu_gr(const std::string& impu,
+                                     ImpuStore::Impu*& out_impu,
+                                     SAS::TrailId trail);
 
   // Get the ImpiMapping for this impi, by first checking the local store and
   // then any remote stores if no mapping is found in the local store.
-  // If successful, set the pointer out_mapping to be the retrieved ImpiMapping
+  // If successful, sets the pointer out_mapping to be the retrieved ImpiMapping
   // If not, does not alter mapping
   Store::Status get_impi_mapping_gr(const std::string& impi,
                                     ImpuStore::ImpiMapping*& out_mapping,

--- a/include/memcached_cache.h
+++ b/include/memcached_cache.h
@@ -370,8 +370,13 @@ private:
   ImpuStore::Impu* get_impu_for_impu_gr(const std::string& impu,
                                         SAS::TrailId trail);
 
-  ImpuStore::ImpiMapping* get_impi_mapping_gr(const std::string& impi,
-                                              SAS::TrailId trail);
+  // Get the ImpiMapping for this impi, by first checking the local store and
+  // then any remote stores if no mapping is found in the local store.
+  // If successful, set the pointer out_mapping to be the retrieved ImpiMapping
+  // If not, does not alter mapping
+  Store::Status get_impi_mapping_gr(const std::string& impi,
+                                    ImpuStore::ImpiMapping*& out_mapping,
+                                    SAS::TrailId trail);
 
   // Per Store IRS methods
 

--- a/src/impu_store.cpp
+++ b/src/impu_store.cpp
@@ -494,8 +494,9 @@ Store::Status ImpuStore::ImpiMapping::to_data(std::string& data)
   return Store::Status::OK;
 }
 
-ImpuStore::Impu* ImpuStore::get_impu(const std::string& impu,
-                                     SAS::TrailId trail)
+Store::Status ImpuStore::get_impu(const std::string& impu,
+                                  ImpuStore::Impu*& out_impu,
+                                  SAS::TrailId trail)
 {
   std::string data;
   uint64_t cas;
@@ -509,12 +510,23 @@ ImpuStore::Impu* ImpuStore::get_impu(const std::string& impu,
 
   if (status == Store::Status::OK)
   {
-    return ImpuStore::Impu::from_data(impu, data, cas, this);
+    // Use a temporary variable to hold the Impu* so that we don't change
+    // out_impu if we fail to decode the impu
+    ImpuStore::Impu* temp_impu = ImpuStore::Impu::from_data(impu, data, cas, this);
+
+    if (temp_impu == nullptr)
+    {
+      // We failed to decode the impu from the retrieved data, so just return an
+      // ERROR
+      status = Store::Status::ERROR;
+    }
+    else
+    {
+      out_impu = temp_impu;
+    }
   }
-  else
-  {
-    return nullptr;
-  }
+
+  return status;
 }
 
 Store::Status ImpuStore::set_impu_without_cas(ImpuStore::Impu* impu,

--- a/src/impu_store.cpp
+++ b/src/impu_store.cpp
@@ -619,14 +619,12 @@ Store::Status ImpuStore::get_impi_mapping(const std::string impi,
     ImpuStore::ImpiMapping* mapping = ImpuStore::ImpiMapping::from_data(impi,
                                                                         data,
                                                                         cas);
-    // LCOV_EXCL_START
     if (mapping == nullptr)
     {
       // We failed to decode the mapping from the retrieved data, so just return
       // an ERROR
       status = Store::Status::ERROR;
     }
-    // LCOV_EXCL_STOP
     else
     {
       out_mapping = mapping;

--- a/src/memcached_cache.cpp
+++ b/src/memcached_cache.cpp
@@ -550,11 +550,16 @@ Store::Status MemcachedCache::update_irs_impi_mappings(MemcachedImplicitRegistra
 
       if (status == Store::Status::DATA_CONTENTION)
       {
-        Store::Status inner_status = store->get_impi_mapping(impi, mapping, trail);
+        ImpuStore::ImpiMapping* new_mapping = nullptr;
+        Store::Status inner_status = store->get_impi_mapping(impi, new_mapping, trail);
 
         if (inner_status == Store::Status::OK)
         {
-          // We found an existing mapping so update it
+          // We found an existing mapping so delete the old one and update the
+          // one we found
+          delete mapping;
+          mapping = new_mapping;
+
           int now = time(0);
           mapping->set_expiry(irs->get_ttl() + now);
 

--- a/src/ut/impu_store_test.cpp
+++ b/src/ut/impu_store_test.cpp
@@ -453,6 +453,26 @@ TEST_F(ImpuStoreTest, ImpiMappingNotFound)
   delete local_store;
 }
 
+TEST_F(ImpuStoreTest, ImpiMappingBadJson)
+{
+  LocalStore* local_store = new LocalStore();
+  ImpuStore* impu_store = new ImpuStore(local_store);
+  local_store->set_data("impi_mapping",
+                        IMPI,
+                        INVALID_JSON,
+                        0,
+                        1,
+                        0L);
+
+  ImpuStore::ImpiMapping* mapping = nullptr;
+  Store::Status status = impu_store->get_impi_mapping(IMPI, mapping, 0L);
+  ASSERT_EQ(nullptr, mapping);
+  ASSERT_EQ(status, Store::Status::ERROR);
+
+  delete impu_store;
+  delete local_store;
+}
+
 TEST_F(ImpuStoreTest, ImpuSetWithoutCas)
 {
   LocalStore* local_store = new LocalStore();

--- a/src/ut/impu_store_test.cpp
+++ b/src/ut/impu_store_test.cpp
@@ -303,9 +303,10 @@ TEST_F(ImpuStoreTest, GetAssociatedImpiMapping)
 
   delete mapping;
 
-  ImpuStore::ImpiMapping* got_mapping =
-    impu_store->get_impi_mapping(IMPI, 0);
+  ImpuStore::ImpiMapping* got_mapping = nullptr;
+  Store::Status status = impu_store->get_impi_mapping(IMPI, got_mapping, 0);
 
+  ASSERT_EQ(status, Store::Status::OK);
   ASSERT_NE(nullptr, got_mapping);
   ASSERT_EQ(IMPI, got_mapping->impi);
   ASSERT_TRUE(got_mapping->has_default_impu(IMPU));
@@ -443,7 +444,10 @@ TEST_F(ImpuStoreTest, ImpiMappingNotFound)
   LocalStore* local_store = new LocalStore();
   ImpuStore* impu_store = new ImpuStore(local_store);
 
-  ASSERT_EQ(nullptr, impu_store->get_impi_mapping(IMPI, 0L));
+  ImpuStore::ImpiMapping* mapping = nullptr;
+  Store::Status status = impu_store->get_impi_mapping(IMPI, mapping, 0L);
+  ASSERT_EQ(nullptr, mapping);
+  ASSERT_EQ(status, Store::Status::NOT_FOUND);
 
   delete impu_store;
   delete local_store;

--- a/src/ut/impu_store_test.cpp
+++ b/src/ut/impu_store_test.cpp
@@ -140,6 +140,26 @@ TEST_F(ImpuStoreTest, SetInvalidRegistrationStateDefaultImpu)
   delete local_store;
 }
 
+TEST_F(ImpuStoreTest, GetImpuInvalidData)
+{
+  LocalStore* local_store = new LocalStore();
+  ImpuStore* impu_store = new ImpuStore(local_store);
+  local_store->set_data("impu",
+                        IMPU,
+                        INVALID_JSON,
+                        0,
+                        1,
+                        0L);
+
+  ImpuStore::Impu* impu = nullptr;
+  Store::Status status = impu_store->get_impu(IMPU, impu, 0L);
+  ASSERT_EQ(nullptr, impu);
+  ASSERT_EQ(status, Store::Status::ERROR);
+
+  delete impu_store;
+  delete local_store;
+}
+
 TEST_F(ImpuStoreTest, GetDefaultImpu)
 {
   LocalStore* local_store = new LocalStore();
@@ -161,8 +181,10 @@ TEST_F(ImpuStoreTest, GetDefaultImpu)
 
   delete default_impu;
 
-  ImpuStore::Impu* got_impu = impu_store->get_impu(IMPU.c_str(), 0L);
+  ImpuStore::Impu* got_impu = nullptr;
+  Store::Status status = impu_store->get_impu(IMPU.c_str(), got_impu, 0L);
 
+  ASSERT_EQ(status, Store::Status::OK);
   ASSERT_NE(nullptr, got_impu);
   ASSERT_EQ(IMPU, got_impu->impu);
   ASSERT_TRUE(got_impu->is_default_impu());
@@ -224,8 +246,10 @@ TEST_F(ImpuStoreTest, GetAssociatedImpu)
 
   delete assoc_impu;
 
-  ImpuStore::Impu* got_impu = impu_store->get_impu(ASSOC_IMPU, 0);
+  ImpuStore::Impu* got_impu = nullptr;
+  Store::Status status = impu_store->get_impu(ASSOC_IMPU, got_impu, 0);
 
+  ASSERT_EQ(status, Store::Status::OK);
   ASSERT_NE(nullptr, got_impu);
   ASSERT_EQ(ASSOC_IMPU, got_impu->impu);
   ASSERT_FALSE(got_impu->is_default_impu());
@@ -433,7 +457,10 @@ TEST_F(ImpuStoreTest, ImpuNotFound)
   LocalStore* local_store = new LocalStore();
   ImpuStore* impu_store = new ImpuStore(local_store);
 
-  ASSERT_EQ(nullptr, impu_store->get_impu(IMPU, 0L));
+  ImpuStore::Impu* got_impu = nullptr;
+  Store::Status status = impu_store->get_impu(IMPU, got_impu, 0L);
+  ASSERT_EQ(status, Store::Status::NOT_FOUND);
+  ASSERT_EQ(nullptr, got_impu);
 
   delete impu_store;
   delete local_store;

--- a/src/ut/mockimpustore.hpp
+++ b/src/ut/mockimpustore.hpp
@@ -1,0 +1,34 @@
+/**
+ * @file mockimpustore.h Mock HTTP connection.
+ *
+ * Copyright (C) Metaswitch Networks 2017
+ * If license terms are provided to you in a COPYING file in the root directory
+ * of the source code repository by which you are accessing this code, then
+ * the license outlined in that COPYING file applies to your use.
+ * Otherwise no rights are granted except for those provided to you by
+ * Metaswitch Networks in a separate written agreement.
+ */
+
+#ifndef MOCKIMPUSTORE_H__
+#define MOCKIMPUSTORE_H__
+
+#include "gmock/gmock.h"
+#include "impu_store.h"
+
+class MockImpuStore : public ImpuStore
+{
+public:
+  MockImpuStore() : ImpuStore(nullptr) {};
+  virtual ~MockImpuStore() {};
+
+  MOCK_METHOD2(set_impu_without_cas, Store::Status(Impu* impu, SAS::TrailId trail));
+  MOCK_METHOD2(add_impu, Store::Status(Impu* impu, SAS::TrailId trail));
+  MOCK_METHOD2(set_impu, Store::Status(Impu* impu, SAS::TrailId trail));
+  MOCK_METHOD2(get_impu, Impu*(const std::string& impu, SAS::TrailId trail));
+  MOCK_METHOD2(delete_impu, Store::Status(Impu* impu, SAS::TrailId trail));
+  MOCK_METHOD2(set_impi_mapping, Store::Status(ImpiMapping* mapping, SAS::TrailId trail));
+  MOCK_METHOD3(get_impi_mapping, Store::Status(const std::string impi, ImpiMapping*& out_mapping, SAS::TrailId trail));
+  MOCK_METHOD2(delete_impi_mapping, Store::Status(ImpiMapping* mapping, SAS::TrailId trail));
+};
+
+#endif

--- a/src/ut/mockimpustore.hpp
+++ b/src/ut/mockimpustore.hpp
@@ -1,5 +1,5 @@
 /**
- * @file mockimpustore.h Mock HTTP connection.
+ * @file mockimpustore.hpp Mock IMPU store.
  *
  * Copyright (C) Metaswitch Networks 2017
  * If license terms are provided to you in a COPYING file in the root directory
@@ -9,8 +9,8 @@
  * Metaswitch Networks in a separate written agreement.
  */
 
-#ifndef MOCKIMPUSTORE_H__
-#define MOCKIMPUSTORE_H__
+#ifndef MOCKIMPUSTORE_HPP__
+#define MOCKIMPUSTORE_HPP__
 
 #include "gmock/gmock.h"
 #include "impu_store.h"


### PR DESCRIPTION
This is a fix for: https://github.com/Metaswitch/clearwater-issues/issues/2627

There's an explanation in the issue as to what was happening, so not going to duplicate that here.

The fix is to allow `get_impi_mapping` to return a `Store::Status` (it now also takes an `ImpiMapping*` as an argument, which it sets if it succeeds).

This allows us to check why getting an ImpiMapping failed, because we want to treat NOT_FOUND differently from ERROR.

I've also added a MockImpuStore, as I needed it for the UTs I added.

`make full_test` passes.

As discussed, if this approach looks good, I'll make the corresponding change to the `get_impu_*` functions too, as those should really be treating ERROR and NOT_FOUND differently too.