### PR TITLE
[Reviewer: Seb] Downgrade error log which is already SAS logged

### DIFF
--- a/src/memcached_cache.cpp
+++ b/src/memcached_cache.cpp
@@ -437,7 +437,7 @@ Store::Status MemcachedCache::perform(MemcachedCache::store_action action,
        if (inner_status != Store::Status::OK)
        {
          // Nothing we can do, but log the error
-         TRC_ERROR("Failed to perform operation to remote store with error %d",
+         TRC_DEBUG("Failed to perform operation to remote store with error %d",
                    inner_status);
        }
      }


### PR DESCRIPTION
We'll get memcached SAS logs here, so I'm not concerned about the lack of diagnostics in this case, and in the event of a GR site failure, it's just spam.