### PR TITLE
[Reviewer: Richard] Don't track cache and HSS latency as part of our HTTP request latency

### DIFF
--- a/include/base_hss_cache.h
+++ b/include/base_hss_cache.h
@@ -20,21 +20,25 @@ public:
   // Used for RTR when we have a list of impus
   virtual Store::Status get_implicit_registration_sets_for_impis(const std::vector<std::string>& impis,
                                                                  SAS::TrailId trail,
-                                                                 std::vector<ImplicitRegistrationSet*>& result);
+                                                                 Utils::StopWatch* stopwatch,
+                                                                 std::vector<ImplicitRegistrationSet*>& result) override;
 
   // Get the list of IRSs for the given list of imps
   // Used for RTR when we have a list of impis
   virtual Store::Status get_implicit_registration_sets_for_impus(const std::vector<std::string>& impus,
                                                                  SAS::TrailId trail,
-                                                                 std::vector<ImplicitRegistrationSet*>& result);
+                                                                 Utils::StopWatch* stopwatch,
+                                                                 std::vector<ImplicitRegistrationSet*>& result) override;
 
 protected:
   virtual Store::Status get_implicit_registration_sets_for_impi(const std::string& impi,
                                                                 SAS::TrailId trail,
+                                                                Utils::StopWatch* stopwatch,
                                                                 std::vector<ImplicitRegistrationSet*>& result);
 
   virtual Store::Status get_impus_for_impi(const std::string& impi,
                                            SAS::TrailId trail,
+                                           Utils::StopWatch* stopwatch,
                                            std::vector<std::string>& impus) = 0;
 };
 

--- a/include/diameter_hss_connection.h
+++ b/include/diameter_hss_connection.h
@@ -92,12 +92,14 @@ private:
                         StatsFlags stat_updates,
                         callback_t response_clbk,
                         SNMP::CxCounterTable* cx_results_tbl,
-                        StatisticsManager* stats_manager) :
+                        StatisticsManager* stats_manager,
+                        Utils::StopWatch* stopwatch) :
       Diameter::Transaction(dict, trail),
       _stat_updates(stat_updates),
       _response_clbk(response_clbk),
       _cx_results_tbl(cx_results_tbl),
-      _stats_manager(stats_manager)
+      _stats_manager(stats_manager),
+      _stopwatch(stopwatch)
     {};
 
   protected:
@@ -105,6 +107,7 @@ private:
     callback_t _response_clbk;
     SNMP::CxCounterTable* _cx_results_tbl;
     StatisticsManager* _stats_manager;
+    Utils::StopWatch* _stopwatch;
 
     // Implementations will use this to create the correct answer
     virtual AnswerType create_answer(Diameter::Message& rsp) = 0;

--- a/include/diameter_hss_connection.h
+++ b/include/diameter_hss_connection.h
@@ -52,22 +52,26 @@ public:
   // Send a multimedia auth request to the HSS
   virtual void send_multimedia_auth_request(maa_cb callback,
                                             MultimediaAuthRequest request,
-                                            SAS::TrailId trail);
+                                            SAS::TrailId trail,
+                                            Utils::StopWatch* stopwatch);
 
   // Send a user auth request to the HSS
   virtual void send_user_auth_request(uaa_cb callback,
                                       UserAuthRequest request,
-                                      SAS::TrailId trail);
+                                      SAS::TrailId trail,
+                                      Utils::StopWatch* stopwatch);
 
   // Send a location info request to the HSS
   virtual void send_location_info_request(lia_cb callback,
                                           LocationInfoRequest request,
-                                          SAS::TrailId trail);
+                                          SAS::TrailId trail,
+                                          Utils::StopWatch* stopwatch);
 
   // Send a server assignment request to the HSS
   virtual void send_server_assignment_request(saa_cb callback,
                                               ServerAssignmentRequest request,
-                                              SAS::TrailId trail);
+                                              SAS::TrailId trail,
+                                              Utils::StopWatch* stopwatch);
 
 private:
   Cx::Dictionary* _dict;

--- a/include/hsprov_hss_connection.h
+++ b/include/hsprov_hss_connection.h
@@ -28,22 +28,26 @@ public:
   // Send a multimedia auth request to the HSS
   virtual void send_multimedia_auth_request(maa_cb callback,
                                             MultimediaAuthRequest request,
-                                            SAS::TrailId trail) override;
+                                            SAS::TrailId trail,
+                                            Utils::StopWatch* stopwatch) override;
 
   // Send a user auth request to the HSS
   virtual void send_user_auth_request(uaa_cb callback,
                                       UserAuthRequest request,
-                                      SAS::TrailId trail) override;
+                                      SAS::TrailId trail,
+                                      Utils::StopWatch* stopwatch) override;
 
   // Send a location info request to the HSS
   virtual void send_location_info_request(lia_cb callback,
                                           LocationInfoRequest request,
-                                          SAS::TrailId trail) override;
+                                          SAS::TrailId trail,
+                                          Utils::StopWatch* stopwatch) override;
 
   // Send a server assignment request to the HSS
   virtual void send_server_assignment_request(saa_cb callback,
                                               ServerAssignmentRequest request,
-                                              SAS::TrailId trail) override;
+                                              SAS::TrailId trail,
+                                              Utils::StopWatch* stopwatch) override;
 
   template <class AnswerType>
   class HsProvTransaction : public CassandraStore::Transaction

--- a/include/hss_cache.h
+++ b/include/hss_cache.h
@@ -17,6 +17,7 @@
 #include <string>
 #include "ims_subscription.h"
 #include "implicit_reg_set.h"
+#include "utils.h"
 
 // The purpose of the progress_callback is explained in hss_cache_processor.h
 typedef std::function<void()> progress_callback;
@@ -31,6 +32,7 @@ public:
   // All of these methods are synchronous, and run on a thread that is OK to block
   // They return Store::Status (from cpp-common's Store) which is used to determine which callback to use
   // If they are getting/listing data, the data is put into the supplied datastructure
+  // If a StopWatch* is provided, it will be paused when the cache is performing network I/O.
 
   // Create an IRS
   virtual ImplicitRegistrationSet* create_implicit_registration_set() = 0;
@@ -38,48 +40,56 @@ public:
   // Get the IRS for a given impu
   virtual Store::Status get_implicit_registration_set_for_impu(const std::string& impu,
                                                                SAS::TrailId trail,
+                                                               Utils::StopWatch* stopwatch,
                                                                ImplicitRegistrationSet*& result) = 0;
 
   // Get the list of IRSs for the given list of impus
   // Used for RTR when we have a list of impus
   virtual Store::Status get_implicit_registration_sets_for_impis(const std::vector<std::string>& impis,
                                                                  SAS::TrailId trail,
+                                                                 Utils::StopWatch* stopwatch,
                                                                  std::vector<ImplicitRegistrationSet*>& result) = 0;
 
   // Get the list of IRSs for the given list of imps
   // Used for RTR when we have a list of impis
   virtual Store::Status get_implicit_registration_sets_for_impus(const std::vector<std::string>& impus,
                                                                  SAS::TrailId trail,
+                                                                 Utils::StopWatch* stopwatch,
                                                                  std::vector<ImplicitRegistrationSet*>& result) = 0;
 
   // Save the IRS in the cache
   // Must include updating the impi mapping table if impis have been added
   virtual Store::Status put_implicit_registration_set(ImplicitRegistrationSet* irs,
                                                       progress_callback progress_cb,
-                                                      SAS::TrailId trail) = 0;
+                                                      SAS::TrailId trail,
+                                                      Utils::StopWatch* stopwatch) = 0;
 
   // Used for de-registration
   virtual Store::Status delete_implicit_registration_set(ImplicitRegistrationSet* irs,
                                                          progress_callback progress_cb,
-                                                         SAS::TrailId trail) = 0;
+                                                         SAS::TrailId trail,
+                                                         Utils::StopWatch* stopwatch) = 0;
 
   // Deletes several registration sets
   // Used for an RTR when we have several registration sets to delete
   virtual Store::Status delete_implicit_registration_sets(const std::vector<ImplicitRegistrationSet*>& irss,
                                                           progress_callback progress_cb,
-                                                          SAS::TrailId trail) = 0;
+                                                          SAS::TrailId trail,
+                                                          Utils::StopWatch* stopwatch) = 0;
 
   // Gets the whole IMS subscription for this impi
   // This is used when we get a PPR, and we have to update charging functions
   // as we'll need to updated every IRS that we've stored
   virtual Store::Status get_ims_subscription(const std::string& impi,
                                              SAS::TrailId trail,
+                                             Utils::StopWatch* stopwatch,
                                              ImsSubscription*& result) = 0;
 
   // This is used to save the state that we changed in the PPR
   virtual Store::Status put_ims_subscription(ImsSubscription* subscription,
                                              progress_callback progress_cb,
-                                             SAS::TrailId trail) = 0;
+                                             SAS::TrailId trail,
+                                             Utils::StopWatch* stopwatch) = 0;
 };
 
 #endif

--- a/include/hss_cache_processor.h
+++ b/include/hss_cache_processor.h
@@ -70,27 +70,34 @@ public:
   // If the request fails, the Store::Status code is provided as an argument to
   // the failure callback. The progress callback will not be called in a failure
   // scenario, so the failure callback must delete any put/deleted data.
+  //
+  // All requests optionally take a StopWatch*, which is passed to the HssCache
+  // to allow it to pause the StopWatch when performing network I/O that
+  // shouldn't count towards request latency.
   // ---------------------------------------------------------------------------
 
   // Get the IRS for a given impu
   virtual void get_implicit_registration_set_for_impu(irs_success_callback success_cb,
                                                       failure_callback failure_cb,
                                                       std::string impu,
-                                                      SAS::TrailId trail);
+                                                      SAS::TrailId trail,
+                                                      Utils::StopWatch* stopwatch);
 
   // Get the list of IRSs for the given list of impus
   // Used for RTR when we have a list of impus
   virtual void get_implicit_registration_sets_for_impis(irs_vector_success_callback success_cb,
                                                         failure_callback failure_cb,
                                                         std::vector<std::string> impis,
-                                                        SAS::TrailId trail);
+                                                        SAS::TrailId trail,
+                                                        Utils::StopWatch* stopwatch);
 
   // Get the list of IRSs for the given list of imps
   // Used for RTR when we have a list of impis
   virtual void get_implicit_registration_sets_for_impus(irs_vector_success_callback success_cb,
                                                         failure_callback failure_cb,
                                                         std::vector<std::string> impus,
-                                                        SAS::TrailId trail);
+                                                        SAS::TrailId trail,
+                                                        Utils::StopWatch* stopwatch);
 
   // Save the IRS in the cache
   // Must include updating the impi mapping table if impis have been added
@@ -98,14 +105,16 @@ public:
                                              progress_callback progress_cb,
                                              failure_callback failure_cb,
                                              ImplicitRegistrationSet* irs,
-                                             SAS::TrailId trail);
+                                             SAS::TrailId trail,
+                                             Utils::StopWatch* stopwatch);
 
   // Used for de-registration
   virtual void delete_implicit_registration_set(void_success_cb success_cb,
                                                 progress_callback progress_cb,
                                                 failure_callback failure_cb,
                                                 ImplicitRegistrationSet* irs,
-                                                SAS::TrailId trail);
+                                                SAS::TrailId trail,
+                                                Utils::StopWatch* stopwatch);
 
   // Deletes several registration sets
   // Used for an RTR when we have several registration sets to delete
@@ -113,7 +122,8 @@ public:
                                                  progress_callback progress_cb,
                                                  failure_callback failure_cb,
                                                  std::vector<ImplicitRegistrationSet*> irss,
-                                                 SAS::TrailId trail);
+                                                 SAS::TrailId trail,
+                                                 Utils::StopWatch* stopwatch);
 
   // Gets the whole IMS subscription for this impi
   // This is used when we get a PPR, and we have to update charging functions
@@ -121,14 +131,16 @@ public:
   virtual void get_ims_subscription(ims_sub_success_cb success_cb,
                                     failure_callback failure_cb,
                                     std::string impi,
-                                    SAS::TrailId trail);
+                                    SAS::TrailId trail,
+                                    Utils::StopWatch* stopwatch);
 
   // This is used to save the state that we changed in the PPR
   virtual void put_ims_subscription(void_success_cb success_cb,
                                     progress_callback progress_cb,
                                     failure_callback failure_cb,
                                     ImsSubscription* subscription,
-                                    SAS::TrailId trail);
+                                    SAS::TrailId trail,
+                                    Utils::StopWatch* stopwatch);
 
 private:
   // Dummy exception handler callback for the thread pool

--- a/include/hss_connection.h
+++ b/include/hss_connection.h
@@ -18,6 +18,7 @@
 #include "servercapabilities.h"
 #include "charging_addresses.h"
 #include "statisticsmanager.h"
+#include "utils.h"
 
 namespace HssConnection {
 
@@ -305,27 +306,33 @@ public:
   // Ownership of the response objects passed to the callbacks is delegated to
   // the callback target. It's the responsibility of the callback to delete the
   // object when it is done with it.
+  // Each method also takes a StopWatch, which it will pause when performing
+  // network I/O.
   // ---------------------------------------------------------------------------
 
   // Send a multimedia auth request to the HSS
   virtual void send_multimedia_auth_request(maa_cb callback,
                                             MultimediaAuthRequest request,
-                                            SAS::TrailId trail) = 0;
+                                            SAS::TrailId trail,
+                                            Utils::StopWatch* stopwatch) = 0;
 
   // Send a user auth request to the HSS
   virtual void send_user_auth_request(uaa_cb callback,
                                       UserAuthRequest request,
-                                      SAS::TrailId trail) = 0;
+                                      SAS::TrailId trail,
+                                      Utils::StopWatch* stopwatch) = 0;
 
   // Send a location info request to the HSS
   virtual void send_location_info_request(lia_cb callback,
                                           LocationInfoRequest request,
-                                          SAS::TrailId trail) = 0;
+                                          SAS::TrailId trail,
+                                          Utils::StopWatch* stopwatch) = 0;
 
   // Send a server assignment request to the HSS
   virtual void send_server_assignment_request(saa_cb callback,
                                               ServerAssignmentRequest request,
-                                              SAS::TrailId trail) = 0;
+                                              SAS::TrailId trail,
+                                              Utils::StopWatch* stopwatch) = 0;
 
   static void configure_auth_schemes(const std::string& scheme_digest,
                                      const std::string& scheme_akav1,

--- a/include/memcached_cache.h
+++ b/include/memcached_cache.h
@@ -394,12 +394,15 @@ private:
 
   // Per Store IRS methods
 
-  typedef std::function<Store::Status(ImpuStore*)> store_action;
+  typedef std::function<Store::Status(ImpuStore*, Utils::StopWatch*)> store_action;
 
   // Performs the action on each store, calling the progress_cb once the action
   // has been performed on the local store
+  // If a StopWatch is provided, it will be paused when performing network I/O
+  // for the local store, but not for the remotes.
   Store::Status perform(store_action action,
-                        progress_callback progress_cb);
+                        progress_callback progress_cb,
+                        Utils::StopWatch* stopwatch);
 
   Store::Status put_irs_action(MemcachedImplicitRegistrationSet* irs,
                                SAS::TrailId trail,

--- a/include/memcached_cache.h
+++ b/include/memcached_cache.h
@@ -326,40 +326,47 @@ public:
   // Get the IRS for a given IMPU
   virtual Store::Status get_implicit_registration_set_for_impu(const std::string& impu,
                                                                SAS::TrailId trail,
+                                                               Utils::StopWatch* stopwatch,
                                                                ImplicitRegistrationSet*& result) override;
 
   // Save the IRS in the cache
   // Must include updating the impi mapping table if impis have been added
   virtual Store::Status put_implicit_registration_set(ImplicitRegistrationSet* irs,
                                                       progress_callback progress_cb,
-                                                      SAS::TrailId trail) override;
+                                                      SAS::TrailId trail,
+                                                      Utils::StopWatch* stopwatch) override;
 
   // Used for de-registration
   virtual Store::Status delete_implicit_registration_set(ImplicitRegistrationSet* irs,
                                                          progress_callback progress_cb,
-                                                         SAS::TrailId trail) override;
+                                                         SAS::TrailId trail,
+                                                         Utils::StopWatch* stopwatch) override;
 
   // Used for RTRs
   virtual Store::Status delete_implicit_registration_sets(const std::vector<ImplicitRegistrationSet*>& irss,
                                                           progress_callback progress_cb,
-                                                          SAS::TrailId trail) override;
+                                                          SAS::TrailId trail,
+                                                          Utils::StopWatch* stopwatch) override;
 
   // Gets the whole IMS subscription for this impi
   // This is used when we get a PPR, and we have to update charging functions
   // as we'll need to updated every IRS that we've stored
   virtual Store::Status get_ims_subscription(const std::string& impi,
                                              SAS::TrailId trail,
+                                             Utils::StopWatch* stopwatch,
                                              ImsSubscription*& result) override;
 
   // This is used to save the state that we changed in the PPR
   virtual Store::Status put_ims_subscription(ImsSubscription* subscription,
                                              progress_callback progress_cb,
-                                             SAS::TrailId trail) override;
+                                             SAS::TrailId trail,
+                                             Utils::StopWatch* stopwatch) override;
 
 protected:
   // Base HSS Cache methods
   virtual Store::Status get_impus_for_impi(const std::string& impi,
                                            SAS::TrailId trail,
+                                           Utils::StopWatch* stopwatch,
                                            std::vector<std::string>& impus);
 
 private:
@@ -373,7 +380,8 @@ private:
   // If not, does not alter out_impu.
   Store::Status get_impu_for_impu_gr(const std::string& impu,
                                      ImpuStore::Impu*& out_impu,
-                                     SAS::TrailId trail);
+                                     SAS::TrailId trail,
+                                     Utils::StopWatch* stopwatch);
 
   // Get the ImpiMapping for this impi, by first checking the local store and
   // then any remote stores if no mapping is found in the local store.
@@ -381,7 +389,8 @@ private:
   // If not, does not alter mapping
   Store::Status get_impi_mapping_gr(const std::string& impi,
                                     ImpuStore::ImpiMapping*& out_mapping,
-                                    SAS::TrailId trail);
+                                    SAS::TrailId trail,
+                                    Utils::StopWatch* stopwatch);
 
   // Per Store IRS methods
 
@@ -394,45 +403,54 @@ private:
 
   Store::Status put_irs_action(MemcachedImplicitRegistrationSet* irs,
                                SAS::TrailId trail,
-                               ImpuStore* store);
+                               ImpuStore* store,
+                               Utils::StopWatch* stopwatch);
 
   Store::Status delete_irs_action(MemcachedImplicitRegistrationSet* irs,
                                   SAS::TrailId trail,
-                                  ImpuStore* store);
+                                  ImpuStore* store,
+                                  Utils::StopWatch* stopwatch);
 
   Store::Status delete_irss_action(const std::vector<ImplicitRegistrationSet*>& irss,
                                    SAS::TrailId trail,
-                                   ImpuStore* store);
+                                   ImpuStore* store,
+                                   Utils::StopWatch* stopwatch);
 
   Store::Status put_ims_sub_action(ImsSubscription* subscription,
                                    SAS::TrailId trail,
-                                   ImpuStore* store);
+                                   ImpuStore* store,
+                                   Utils::StopWatch* stopwatch);
 
   // IRS IMPU handling methods
 
   Store::Status create_irs_impu(MemcachedImplicitRegistrationSet* irs,
                                 SAS::TrailId trail,
-                                ImpuStore* store);
+                                ImpuStore* store,
+                                Utils::StopWatch* stopwatch);
 
   Store::Status update_irs_impu(MemcachedImplicitRegistrationSet* irs,
                                 SAS::TrailId trail,
-                                ImpuStore* store);
+                                ImpuStore* store,
+                                Utils::StopWatch* stopwatch);
 
   Store::Status delete_irs_impu(MemcachedImplicitRegistrationSet* irs,
                                 SAS::TrailId trail,
-                                ImpuStore* store);
+                                ImpuStore* store,
+                                Utils::StopWatch* stopwatch);
 
   // Associated IMPU handling
 
   Store::Status update_irs_associated_impus(MemcachedImplicitRegistrationSet* irs,
-                                              SAS::TrailId trail,
-                                              ImpuStore* store);
+                                            SAS::TrailId trail,
+                                            ImpuStore* store,
+                                            Utils::StopWatch* stopwatch);
 
   // IMPI Mapping Handling
 
   Store::Status update_irs_impi_mappings(MemcachedImplicitRegistrationSet* irs,
-                                              SAS::TrailId trail,
-                                              ImpuStore* store);
+                                         SAS::TrailId trail,
+                                         ImpuStore* store,
+                                         Utils::StopWatch* stopwatch);
 };
 
 #endif

--- a/src/base_hss_cache.cpp
+++ b/src/base_hss_cache.cpp
@@ -12,15 +12,16 @@
 
 Store::Status BaseHssCache::get_implicit_registration_sets_for_impi(const std::string& impi,
                                                                 SAS::TrailId trail,
+                                                                Utils::StopWatch* stopwatch,
                                                                 std::vector<ImplicitRegistrationSet*>& result)
 {
   std::vector<std::string> impus;
 
-  Store::Status status = get_impus_for_impi(impi, trail, impus);
+  Store::Status status = get_impus_for_impi(impi, trail, stopwatch, impus);
 
   if (status == Store::Status::OK)
   {
-    status = BaseHssCache::get_implicit_registration_sets_for_impus(impus, trail, result);
+    status = BaseHssCache::get_implicit_registration_sets_for_impus(impus, trail, stopwatch, result);
   }
 
   return status;
@@ -28,6 +29,7 @@ Store::Status BaseHssCache::get_implicit_registration_sets_for_impi(const std::s
 
 Store::Status BaseHssCache::get_implicit_registration_sets_for_impus(const std::vector<std::string>& impus,
                                                                      SAS::TrailId trail,
+                                                                     Utils::StopWatch* stopwatch,
                                                                      std::vector<ImplicitRegistrationSet*>& result)
 {
   Store::Status status = Store::Status::OK;
@@ -35,7 +37,7 @@ Store::Status BaseHssCache::get_implicit_registration_sets_for_impus(const std::
   for (const std::string& impu : impus)
   {
     ImplicitRegistrationSet* irs;
-    Store::Status inner_status = get_implicit_registration_set_for_impu(impu, trail, irs);
+    Store::Status inner_status = get_implicit_registration_set_for_impu(impu, trail, stopwatch, irs);
 
     if (inner_status == Store::Status::OK)
     {
@@ -70,6 +72,7 @@ Store::Status BaseHssCache::get_implicit_registration_sets_for_impus(const std::
 
 Store::Status BaseHssCache::get_implicit_registration_sets_for_impis(const std::vector<std::string>& impis,
                                                                      SAS::TrailId trail,
+                                                                     Utils::StopWatch* stopwatch,
                                                                      std::vector<ImplicitRegistrationSet*>& result)
 {
   Store::Status status = Store::Status::OK;
@@ -77,7 +80,7 @@ Store::Status BaseHssCache::get_implicit_registration_sets_for_impis(const std::
   for (const std::string& impi : impis)
   {
     std::vector<ImplicitRegistrationSet*> inner_result;
-    Store::Status inner_status = get_implicit_registration_sets_for_impi(impi, trail, inner_result);
+    Store::Status inner_status = get_implicit_registration_sets_for_impi(impi, trail, stopwatch, inner_result);
 
     if (inner_status == Store::Status::OK)
     {

--- a/src/diameter_handlers.cpp
+++ b/src/diameter_handlers.cpp
@@ -113,7 +113,8 @@ void RegistrationTerminationTask::run()
     _cfg->cache->get_implicit_registration_sets_for_impis(success_cb,
                                                           failure_cb,
                                                           _impis,
-                                                          this->trail());
+                                                          this->trail(),
+                                                          nullptr);
   }
   else if ((!_impus.empty()) && ((_deregistration_reason == PERMANENT_TERMINATION) ||
                                  (_deregistration_reason == REMOVE_SCSCF)))
@@ -130,7 +131,8 @@ void RegistrationTerminationTask::run()
     _cfg->cache->get_implicit_registration_sets_for_impus(success_cb,
                                                           failure_cb,
                                                           _impus,
-                                                          this->trail());
+                                                          this->trail(),
+                                                          nullptr);
   }
   else
   {
@@ -256,7 +258,7 @@ void RegistrationTerminationTask::get_registration_sets_success(std::vector<Impl
     failure_callback failure_cb =
       std::bind(&RegistrationTerminationTask::delete_reg_sets_failure, this, _1);
 
-    _cfg->cache->delete_implicit_registration_sets(success_cb, progress_cb, failure_cb, _reg_sets, this->trail());
+    _cfg->cache->delete_implicit_registration_sets(success_cb, progress_cb, failure_cb, _reg_sets, this->trail(), nullptr);
   }
 }
 
@@ -354,7 +356,7 @@ void PushProfileTask::run()
     failure_callback failure_cb =
       std::bind(&PushProfileTask::on_get_ims_sub_failure, this, _1);
 
-    _cfg->cache->get_ims_subscription(success_cb, failure_cb, _impi, this->trail());
+    _cfg->cache->get_ims_subscription(success_cb, failure_cb, _impi, this->trail(), nullptr);
   }
 }
 
@@ -482,7 +484,7 @@ void PushProfileTask::on_get_ims_sub_success(ImsSubscription* ims_sub)
   failure_callback failure_cb =
     std::bind(&PushProfileTask::on_save_ims_sub_failure, this, _1);
 
-  _cfg->cache->put_ims_subscription(success_cb, progress_cb, failure_cb, _ims_sub, this->trail());
+  _cfg->cache->put_ims_subscription(success_cb, progress_cb, failure_cb, _ims_sub, this->trail(), nullptr);
 }
 
 void PushProfileTask::on_get_ims_sub_failure(Store::Status rc)

--- a/src/diameter_hss_connection.cpp
+++ b/src/diameter_hss_connection.cpp
@@ -402,7 +402,8 @@ DiameterHssConnection::DiameterHssConnection(StatisticsManager* stats_manager,
 // Send a multimedia auth request to the HSS
 void DiameterHssConnection::send_multimedia_auth_request(maa_cb callback,
                                                          MultimediaAuthRequest request,
-                                                         SAS::TrailId trail)
+                                                         SAS::TrailId trail,
+                                                         Utils::StopWatch* stopwatch)
 {
   // Transactions are deleted in the DiameterStack's on_response or or_timeout,
   // so we don't have to delete this after sending
@@ -425,7 +426,8 @@ void DiameterHssConnection::send_multimedia_auth_request(maa_cb callback,
 // Send a user auth request to the HSS
 void DiameterHssConnection::send_user_auth_request(uaa_cb callback,
                                                    UserAuthRequest request,
-                                                   SAS::TrailId trail)
+                                                   SAS::TrailId trail,
+                                                   Utils::StopWatch* stopwatch)
 {
   // Transactions are deleted in the DiameterStack's on_response or or_timeout,
   // so we don't have to delete this after sending
@@ -448,7 +450,8 @@ void DiameterHssConnection::send_user_auth_request(uaa_cb callback,
 // Send a location info request to the HSS
 void DiameterHssConnection::send_location_info_request(lia_cb callback,
                                                        LocationInfoRequest request,
-                                                       SAS::TrailId trail)
+                                                       SAS::TrailId trail,
+                                                       Utils::StopWatch* stopwatch)
 {
   LirDiameterTransaction* tsx =
     new LirDiameterTransaction(_dict, trail, SUBSCRIPTION_STATS, callback, lir_results_tbl, _stats_manager);
@@ -467,7 +470,8 @@ void DiameterHssConnection::send_location_info_request(lia_cb callback,
 // Send a server assignment request to the HSS
 void DiameterHssConnection::send_server_assignment_request(saa_cb callback,
                                                            ServerAssignmentRequest request,
-                                                           SAS::TrailId trail)
+                                                           SAS::TrailId trail,
+                                                           Utils::StopWatch* stopwatch)
 {
   // Transactions are deleted in the DiameterStack's on_response or or_timeout,
   // so we don't have to delete this after sending

--- a/src/hsprov_hss_connection.cpp
+++ b/src/hsprov_hss_connection.cpp
@@ -205,7 +205,8 @@ HsProvHssConnection::HsProvHssConnection(StatisticsManager* stats_manager,
 // Send a multimedia auth request to the HSS
 void HsProvHssConnection::send_multimedia_auth_request(maa_cb callback,
                                                        MultimediaAuthRequest request,
-                                                       SAS::TrailId trail)
+                                                       SAS::TrailId trail,
+                                                       Utils::StopWatch* stopwatch)
 {
   SAS::Event event(trail, SASEvent::HSPROV_GET_AV, 0);
   event.add_var_param(request.impi);
@@ -226,7 +227,8 @@ void HsProvHssConnection::send_multimedia_auth_request(maa_cb callback,
 // Send a user auth request to the HSS
 void HsProvHssConnection::send_user_auth_request(uaa_cb callback,
                                                  UserAuthRequest request,
-                                                 SAS::TrailId trail)
+                                                 SAS::TrailId trail,
+                                                 Utils::StopWatch* stopwatch)
 {
   SAS::Event event(trail, SASEvent::ICSCF_NO_HSS, 0);
   SAS::report_event(event);
@@ -244,7 +246,8 @@ void HsProvHssConnection::send_user_auth_request(uaa_cb callback,
 // Send a location info request to the HSS
 void HsProvHssConnection::send_location_info_request(lia_cb callback,
                                                      LocationInfoRequest request,
-                                                     SAS::TrailId trail)
+                                                     SAS::TrailId trail,
+                                                     Utils::StopWatch* stopwatch)
 {
   SAS::Event event(trail, SASEvent::ICSCF_NO_HSS_CHECK_CASSANDRA, 0);
   SAS::report_event(event);
@@ -263,7 +266,8 @@ void HsProvHssConnection::send_location_info_request(lia_cb callback,
 // Send a server assignment request to the HSS
 void HsProvHssConnection::send_server_assignment_request(saa_cb callback,
                                                          ServerAssignmentRequest request,
-                                                         SAS::TrailId trail)
+                                                         SAS::TrailId trail,
+                                                         Utils::StopWatch* stopwatch)
 {
   if ((request.type == Cx::ServerAssignmentType::REGISTRATION) ||
       (request.type == Cx::ServerAssignmentType::RE_REGISTRATION) ||

--- a/src/hss_cache_processor.cpp
+++ b/src/hss_cache_processor.cpp
@@ -63,15 +63,17 @@ ImplicitRegistrationSet* HssCacheProcessor::create_implicit_registration_set()
 void HssCacheProcessor::get_implicit_registration_set_for_impu(irs_success_callback success_cb,
                                                                 failure_callback failure_cb,
                                                                 std::string impu,
-                                                                SAS::TrailId trail)
+                                                                SAS::TrailId trail,
+                                                                Utils::StopWatch* stopwatch)
 {
   // Create a work item that can run on the thread pool, capturing required
   // variables to complete the work
-  std::function<void()> work = [this, impu, trail, success_cb, failure_cb]()->void
+  std::function<void()> work = [this, impu, trail, success_cb, failure_cb, stopwatch]()->void
   {
     ImplicitRegistrationSet* result = NULL;
     Store::Status rc = _cache->get_implicit_registration_set_for_impu(impu,
                                                                       trail,
+                                                                      stopwatch,
                                                                       result);
 
     if (rc == Store::Status::OK)
@@ -91,15 +93,17 @@ void HssCacheProcessor::get_implicit_registration_set_for_impu(irs_success_callb
 void HssCacheProcessor::get_implicit_registration_sets_for_impis(irs_vector_success_callback success_cb,
                                                                  failure_callback failure_cb,
                                                                  std::vector<std::string> impis,
-                                                                 SAS::TrailId trail)
+                                                                 SAS::TrailId trail,
+                                                                 Utils::StopWatch* stopwatch)
 {
   // Create a work item that can run on the thread pool, capturing required
   // variables to complete the work
-  std::function<void()> work = [this, impis, trail, success_cb, failure_cb]()->void
+  std::function<void()> work = [this, impis, trail, success_cb, failure_cb, stopwatch]()->void
   {
     std::vector<ImplicitRegistrationSet*> result;
     Store::Status rc = _cache->get_implicit_registration_sets_for_impis(impis,
                                                                         trail,
+                                                                        stopwatch,
                                                                         result);
 
     if (rc == Store::Status::OK)
@@ -119,15 +123,17 @@ void HssCacheProcessor::get_implicit_registration_sets_for_impis(irs_vector_succ
 void HssCacheProcessor::get_implicit_registration_sets_for_impus(irs_vector_success_callback success_cb,
                                                                  failure_callback failure_cb,
                                                                  std::vector<std::string> impus,
-                                                                 SAS::TrailId trail)
+                                                                 SAS::TrailId trail,
+                                                                 Utils::StopWatch* stopwatch)
 {
   // Create a work item that can run on the thread pool, capturing required
   // variables to complete the work
-  std::function<void()> work = [this, impus, trail, success_cb, failure_cb]()->void
+  std::function<void()> work = [this, impus, trail, success_cb, failure_cb, stopwatch]()->void
   {
     std::vector<ImplicitRegistrationSet*> result;
     Store::Status rc = _cache->get_implicit_registration_sets_for_impus(impus,
                                                                         trail,
+                                                                        stopwatch,
                                                                         result);
 
     if (rc == Store::Status::OK)
@@ -148,13 +154,14 @@ void HssCacheProcessor::put_implicit_registration_set(void_success_cb success_cb
                                                       progress_callback progress_cb,
                                                       failure_callback failure_cb,
                                                       ImplicitRegistrationSet* irs,
-                                                      SAS::TrailId trail)
+                                                      SAS::TrailId trail,
+                                                      Utils::StopWatch* stopwatch)
 {
   // Create a work item that can run on the thread pool, capturing required
   // variables to complete the work
-  std::function<void()> work = [this, irs, trail, success_cb, progress_cb, failure_cb]()->void
+  std::function<void()> work = [this, irs, trail, success_cb, progress_cb, failure_cb, stopwatch]()->void
   {
-    Store::Status rc = _cache->put_implicit_registration_set(irs, progress_cb, trail);
+    Store::Status rc = _cache->put_implicit_registration_set(irs, progress_cb, trail, stopwatch);
 
     if (rc == Store::Status::OK)
     {
@@ -174,13 +181,14 @@ void HssCacheProcessor::delete_implicit_registration_set(void_success_cb success
                                                          progress_callback progress_cb,
                                                          failure_callback failure_cb,
                                                          ImplicitRegistrationSet* irs,
-                                                         SAS::TrailId trail)
+                                                         SAS::TrailId trail,
+                                                         Utils::StopWatch* stopwatch)
 {
   // Create a work item that can run on the thread pool, capturing required
   // variables to complete the work
-  std::function<void()> work = [this, irs, trail, success_cb, progress_cb, failure_cb]()->void
+  std::function<void()> work = [this, irs, trail, success_cb, progress_cb, failure_cb, stopwatch]()->void
   {
-    Store::Status rc = _cache->delete_implicit_registration_set(irs, progress_cb, trail);
+    Store::Status rc = _cache->delete_implicit_registration_set(irs, progress_cb, trail, stopwatch);
 
     if (rc == Store::Status::OK)
     {
@@ -200,13 +208,14 @@ void HssCacheProcessor::delete_implicit_registration_sets(void_success_cb succes
                                                           progress_callback progress_cb,
                                                           failure_callback failure_cb,
                                                           std::vector<ImplicitRegistrationSet*> irss,
-                                                          SAS::TrailId trail)
+                                                          SAS::TrailId trail,
+                                                          Utils::StopWatch* stopwatch)
 {
   // Create a work item that can run on the thread pool, capturing required
   // variables to complete the work
-  std::function<void()> work = [this, irss, trail, success_cb, progress_cb, failure_cb]()->void
+  std::function<void()> work = [this, irss, trail, success_cb, progress_cb, failure_cb, stopwatch]()->void
   {
-    Store::Status rc = _cache->delete_implicit_registration_sets(irss, progress_cb, trail);
+    Store::Status rc = _cache->delete_implicit_registration_sets(irss, progress_cb, trail, stopwatch);
 
     if (rc == Store::Status::OK)
     {
@@ -225,14 +234,15 @@ void HssCacheProcessor::delete_implicit_registration_sets(void_success_cb succes
 void HssCacheProcessor::get_ims_subscription(ims_sub_success_cb success_cb,
                                              failure_callback failure_cb,
                                              std::string impi,
-                                             SAS::TrailId trail)
+                                             SAS::TrailId trail,
+                                             Utils::StopWatch* stopwatch)
 {
   // Create a work item that can run on the thread pool, capturing required
   // variables to complete the work
-  std::function<void()> work = [this, impi, trail, success_cb, failure_cb]()->void
+  std::function<void()> work = [this, impi, trail, success_cb, failure_cb, stopwatch]()->void
   {
     ImsSubscription* result = NULL;
-    Store::Status rc = _cache->get_ims_subscription(impi, trail, result);
+    Store::Status rc = _cache->get_ims_subscription(impi, trail, stopwatch, result);
 
     if (rc == Store::Status::OK)
     {
@@ -252,13 +262,14 @@ void HssCacheProcessor::put_ims_subscription(void_success_cb success_cb,
                                              progress_callback progress_cb,
                                              failure_callback failure_cb,
                                              ImsSubscription* subscription,
-                                             SAS::TrailId trail)
+                                             SAS::TrailId trail,
+                                             Utils::StopWatch* stopwatch)
 {
   // Create a work item that can run on the thread pool, capturing required
   // variables to complete the work
-  std::function<void()> work = [this, subscription, trail, success_cb, progress_cb, failure_cb]()->void
+  std::function<void()> work = [this, subscription, trail, success_cb, progress_cb, failure_cb, stopwatch]()->void
   {
-    Store::Status rc = _cache->put_ims_subscription(subscription, progress_cb, trail);
+    Store::Status rc = _cache->put_ims_subscription(subscription, progress_cb, trail, stopwatch);
 
     if (rc == Store::Status::OK)
     {

--- a/src/http_handlers.cpp
+++ b/src/http_handlers.cpp
@@ -99,7 +99,7 @@ void ImpiTask::send_mar()
     std::bind(&ImpiTask::on_mar_response, this, _1);
 
   // Send the request
-  _hss->send_multimedia_auth_request(callback, request, this->trail());
+  _hss->send_multimedia_auth_request(callback, request, this->trail(), _req.get_stopwatch());
 }
 
 void ImpiTask::on_mar_response(const HssConnection::MultimediaAuthAnswer& maa)
@@ -345,7 +345,7 @@ void ImpiRegistrationStatusTask::run()
     std::bind(&ImpiRegistrationStatusTask::on_uar_response, this, _1);
 
   // Send the request
-  _hss->send_user_auth_request(callback, request, this->trail());
+  _hss->send_user_auth_request(callback, request, this->trail(), _req.get_stopwatch());
 }
 
 void ImpiRegistrationStatusTask::on_uar_response(const HssConnection::UserAuthAnswer& uaa)
@@ -465,7 +465,7 @@ void ImpuLocationInfoTask::run()
     std::bind(&ImpuLocationInfoTask::on_lir_response, this, _1);
 
   // Send the request
-  _hss->send_location_info_request(callback, request, this->trail());
+  _hss->send_location_info_request(callback, request, this->trail(), _req.get_stopwatch());
 }
 
 void ImpuLocationInfoTask::on_lir_response(const HssConnection::LocationInfoAnswer& lia)
@@ -1075,7 +1075,7 @@ void ImpuRegDataTask::send_server_assignment_request(Cx::ServerAssignmentType ty
     std::bind(&ImpuRegDataTask::on_sar_response, this, _1);
 
   // Send the request
-  _hss->send_server_assignment_request(callback, request, this->trail());
+  _hss->send_server_assignment_request(callback, request, this->trail(), _req.get_stopwatch());
 }
 
 void ImpuRegDataTask::put_in_cache()

--- a/src/http_handlers.cpp
+++ b/src/http_handlers.cpp
@@ -770,7 +770,8 @@ void ImpuRegDataTask::get_reg_data()
   _cache->get_implicit_registration_set_for_impu(success_cb,
                                                  failure_cb,
                                                  public_id(),
-                                                 this->trail());
+                                                 this->trail(),
+                                                 _req.get_stopwatch());
 }
 
 std::string regstate_to_str(RegistrationState state)
@@ -1140,7 +1141,7 @@ void ImpuRegDataTask::put_in_cache()
       std::bind(&ImpuRegDataTask::on_put_reg_data_failure, this, _1);
 
     // Cache the IRS
-    _cache->put_implicit_registration_set(success_cb, progress_cb, failure_cb, _irs, this->trail());
+    _cache->put_implicit_registration_set(success_cb, progress_cb, failure_cb, _irs, this->trail(), _req.get_stopwatch());
   }
   else
   {
@@ -1297,7 +1298,7 @@ void ImpuRegDataTask::on_sar_response(const HssConnection::ServerAssignmentAnswe
     failure_callback failure_cb =
       std::bind(&ImpuRegDataTask::on_del_impu_failure, this, _1);
 
-    _cache->delete_implicit_registration_set(success_cb, progress_cb, failure_cb, _irs, this->trail());
+    _cache->delete_implicit_registration_set(success_cb, progress_cb, failure_cb, _irs, this->trail(), _req.get_stopwatch());
     pending_cache_op = true;
   }
 

--- a/src/memcached_cache.cpp
+++ b/src/memcached_cache.cpp
@@ -20,23 +20,23 @@ using std::placeholders::_1;
 using std::placeholders::_2;
 
 // LCOV_EXCL_START
-static void pause_stopwatch(Utils::StopWatch& stopwatch, const std::string& reason)
+static void pause_stopwatch(Utils::StopWatch* stopwatch, const std::string& reason)
 {
   TRC_DEBUG("Pausing stopwatch due to %s", reason.c_str());
-  stopwatch.stop();
+  stopwatch->stop();
 }
 
-static void resume_stopwatch(Utils::StopWatch& stopwatch, const std::string& reason)
+static void resume_stopwatch(Utils::StopWatch* stopwatch, const std::string& reason)
 {
   TRC_DEBUG("Resuming stopwatch due to %s", reason.c_str());
-  stopwatch.start();
+  stopwatch->start();
 }
 // LCOV_EXCL_STOP
 
 Utils::IOHook* create_hook(Utils::StopWatch* stopwatch)
 {
-  return new Utils::IOHook(std::bind(pause_stopwatch, *stopwatch, _1),
-                           std::bind(resume_stopwatch, *stopwatch, _1));
+  return new Utils::IOHook(std::bind(pause_stopwatch, stopwatch, _1),
+                           std::bind(resume_stopwatch, stopwatch, _1));
 }
 
 ImpuStore::DefaultImpu* MemcachedImplicitRegistrationSet::create_impu(uint64_t cas,

--- a/src/memcached_cache.cpp
+++ b/src/memcached_cache.cpp
@@ -19,6 +19,7 @@
 using std::placeholders::_1;
 using std::placeholders::_2;
 
+// LCOV_EXCL_START
 static void pause_stopwatch(Utils::StopWatch& stopwatch, const std::string& reason)
 {
   TRC_DEBUG("Pausing stopwatch due to %s", reason.c_str());
@@ -30,6 +31,7 @@ static void resume_stopwatch(Utils::StopWatch& stopwatch, const std::string& rea
   TRC_DEBUG("Resuming stopwatch due to %s", reason.c_str());
   stopwatch.start();
 }
+// LCOV_EXCL_STOP
 
 Utils::IOHook* create_hook(Utils::StopWatch* stopwatch)
 {

--- a/src/ut/diameter_handlers_test.cpp
+++ b/src/ut/diameter_handlers_test.cpp
@@ -243,13 +243,13 @@ public:
                           (dereg_reason == NEW_SERVER_ASSIGNED)))
       {
         // Expect a cache lookup using the provided list of IMPUs
-        EXPECT_CALL(*_cache, get_implicit_registration_sets_for_impus(_, _, IMPUS, FAKE_TRAIL_ID))
+        EXPECT_CALL(*_cache, get_implicit_registration_sets_for_impus(_, _, IMPUS, FAKE_TRAIL_ID, _))
           .WillOnce(InvokeArgument<0>(irss));
       }
       else
       {
         // Expect a cache lookup using the list of IMPIs
-        EXPECT_CALL(*_cache, get_implicit_registration_sets_for_impis(_, _, impis, FAKE_TRAIL_ID))
+        EXPECT_CALL(*_cache, get_implicit_registration_sets_for_impis(_, _, impis, FAKE_TRAIL_ID, _))
           .WillOnce(InvokeArgument<0>(irss));
       }
 
@@ -259,7 +259,7 @@ public:
         .WillOnce(Return(http_ret_code)).RetiresOnSaturation();
 
       // Expect deletions for each IRS
-      EXPECT_CALL(*_cache, delete_implicit_registration_sets(_, _, _, irss, FAKE_TRAIL_ID))
+      EXPECT_CALL(*_cache, delete_implicit_registration_sets(_, _, _, irss, FAKE_TRAIL_ID, _))
         .WillOnce(DoAll(InvokeArgument<1>(), InvokeArgument<0>()));
     }
     else
@@ -520,7 +520,7 @@ TEST_F(DiameterHandlersTest, RTRIncludesBarredImpus)
 
   std::vector<ImplicitRegistrationSet*> irss = { irs };
 
-  EXPECT_CALL(*_cache, get_implicit_registration_sets_for_impus(_, _, IMPU_IN_VECTOR, FAKE_TRAIL_ID))
+  EXPECT_CALL(*_cache, get_implicit_registration_sets_for_impus(_, _, IMPU_IN_VECTOR, FAKE_TRAIL_ID, _))
     .WillOnce(InvokeArgument<0>(irss));
 
   // Expect a delete to be sent to Sprout.
@@ -529,7 +529,7 @@ TEST_F(DiameterHandlersTest, RTRIncludesBarredImpus)
     .WillOnce(Return(200)).RetiresOnSaturation();
 
   // Expect deletions for each IRS
-  EXPECT_CALL(*_cache, delete_implicit_registration_sets(_, _, _, irss, FAKE_TRAIL_ID))
+  EXPECT_CALL(*_cache, delete_implicit_registration_sets(_, _, _, irss, FAKE_TRAIL_ID, _))
     .WillOnce(DoAll(InvokeArgument<1>(), InvokeArgument<0>()));
 
   task->run();
@@ -585,7 +585,7 @@ TEST_F(DiameterHandlersTest, RTRIncludesBarringIndication)
 
   std::vector<ImplicitRegistrationSet*> irss = { irs };
 
-  EXPECT_CALL(*_cache, get_implicit_registration_sets_for_impus(_, _, IMPU_IN_VECTOR, FAKE_TRAIL_ID))
+  EXPECT_CALL(*_cache, get_implicit_registration_sets_for_impus(_, _, IMPU_IN_VECTOR, FAKE_TRAIL_ID, _))
     .WillOnce(InvokeArgument<0>(irss));
 
   // Expect a delete to be sent to Sprout.
@@ -594,7 +594,7 @@ TEST_F(DiameterHandlersTest, RTRIncludesBarringIndication)
     .WillOnce(Return(200)).RetiresOnSaturation();
 
   // Expect deletions for each IRS
-  EXPECT_CALL(*_cache, delete_implicit_registration_sets(_, _, _, irss, FAKE_TRAIL_ID))
+  EXPECT_CALL(*_cache, delete_implicit_registration_sets(_, _, _, irss, FAKE_TRAIL_ID, _))
     .WillOnce(DoAll(InvokeArgument<1>(), InvokeArgument<0>()));
 
   task->run();
@@ -642,7 +642,7 @@ TEST_F(DiameterHandlersTest, RTRNoRegSets)
 
   // The cache returns an empty vectory
   std::vector<ImplicitRegistrationSet*> irss = {};
-  EXPECT_CALL(*_cache, get_implicit_registration_sets_for_impus(_, _, IMPUS, FAKE_TRAIL_ID))
+  EXPECT_CALL(*_cache, get_implicit_registration_sets_for_impus(_, _, IMPUS, FAKE_TRAIL_ID, _))
     .WillOnce(InvokeArgument<0>(irss));
 
   task->run();
@@ -687,7 +687,7 @@ TEST_F(DiameterHandlersTest, RTRCacheError)
   std::vector<std::string> impis = { IMPI, ASSOCIATED_IDENTITY1, ASSOCIATED_IDENTITY2 };
 
   // The cache will return ERROR
-  EXPECT_CALL(*_cache, get_implicit_registration_sets_for_impus(_, _, IMPUS, FAKE_TRAIL_ID))
+  EXPECT_CALL(*_cache, get_implicit_registration_sets_for_impus(_, _, IMPUS, FAKE_TRAIL_ID, _))
     .WillOnce(InvokeArgument<1>(Store::Status::ERROR));
 
   task->run();
@@ -720,7 +720,7 @@ TEST_F(DiameterHandlersTest, PPRMainline)
   MockImsSubscription* sub = new MockImsSubscription();
 
   // Expect that we'll look up the ImsSubscription for the provided IMPI
-  EXPECT_CALL(*_cache, get_ims_subscription(_, _, IMPI, FAKE_TRAIL_ID))
+  EXPECT_CALL(*_cache, get_ims_subscription(_, _, IMPI, FAKE_TRAIL_ID, _))
     .WillOnce(InvokeArgument<0>(sub));
 
   // Expect that we'll request the IRS for the default IMPU from the ImsSubscription
@@ -732,7 +732,7 @@ TEST_F(DiameterHandlersTest, PPRMainline)
     .Times(1);
 
   // We'll then save the ImsSubscription in the cache
-  EXPECT_CALL(*_cache, put_ims_subscription(_, _, _, sub, FAKE_TRAIL_ID))
+  EXPECT_CALL(*_cache, put_ims_subscription(_, _, _, sub, FAKE_TRAIL_ID, _))
     .WillOnce(DoAll(InvokeArgument<1>(), InvokeArgument<0>()));
 
   // And notify Sprout
@@ -769,7 +769,7 @@ TEST_F(DiameterHandlersTest, PPRChangeIDs)
   MockImsSubscription* sub = new MockImsSubscription();
 
   // Expect that we'll look up the ImsSubscription for the provided IMPI
-  EXPECT_CALL(*_cache, get_ims_subscription(_, _, IMPI, FAKE_TRAIL_ID))
+  EXPECT_CALL(*_cache, get_ims_subscription(_, _, IMPI, FAKE_TRAIL_ID, _))
     .WillOnce(InvokeArgument<0>(sub));
 
   // Expect that we'll request the IRS for the default IMPU from the ImsSubscription
@@ -784,7 +784,7 @@ TEST_F(DiameterHandlersTest, PPRChangeIDs)
   ppr_sprout_connection(IMPU, IMPU_IMS_SUBSCRIPTION, HTTP_OK);
 
   // We'll then save the ImsSubscription in the cache
-  EXPECT_CALL(*_cache, put_ims_subscription(_, _, _, sub, FAKE_TRAIL_ID))
+  EXPECT_CALL(*_cache, put_ims_subscription(_, _, _, sub, FAKE_TRAIL_ID, _))
     .WillOnce(DoAll(InvokeArgument<1>(), InvokeArgument<0>()));
 
   ppr_expect_ppa();
@@ -823,7 +823,7 @@ TEST_F(DiameterHandlersTest, PPRChangeIDsServerError)
   MockImsSubscription* sub = new MockImsSubscription();
 
   // Expect that we'll look up the ImsSubscription for the provided IMPI
-  EXPECT_CALL(*_cache, get_ims_subscription(_, _, IMPI, FAKE_TRAIL_ID))
+  EXPECT_CALL(*_cache, get_ims_subscription(_, _, IMPI, FAKE_TRAIL_ID, _))
     .WillOnce(InvokeArgument<0>(sub));
 
   // Expect that we'll request the IRS for the default IMPU from the ImsSubscription
@@ -859,7 +859,7 @@ TEST_F(DiameterHandlersTest, PPRChargingAddrs)
   MockImsSubscription* sub = new MockImsSubscription();
 
   // Expect that we'll look up the ImsSubscription for the provided IMPI
-  EXPECT_CALL(*_cache, get_ims_subscription(_, _, IMPI, FAKE_TRAIL_ID))
+  EXPECT_CALL(*_cache, get_ims_subscription(_, _, IMPI, FAKE_TRAIL_ID, _))
     .WillOnce(InvokeArgument<0>(sub));
 
   // Expect that we'll set the charging addresses on the ImsSubscription
@@ -868,7 +868,7 @@ TEST_F(DiameterHandlersTest, PPRChargingAddrs)
     .Times(1);
 
   // We'll then save the ImsSubscription in the cache
-  EXPECT_CALL(*_cache, put_ims_subscription(_, _, _, sub, FAKE_TRAIL_ID))
+  EXPECT_CALL(*_cache, put_ims_subscription(_, _, _, sub, FAKE_TRAIL_ID, _))
     .WillOnce(DoAll(InvokeArgument<1>(), InvokeArgument<0>()));
 
   ppr_expect_ppa();
@@ -896,7 +896,7 @@ TEST_F(DiameterHandlersTest, PPRImsSub)
   MockImsSubscription* sub = new MockImsSubscription();
 
   // Expect that we'll look up the ImsSubscription for the provided IMPI
-  EXPECT_CALL(*_cache, get_ims_subscription(_, _, IMPI, FAKE_TRAIL_ID))
+  EXPECT_CALL(*_cache, get_ims_subscription(_, _, IMPI, FAKE_TRAIL_ID, _))
     .WillOnce(InvokeArgument<0>(sub));
 
   // Expect that we'll request the IRS for the default IMPU from the ImsSubscription
@@ -906,7 +906,7 @@ TEST_F(DiameterHandlersTest, PPRImsSub)
   ppr_sprout_connection(IMPU, IMS_SUBSCRIPTION, HTTP_OK);
 
   // We'll then save the ImsSubscription in the cache
-  EXPECT_CALL(*_cache, put_ims_subscription(_, _, _, sub, FAKE_TRAIL_ID))
+  EXPECT_CALL(*_cache, put_ims_subscription(_, _, _, sub, FAKE_TRAIL_ID, _))
     .WillOnce(DoAll(InvokeArgument<1>(), InvokeArgument<0>()));
 
   ppr_expect_ppa();
@@ -942,7 +942,7 @@ TEST_F(DiameterHandlersTest, PPRIMSSubNoSIPURI)
   MockImsSubscription* sub = new MockImsSubscription();
 
   // Expect that we'll look up the ImsSubscription for the provided IMPI
-  EXPECT_CALL(*_cache, get_ims_subscription(_, _, IMPI, FAKE_TRAIL_ID))
+  EXPECT_CALL(*_cache, get_ims_subscription(_, _, IMPI, FAKE_TRAIL_ID, _))
     .WillOnce(InvokeArgument<0>(sub));
 
   // Expect that we'll request the IRS for the default IMPU from the ImsSubscription
@@ -952,7 +952,7 @@ TEST_F(DiameterHandlersTest, PPRIMSSubNoSIPURI)
   ppr_sprout_connection(TEL_URI, TEL_URIS_IMS_SUBSCRIPTION, HTTP_OK);
 
   // We'll then save the ImsSubscription in the cache
-  EXPECT_CALL(*_cache, put_ims_subscription(_, _, _, sub, FAKE_TRAIL_ID))
+  EXPECT_CALL(*_cache, put_ims_subscription(_, _, _, sub, FAKE_TRAIL_ID, _))
     .WillOnce(DoAll(InvokeArgument<1>(), InvokeArgument<0>()));
 
   ppr_expect_ppa();
@@ -988,7 +988,7 @@ TEST_F(DiameterHandlersTest, PPRCacheFailure)
   MockImsSubscription* sub = new MockImsSubscription();
 
   // Expect that we'll look up the ImsSubscription for the provided IMPI
-  EXPECT_CALL(*_cache, get_ims_subscription(_, _, IMPI, FAKE_TRAIL_ID))
+  EXPECT_CALL(*_cache, get_ims_subscription(_, _, IMPI, FAKE_TRAIL_ID, _))
     .WillOnce(InvokeArgument<0>(sub));
 
   // Expect that we'll request the IRS for the default IMPU from the ImsSubscription
@@ -998,7 +998,7 @@ TEST_F(DiameterHandlersTest, PPRCacheFailure)
   ppr_sprout_connection(IMPU, IMS_SUBSCRIPTION, HTTP_OK);
 
   // We'll then save the ImsSubscription in the cache, which will give an error
-  EXPECT_CALL(*_cache, put_ims_subscription(_, _, _, sub, FAKE_TRAIL_ID))
+  EXPECT_CALL(*_cache, put_ims_subscription(_, _, _, sub, FAKE_TRAIL_ID, _))
     .WillOnce(InvokeArgument<2>(Store::Status::ERROR));
 
   ppr_expect_ppa();
@@ -1024,7 +1024,7 @@ TEST_F(DiameterHandlersTest, PPRGetRegSetFailure)
 
   // Expect that we'll look up the ImsSubscription for the provided IMPI, which
   // will fail
-  EXPECT_CALL(*_cache, get_ims_subscription(_, _, IMPI, FAKE_TRAIL_ID))
+  EXPECT_CALL(*_cache, get_ims_subscription(_, _, IMPI, FAKE_TRAIL_ID, _))
     .WillOnce(InvokeArgument<1>(Store::Status::ERROR));
 
   ppr_expect_ppa();
@@ -1063,7 +1063,7 @@ TEST_F(DiameterHandlersTest, PPRChangesDefaultRejected)
   MockImsSubscription* sub = new MockImsSubscription();
 
   // Expect that we'll look up the ImsSubscription for the provided IMPI
-  EXPECT_CALL(*_cache, get_ims_subscription(_, _, IMPI, FAKE_TRAIL_ID))
+  EXPECT_CALL(*_cache, get_ims_subscription(_, _, IMPI, FAKE_TRAIL_ID, _))
     .WillOnce(InvokeArgument<0>(sub));
 
   // Expect that we'll request the IRS for the default IMPU from the ImsSubscription,

--- a/src/ut/diameter_hss_connection_test.cpp
+++ b/src/ut/diameter_hss_connection_test.cpp
@@ -344,12 +344,12 @@ TEST_F(DiameterHssConnectionTest, SendMARDigest)
   EXPECT_CALL(*_stats, update_H_hss_latency_us(12000));
   cwtest_advance_time_ms(12);
 
+  _caught_diam_tsx->on_response(maa);
+
   // Check that the stopwatch doesn't include the time spent waiting on diameter response
   unsigned long time;
   EXPECT_EQ(true, stopwatch.read(time));
   EXPECT_EQ(time, 0L);
-
-  _caught_diam_tsx->on_response(maa);
 
   _caught_fd_msg = NULL;
   delete _caught_diam_tsx; _caught_diam_tsx = NULL;
@@ -835,12 +835,12 @@ TEST_F(DiameterHssConnectionTest, SendUARServerName)
   EXPECT_CALL(*_stats, update_H_hss_subscription_latency_us(12000));
   cwtest_advance_time_ms(12);
 
+  _caught_diam_tsx->on_response(uaa);
+
   // Check that the stopwatch doesn't include the time spent waiting on diameter response
   unsigned long time;
   EXPECT_EQ(true, stopwatch.read(time));
   EXPECT_EQ(time, 0L);
-
-  _caught_diam_tsx->on_response(uaa);
 
   _caught_fd_msg = NULL;
   delete _caught_diam_tsx; _caught_diam_tsx = NULL;
@@ -1420,12 +1420,12 @@ TEST_F(DiameterHssConnectionTest, SendLIROriginating)
   EXPECT_CALL(*_stats, update_H_hss_subscription_latency_us(12000));
   cwtest_advance_time_ms(12);
 
+  _caught_diam_tsx->on_response(lia);
+
   // Check that the stopwatch doesn't include the time spent waiting on diameter response
   unsigned long time;
   EXPECT_EQ(true, stopwatch.read(time));
   EXPECT_EQ(time, 0L);
-
-  _caught_diam_tsx->on_response(lia);
 
   _caught_fd_msg = NULL;
   delete _caught_diam_tsx; _caught_diam_tsx = NULL;
@@ -1995,12 +1995,12 @@ TEST_F(DiameterHssConnectionTest, SendSARMainline)
   EXPECT_CALL(*_stats, update_H_hss_subscription_latency_us(12000));
   cwtest_advance_time_ms(12);
 
+  _caught_diam_tsx->on_response(saa);
+
   // Check that the stopwatch doesn't include the time spent waiting on diameter response
   unsigned long time;
   EXPECT_EQ(true, stopwatch.read(time));
   EXPECT_EQ(time, 0L);
-
-  _caught_diam_tsx->on_response(saa);
 
   _caught_fd_msg = NULL;
   delete _caught_diam_tsx; _caught_diam_tsx = NULL;

--- a/src/ut/diameter_hss_connection_test.cpp
+++ b/src/ut/diameter_hss_connection_test.cpp
@@ -291,8 +291,12 @@ TEST_F(DiameterHssConnectionTest, SendMARDigest)
     .Times(1)
     .WillOnce(WithArgs<0,1>(Invoke(store_msg_tsx)));
 
+  // Create a stopwatch to track that we're not including diameter latency
+  Utils::StopWatch stopwatch;
+  stopwatch.start();
+
   // Send the MAR
-  _hss_connection->send_multimedia_auth_request(MAA_CB, request, FAKE_TRAIL_ID);
+  _hss_connection->send_multimedia_auth_request(MAA_CB, request, FAKE_TRAIL_ID, &stopwatch);
 
   // Check that we've caught the message and it's not null
   ASSERT_FALSE(_caught_diam_tsx == NULL);
@@ -340,6 +344,11 @@ TEST_F(DiameterHssConnectionTest, SendMARDigest)
   EXPECT_CALL(*_stats, update_H_hss_latency_us(12000));
   cwtest_advance_time_ms(12);
 
+  // Check that the stopwatch doesn't include the time spent waiting on diameter response
+  unsigned long time;
+  EXPECT_EQ(true, stopwatch.read(time));
+  EXPECT_EQ(time, 0L);
+
   _caught_diam_tsx->on_response(maa);
 
   _caught_fd_msg = NULL;
@@ -364,7 +373,7 @@ TEST_F(DiameterHssConnectionTest, SendMARAKAv1)
     .WillOnce(WithArgs<0,1>(Invoke(store_msg_tsx)));
 
   // Send the MAR
-  _hss_connection->send_multimedia_auth_request(MAA_CB, request, FAKE_TRAIL_ID);
+  _hss_connection->send_multimedia_auth_request(MAA_CB, request, FAKE_TRAIL_ID, nullptr);
 
   // Check that we've caught the message and it's not null
   ASSERT_FALSE(_caught_diam_tsx == NULL);
@@ -438,7 +447,7 @@ TEST_F(DiameterHssConnectionTest, SendMARAKAv2)
     .WillOnce(WithArgs<0,1>(Invoke(store_msg_tsx)));
 
   // Send the MAR
-  _hss_connection->send_multimedia_auth_request(MAA_CB, request, FAKE_TRAIL_ID);
+  _hss_connection->send_multimedia_auth_request(MAA_CB, request, FAKE_TRAIL_ID, nullptr);
 
   // Check that we've caught the message and it's not null
   ASSERT_FALSE(_caught_diam_tsx == NULL);
@@ -513,7 +522,7 @@ TEST_F(DiameterHssConnectionTest, SendMARRecvUnknownScheme)
     .WillOnce(WithArgs<0,1>(Invoke(store_msg_tsx)));
 
   // Send the MAR
-  _hss_connection->send_multimedia_auth_request(MAA_CB, request, FAKE_TRAIL_ID);
+  _hss_connection->send_multimedia_auth_request(MAA_CB, request, FAKE_TRAIL_ID, nullptr);
 
   // Check that we've caught the message and it's not null
   ASSERT_FALSE(_caught_diam_tsx == NULL);
@@ -579,7 +588,7 @@ TEST_F(DiameterHssConnectionTest, SendMARRecvSERVER_UNAVAILABLE)
     .WillOnce(WithArgs<0,1>(Invoke(store_msg_tsx)));
 
   // Send the MAR
-  _hss_connection->send_multimedia_auth_request(MAA_CB, request, FAKE_TRAIL_ID);
+  _hss_connection->send_multimedia_auth_request(MAA_CB, request, FAKE_TRAIL_ID, nullptr);
 
   // Check that we've caught the message and it's not null
   ASSERT_FALSE(_caught_diam_tsx == NULL);
@@ -646,7 +655,7 @@ TEST_F(DiameterHssConnectionTest, SendMARRecvNOT_FOUND)
     .WillOnce(WithArgs<0,1>(Invoke(store_msg_tsx)));
 
   // Send the MAR
-  _hss_connection->send_multimedia_auth_request(MAA_CB, request, FAKE_TRAIL_ID);
+  _hss_connection->send_multimedia_auth_request(MAA_CB, request, FAKE_TRAIL_ID, nullptr);
 
   // Check that we've caught the message and it's not null
   ASSERT_FALSE(_caught_diam_tsx == NULL);
@@ -712,7 +721,7 @@ TEST_F(DiameterHssConnectionTest, SendMARRecvUNKNOWN_ERROR)
     .WillOnce(WithArgs<0,1>(Invoke(store_msg_tsx)));
 
   // Send the MAR
-  _hss_connection->send_multimedia_auth_request(MAA_CB, request, FAKE_TRAIL_ID);
+  _hss_connection->send_multimedia_auth_request(MAA_CB, request, FAKE_TRAIL_ID, nullptr);
 
   // Check that we've caught the message and it's not null
   ASSERT_FALSE(_caught_diam_tsx == NULL);
@@ -781,8 +790,12 @@ TEST_F(DiameterHssConnectionTest, SendUARServerName)
     .Times(1)
     .WillOnce(WithArgs<0,1>(Invoke(store_msg_tsx)));
 
+  // Create a stopwatch to ensure we're not inlcuding diameter latency
+  Utils::StopWatch stopwatch;
+  stopwatch.start();
+
   // Send the UAR
-  _hss_connection->send_user_auth_request(UAA_CB, request, FAKE_TRAIL_ID);
+  _hss_connection->send_user_auth_request(UAA_CB, request, FAKE_TRAIL_ID, &stopwatch);
 
   // Check that we've caught the message and it's not null
   ASSERT_FALSE(_caught_diam_tsx == NULL);
@@ -822,6 +835,11 @@ TEST_F(DiameterHssConnectionTest, SendUARServerName)
   EXPECT_CALL(*_stats, update_H_hss_subscription_latency_us(12000));
   cwtest_advance_time_ms(12);
 
+  // Check that the stopwatch doesn't include the time spent waiting on diameter response
+  unsigned long time;
+  EXPECT_EQ(true, stopwatch.read(time));
+  EXPECT_EQ(time, 0L);
+
   _caught_diam_tsx->on_response(uaa);
 
   _caught_fd_msg = NULL;
@@ -846,7 +864,7 @@ TEST_F(DiameterHssConnectionTest, SendUARServerCapabilities)
     .WillOnce(WithArgs<0,1>(Invoke(store_msg_tsx)));
 
   // Send the UAR
-  _hss_connection->send_user_auth_request(UAA_CB, request, FAKE_TRAIL_ID);
+  _hss_connection->send_user_auth_request(UAA_CB, request, FAKE_TRAIL_ID, nullptr);
 
   // Check that we've caught the message and it's not null
   ASSERT_FALSE(_caught_diam_tsx == NULL);
@@ -915,7 +933,7 @@ TEST_F(DiameterHssConnectionTest, SendUARUserUnknown)
     .WillOnce(WithArgs<0,1>(Invoke(store_msg_tsx)));
 
   // Send the UAR
-  _hss_connection->send_user_auth_request(UAA_CB, request, FAKE_TRAIL_ID);
+  _hss_connection->send_user_auth_request(UAA_CB, request, FAKE_TRAIL_ID, nullptr);
 
   // Check that we've caught the message and it's not null
   ASSERT_FALSE(_caught_diam_tsx == NULL);
@@ -978,7 +996,7 @@ TEST_F(DiameterHssConnectionTest, SendUARIdentitiesDontMatch)
     .WillOnce(WithArgs<0,1>(Invoke(store_msg_tsx)));
 
   // Send the UAR
-  _hss_connection->send_user_auth_request(UAA_CB, request, FAKE_TRAIL_ID);
+  _hss_connection->send_user_auth_request(UAA_CB, request, FAKE_TRAIL_ID, nullptr);
 
   // Check that we've caught the message and it's not null
   ASSERT_FALSE(_caught_diam_tsx == NULL);
@@ -1041,7 +1059,7 @@ TEST_F(DiameterHssConnectionTest, SendUARAuthRejected)
     .WillOnce(WithArgs<0,1>(Invoke(store_msg_tsx)));
 
   // Send the UAR
-  _hss_connection->send_user_auth_request(UAA_CB, request, FAKE_TRAIL_ID);
+  _hss_connection->send_user_auth_request(UAA_CB, request, FAKE_TRAIL_ID, nullptr);
 
   // Check that we've caught the message and it's not null
   ASSERT_FALSE(_caught_diam_tsx == NULL);
@@ -1104,7 +1122,7 @@ TEST_F(DiameterHssConnectionTest, SendUARRoamingNotAllowed)
     .WillOnce(WithArgs<0,1>(Invoke(store_msg_tsx)));
 
   // Send the UAR
-  _hss_connection->send_user_auth_request(UAA_CB, request, FAKE_TRAIL_ID);
+  _hss_connection->send_user_auth_request(UAA_CB, request, FAKE_TRAIL_ID, nullptr);
 
   // Check that we've caught the message and it's not null
   ASSERT_FALSE(_caught_diam_tsx == NULL);
@@ -1167,7 +1185,7 @@ TEST_F(DiameterHssConnectionTest, SendUARTooBusy)
     .WillOnce(WithArgs<0,1>(Invoke(store_msg_tsx)));
 
   // Send the UAR
-  _hss_connection->send_user_auth_request(UAA_CB, request, FAKE_TRAIL_ID);
+  _hss_connection->send_user_auth_request(UAA_CB, request, FAKE_TRAIL_ID, nullptr);
 
   // Check that we've caught the message and it's not null
   ASSERT_FALSE(_caught_diam_tsx == NULL);
@@ -1230,7 +1248,7 @@ TEST_F(DiameterHssConnectionTest, SendUARUnableToDeliver)
     .WillOnce(WithArgs<0,1>(Invoke(store_msg_tsx)));
 
   // Send the UAR
-  _hss_connection->send_user_auth_request(UAA_CB, request, FAKE_TRAIL_ID);
+  _hss_connection->send_user_auth_request(UAA_CB, request, FAKE_TRAIL_ID, nullptr);
 
   // Check that we've caught the message and it's not null
   ASSERT_FALSE(_caught_diam_tsx == NULL);
@@ -1293,7 +1311,7 @@ TEST_F(DiameterHssConnectionTest, SendUARUnknownError)
     .WillOnce(WithArgs<0,1>(Invoke(store_msg_tsx)));
 
   // Send the UAR
-  _hss_connection->send_user_auth_request(UAA_CB, request, FAKE_TRAIL_ID);
+  _hss_connection->send_user_auth_request(UAA_CB, request, FAKE_TRAIL_ID, nullptr);
 
   // Check that we've caught the message and it's not null
   ASSERT_FALSE(_caught_diam_tsx == NULL);
@@ -1357,8 +1375,12 @@ TEST_F(DiameterHssConnectionTest, SendLIROriginating)
     .Times(1)
     .WillOnce(WithArgs<0,1>(Invoke(store_msg_tsx)));
 
-  // Send the UAR
-  _hss_connection->send_location_info_request(LIA_CB, request, FAKE_TRAIL_ID);
+  // Create a stopwatch to track that we're not including diameter latency
+  Utils::StopWatch stopwatch;
+  stopwatch.start();
+
+  // Send the LIR
+  _hss_connection->send_location_info_request(LIA_CB, request, FAKE_TRAIL_ID, &stopwatch);
 
   // Check that we've caught the message and it's not null
   ASSERT_FALSE(_caught_diam_tsx == NULL);
@@ -1376,7 +1398,6 @@ TEST_F(DiameterHssConnectionTest, SendLIROriginating)
   EXPECT_TRUE(lir.originating(test_i32));
   EXPECT_EQ(0, test_i32);
   EXPECT_FALSE(lir.auth_type(test_i32));
-
 
   // We're now going to inject a response
   Cx::LocationInfoAnswer lia(_cx_dict,
@@ -1399,6 +1420,11 @@ TEST_F(DiameterHssConnectionTest, SendLIROriginating)
   EXPECT_CALL(*_stats, update_H_hss_subscription_latency_us(12000));
   cwtest_advance_time_ms(12);
 
+  // Check that the stopwatch doesn't include the time spent waiting on diameter response
+  unsigned long time;
+  EXPECT_EQ(true, stopwatch.read(time));
+  EXPECT_EQ(time, 0L);
+
   _caught_diam_tsx->on_response(lia);
 
   _caught_fd_msg = NULL;
@@ -1420,8 +1446,8 @@ TEST_F(DiameterHssConnectionTest, SendLIRAuthTypeCapabilities)
     .Times(1)
     .WillOnce(WithArgs<0,1>(Invoke(store_msg_tsx)));
 
-  // Send the UAR
-  _hss_connection->send_location_info_request(LIA_CB, request, FAKE_TRAIL_ID);
+  // Send the LIR
+  _hss_connection->send_location_info_request(LIA_CB, request, FAKE_TRAIL_ID, nullptr);
 
   // Check that we've caught the message and it's not null
   ASSERT_FALSE(_caught_diam_tsx == NULL);
@@ -1486,8 +1512,8 @@ TEST_F(DiameterHssConnectionTest, SendLIRWildcardImpu)
     .Times(1)
     .WillOnce(WithArgs<0,1>(Invoke(store_msg_tsx)));
 
-  // Send the UAR
-  _hss_connection->send_location_info_request(LIA_CB, request, FAKE_TRAIL_ID);
+  // Send the LIR
+  _hss_connection->send_location_info_request(LIA_CB, request, FAKE_TRAIL_ID, nullptr);
 
   // Check that we've caught the message and it's not null
   ASSERT_FALSE(_caught_diam_tsx == NULL);
@@ -1549,8 +1575,8 @@ TEST_F(DiameterHssConnectionTest, SendLIRUnregisteredService)
     .Times(1)
     .WillOnce(WithArgs<0,1>(Invoke(store_msg_tsx)));
 
-  // Send the UAR
-  _hss_connection->send_location_info_request(LIA_CB, request, FAKE_TRAIL_ID);
+  // Send the LIR
+  _hss_connection->send_location_info_request(LIA_CB, request, FAKE_TRAIL_ID, nullptr);
 
   // Check that we've caught the message and it's not null
   ASSERT_FALSE(_caught_diam_tsx == NULL);
@@ -1611,8 +1637,8 @@ TEST_F(DiameterHssConnectionTest, SendLIRIdentityNotRegistered)
     .Times(1)
     .WillOnce(WithArgs<0,1>(Invoke(store_msg_tsx)));
 
-  // Send the UAR
-  _hss_connection->send_location_info_request(LIA_CB, request, FAKE_TRAIL_ID);
+  // Send the LIR
+  _hss_connection->send_location_info_request(LIA_CB, request, FAKE_TRAIL_ID, nullptr);
 
   // Check that we've caught the message and it's not null
   ASSERT_FALSE(_caught_diam_tsx == NULL);
@@ -1673,8 +1699,8 @@ TEST_F(DiameterHssConnectionTest, SendLIRUserUnknown)
     .Times(1)
     .WillOnce(WithArgs<0,1>(Invoke(store_msg_tsx)));
 
-  // Send the UAR
-  _hss_connection->send_location_info_request(LIA_CB, request, FAKE_TRAIL_ID);
+  // Send the LIR
+  _hss_connection->send_location_info_request(LIA_CB, request, FAKE_TRAIL_ID, nullptr);
 
   // Check that we've caught the message and it's not null
   ASSERT_FALSE(_caught_diam_tsx == NULL);
@@ -1733,8 +1759,8 @@ TEST_F(DiameterHssConnectionTest, SendLIRTooBusy)
     .Times(1)
     .WillOnce(WithArgs<0,1>(Invoke(store_msg_tsx)));
 
-  // Send the UAR
-  _hss_connection->send_location_info_request(LIA_CB, request, FAKE_TRAIL_ID);
+  // Send the LIR
+  _hss_connection->send_location_info_request(LIA_CB, request, FAKE_TRAIL_ID, nullptr);
 
   // Check that we've caught the message and it's not null
   ASSERT_FALSE(_caught_diam_tsx == NULL);
@@ -1793,8 +1819,8 @@ TEST_F(DiameterHssConnectionTest, SendLIRUnableToDeliver)
     .Times(1)
     .WillOnce(WithArgs<0,1>(Invoke(store_msg_tsx)));
 
-  // Send the UAR
-  _hss_connection->send_location_info_request(LIA_CB, request, FAKE_TRAIL_ID);
+  // Send the LIR
+  _hss_connection->send_location_info_request(LIA_CB, request, FAKE_TRAIL_ID, nullptr);
 
   // Check that we've caught the message and it's not null
   ASSERT_FALSE(_caught_diam_tsx == NULL);
@@ -1853,8 +1879,8 @@ TEST_F(DiameterHssConnectionTest, SendLIRUnknown)
     .Times(1)
     .WillOnce(WithArgs<0,1>(Invoke(store_msg_tsx)));
 
-  // Send the UAR
-  _hss_connection->send_location_info_request(LIA_CB, request, FAKE_TRAIL_ID);
+  // Send the LIR
+  _hss_connection->send_location_info_request(LIA_CB, request, FAKE_TRAIL_ID, nullptr);
 
   // Check that we've caught the message and it's not null
   ASSERT_FALSE(_caught_diam_tsx == NULL);
@@ -1920,8 +1946,12 @@ TEST_F(DiameterHssConnectionTest, SendSARMainline)
     .Times(1)
     .WillOnce(WithArgs<0,1>(Invoke(store_msg_tsx)));
 
+  // Create a stopwatch to track that we're not including diameter latency
+  Utils::StopWatch stopwatch;
+  stopwatch.start();
+
   // Send the SAR
-  _hss_connection->send_server_assignment_request(SAA_CB, request, FAKE_TRAIL_ID);
+  _hss_connection->send_server_assignment_request(SAA_CB, request, FAKE_TRAIL_ID, &stopwatch);
 
   // Check that we've caught the message and it's not null
   ASSERT_FALSE(_caught_diam_tsx == NULL);
@@ -1965,6 +1995,11 @@ TEST_F(DiameterHssConnectionTest, SendSARMainline)
   EXPECT_CALL(*_stats, update_H_hss_subscription_latency_us(12000));
   cwtest_advance_time_ms(12);
 
+  // Check that the stopwatch doesn't include the time spent waiting on diameter response
+  unsigned long time;
+  EXPECT_EQ(true, stopwatch.read(time));
+  EXPECT_EQ(time, 0L);
+
   _caught_diam_tsx->on_response(saa);
 
   _caught_fd_msg = NULL;
@@ -1990,7 +2025,7 @@ TEST_F(DiameterHssConnectionTest, SendSARWildcardImpu)
     .WillOnce(WithArgs<0,1>(Invoke(store_msg_tsx)));
 
   // Send the SAR
-  _hss_connection->send_server_assignment_request(SAA_CB, request, FAKE_TRAIL_ID);
+  _hss_connection->send_server_assignment_request(SAA_CB, request, FAKE_TRAIL_ID, nullptr);
 
   // Check that we've caught the message and it's not null
   ASSERT_FALSE(_caught_diam_tsx == NULL);
@@ -2057,7 +2092,7 @@ TEST_F(DiameterHssConnectionTest, SendSARWildcardEmpty)
     .WillOnce(WithArgs<0,1>(Invoke(store_msg_tsx)));
 
   // Send the SAR
-  _hss_connection->send_server_assignment_request(SAA_CB, request, FAKE_TRAIL_ID);
+  _hss_connection->send_server_assignment_request(SAA_CB, request, FAKE_TRAIL_ID, nullptr);
 
   // Check that we've caught the message and it's not null
   ASSERT_FALSE(_caught_diam_tsx == NULL);
@@ -2123,7 +2158,7 @@ TEST_F(DiameterHssConnectionTest, SendSARUnableToDeliver)
     .WillOnce(WithArgs<0,1>(Invoke(store_msg_tsx)));
 
   // Send the SAR
-  _hss_connection->send_server_assignment_request(SAA_CB, request, FAKE_TRAIL_ID);
+  _hss_connection->send_server_assignment_request(SAA_CB, request, FAKE_TRAIL_ID, nullptr);
 
   // Check that we've caught the message and it's not null
   ASSERT_FALSE(_caught_diam_tsx == NULL);
@@ -2189,7 +2224,7 @@ TEST_F(DiameterHssConnectionTest, SendSARUserUnknown)
     .WillOnce(WithArgs<0,1>(Invoke(store_msg_tsx)));
 
   // Send the SAR
-  _hss_connection->send_server_assignment_request(SAA_CB, request, FAKE_TRAIL_ID);
+  _hss_connection->send_server_assignment_request(SAA_CB, request, FAKE_TRAIL_ID, nullptr);
 
   // Check that we've caught the message and it's not null
   ASSERT_FALSE(_caught_diam_tsx == NULL);
@@ -2255,7 +2290,7 @@ TEST_F(DiameterHssConnectionTest, SendSARUnknown)
     .WillOnce(WithArgs<0,1>(Invoke(store_msg_tsx)));
 
   // Send the SAR
-  _hss_connection->send_server_assignment_request(SAA_CB, request, FAKE_TRAIL_ID);
+  _hss_connection->send_server_assignment_request(SAA_CB, request, FAKE_TRAIL_ID, nullptr);
 
   // Check that we've caught the message and it's not null
   ASSERT_FALSE(_caught_diam_tsx == NULL);
@@ -2327,7 +2362,7 @@ TEST_F(DiameterHssConnectionTest, DiameterTimeout)
     .WillOnce(WithArgs<0,1>(Invoke(store_msg_tsx)));
 
   // Send the SAR
-  _hss_connection->send_server_assignment_request(SAA_CB, request, FAKE_TRAIL_ID);
+  _hss_connection->send_server_assignment_request(SAA_CB, request, FAKE_TRAIL_ID, nullptr);
 
   // Check that we've caught the message and it's not null
   ASSERT_FALSE(_caught_diam_tsx == NULL);

--- a/src/ut/hsprov_hss_connection_test.cpp
+++ b/src/ut/hsprov_hss_connection_test.cpp
@@ -207,7 +207,7 @@ TEST_F(HsProvHssConnectionTest, SendMAR)
   EXPECT_DO_ASYNC(*_mock_store, mock_op);
 
   // Send the MAR
-  _hss_connection->send_multimedia_auth_request(MAA_CB, request, FAKE_TRAIL_ID);
+  _hss_connection->send_multimedia_auth_request(MAA_CB, request, FAKE_TRAIL_ID, nullptr);
 
   // Confirm the transaction is not NULL, and specify an auth vector to be
   // returned
@@ -258,7 +258,7 @@ TEST_F(HsProvHssConnectionTest, SendMARNotFound)
   EXPECT_DO_ASYNC(*_mock_store, mock_op);
 
   // Send the MAR
-  _hss_connection->send_multimedia_auth_request(MAA_CB, request, FAKE_TRAIL_ID);
+  _hss_connection->send_multimedia_auth_request(MAA_CB, request, FAKE_TRAIL_ID, nullptr);
 
   // Confirm the transaction is not NULL
   CassandraStore::Transaction* t = mock_op.get_trx();
@@ -299,7 +299,7 @@ TEST_F(HsProvHssConnectionTest, SendMAROtherError)
   EXPECT_DO_ASYNC(*_mock_store, mock_op);
 
   // Send the MAR
-  _hss_connection->send_multimedia_auth_request(MAA_CB, request, FAKE_TRAIL_ID);
+  _hss_connection->send_multimedia_auth_request(MAA_CB, request, FAKE_TRAIL_ID, nullptr);
 
   // Confirm the transaction is not NULL
   CassandraStore::Transaction* t = mock_op.get_trx();
@@ -342,7 +342,7 @@ TEST_F(HsProvHssConnectionTest, SendUAR)
           Field(&HssConnection::UserAuthAnswer::_server_name, SERVER_NAME)))).Times(1).RetiresOnSaturation();
 
   // Send the UAR
-  _hss_connection->send_user_auth_request(UAA_CB, request, FAKE_TRAIL_ID);
+  _hss_connection->send_user_auth_request(UAA_CB, request, FAKE_TRAIL_ID, nullptr);
 }
 
 //
@@ -366,7 +366,7 @@ TEST_F(HsProvHssConnectionTest, SendLIR)
   EXPECT_DO_ASYNC(*_mock_store, mock_op);
 
   // Send the LIR
-  _hss_connection->send_location_info_request(LIA_CB, request, FAKE_TRAIL_ID);
+  _hss_connection->send_location_info_request(LIA_CB, request, FAKE_TRAIL_ID, nullptr);
 
   // Confirm the transaction is not NULL
   CassandraStore::Transaction* t = mock_op.get_trx();
@@ -409,7 +409,7 @@ TEST_F(HsProvHssConnectionTest, SendLIRNotFound)
   EXPECT_DO_ASYNC(*_mock_store, mock_op);
 
   // Send the LIR
-  _hss_connection->send_location_info_request(LIA_CB, request, FAKE_TRAIL_ID);
+  _hss_connection->send_location_info_request(LIA_CB, request, FAKE_TRAIL_ID, nullptr);
 
   // Confirm the transaction is not NULL
   CassandraStore::Transaction* t = mock_op.get_trx();
@@ -446,7 +446,7 @@ TEST_F(HsProvHssConnectionTest, SendLIROtherError)
   EXPECT_DO_ASYNC(*_mock_store, mock_op);
 
   // Send the LIR
-  _hss_connection->send_location_info_request(LIA_CB, request, FAKE_TRAIL_ID);
+  _hss_connection->send_location_info_request(LIA_CB, request, FAKE_TRAIL_ID, nullptr);
 
   // Confirm the transaction is not NULL
   CassandraStore::Transaction* t = mock_op.get_trx();
@@ -490,7 +490,7 @@ TEST_F(HsProvHssConnectionTest, SendSAR)
   EXPECT_DO_ASYNC(*_mock_store, mock_op);
 
   // Send the SAR
-  _hss_connection->send_server_assignment_request(SAA_CB, request, FAKE_TRAIL_ID);
+  _hss_connection->send_server_assignment_request(SAA_CB, request, FAKE_TRAIL_ID, nullptr);
 
   // Confirm the transaction is not NULL
   CassandraStore::Transaction* t = mock_op.get_trx();
@@ -540,7 +540,7 @@ TEST_F(HsProvHssConnectionTest, SendSARNotFound)
   EXPECT_DO_ASYNC(*_mock_store, mock_op);
 
   // Send the SAR
-  _hss_connection->send_server_assignment_request(SAA_CB, request, FAKE_TRAIL_ID);
+  _hss_connection->send_server_assignment_request(SAA_CB, request, FAKE_TRAIL_ID, nullptr);
 
   // Confirm the transaction is not NULL
   CassandraStore::Transaction* t = mock_op.get_trx();
@@ -581,7 +581,7 @@ TEST_F(HsProvHssConnectionTest, SendSARError)
   EXPECT_DO_ASYNC(*_mock_store, mock_op);
 
   // Send the SAR
-  _hss_connection->send_server_assignment_request(SAA_CB, request, FAKE_TRAIL_ID);
+  _hss_connection->send_server_assignment_request(SAA_CB, request, FAKE_TRAIL_ID, nullptr);
 
   // Confirm the transaction is not NULL
   CassandraStore::Transaction* t = mock_op.get_trx();
@@ -619,5 +619,5 @@ TEST_F(HsProvHssConnectionTest, SendSARDeReg)
     .Times(1).RetiresOnSaturation();
 
   // Send the SAR
-  _hss_connection->send_server_assignment_request(SAA_CB, request, FAKE_TRAIL_ID);
+  _hss_connection->send_server_assignment_request(SAA_CB, request, FAKE_TRAIL_ID, nullptr);
 }

--- a/src/ut/http_handlers_test.cpp
+++ b/src/ut/http_handlers_test.cpp
@@ -49,7 +49,6 @@
 #include "fakesnmp.hpp"
 #include "base64.h"
 
-//#include "fakehssconnection.hpp"
 #include "mockhssconnection.hpp"
 #include "mockhsscacheprocessor.hpp"
 #include "mockimssubscription.hpp"
@@ -194,7 +193,6 @@ public:
     _real_stack->configure(UT_DIR + "/diameterstack.conf", NULL);
     _cache = new MockHssCacheProcessor();
     _hss = new MockHssConnection();
-    //_hss = new FakeHssConnection();
     _httpstack = new MockHttpStack();
     _mock_resolver = new FakeHttpResolver("1.2.3.4");
     _mock_http_conn = new MockHttpConnection(_mock_resolver);
@@ -405,7 +403,7 @@ public:
     // Once the task's run function is called, expect a UAR. We don't check the
     // contents of the UAR explicitly here, as this is done by other tests.
     HssConnection::UserAuthAnswer answer = HssConnection::UserAuthAnswer(hss_rc);
-    EXPECT_CALL(*_hss, send_user_auth_request(_, _, _)).WillOnce(InvokeArgument<0>(ByRef(answer)));
+    EXPECT_CALL(*_hss, send_user_auth_request(_, _, _, _)).WillOnce(InvokeArgument<0>(ByRef(answer)));
 
     // Expect the correct HTTP code
     EXPECT_CALL(*_httpstack, send_reply(_, http_rc, _));
@@ -431,7 +429,7 @@ public:
     // Once the task's run function is called, expect an LIR. We don't check the
     // contents of the LIR explicitly here, as this is done by other tests.
     HssConnection::LocationInfoAnswer answer = HssConnection::LocationInfoAnswer(hss_rc);
-    EXPECT_CALL(*_hss, send_location_info_request(_, _, _)).WillOnce(InvokeArgument<0>(ByRef(answer)));
+    EXPECT_CALL(*_hss, send_location_info_request(_, _, _, _)).WillOnce(InvokeArgument<0>(ByRef(answer)));
 
     // Expect the correct HTTP code
     EXPECT_CALL(*_httpstack, send_reply(_, http_rc, _));
@@ -596,6 +594,7 @@ TEST_F(HTTPHandlersTest, ImpiDigestMainline)
     AllOf(Field(&HssConnection::MultimediaAuthRequest::impi, IMPI),
           Field(&HssConnection::MultimediaAuthRequest::impu, IMPU),
           Field(&HssConnection::MultimediaAuthRequest::scheme, SCHEME_DIGEST)),
+    _,
     _))
     .WillOnce(InvokeArgument<0>(ByRef(answer)));
 
@@ -645,6 +644,7 @@ TEST_F(HTTPHandlersTest, ImpiDigestHssTimeout)
     AllOf(Field(&HssConnection::MultimediaAuthRequest::impi, IMPI),
           Field(&HssConnection::MultimediaAuthRequest::impu, IMPU),
           Field(&HssConnection::MultimediaAuthRequest::scheme, SCHEME_DIGEST)),
+    _,
     _))
     .WillOnce(InvokeArgument<0>(ByRef(answer)));
 
@@ -674,6 +674,7 @@ TEST_F(HTTPHandlersTest, ImpiDigestHssBusy)
     AllOf(Field(&HssConnection::MultimediaAuthRequest::impi, IMPI),
           Field(&HssConnection::MultimediaAuthRequest::impu, IMPU),
           Field(&HssConnection::MultimediaAuthRequest::scheme, SCHEME_DIGEST)),
+    _,
     _))
     .WillOnce(InvokeArgument<0>(ByRef(answer)));
 
@@ -706,6 +707,7 @@ TEST_F(HTTPHandlersTest, ImpiDigestHssUserUnknown)
     AllOf(Field(&HssConnection::MultimediaAuthRequest::impi, IMPI),
           Field(&HssConnection::MultimediaAuthRequest::impu, IMPU),
           Field(&HssConnection::MultimediaAuthRequest::scheme, SCHEME_DIGEST)),
+    _,
     _))
     .WillOnce(InvokeArgument<0>(ByRef(answer)));
 
@@ -735,6 +737,7 @@ TEST_F(HTTPHandlersTest, ImpiDigestHssOtherError)
     AllOf(Field(&HssConnection::MultimediaAuthRequest::impi, IMPI),
           Field(&HssConnection::MultimediaAuthRequest::impu, IMPU),
           Field(&HssConnection::MultimediaAuthRequest::scheme, SCHEME_DIGEST)),
+    _,
     _))
     .WillOnce(InvokeArgument<0>(ByRef(answer)));
 
@@ -766,6 +769,7 @@ TEST_F(HTTPHandlersTest, ImpiDigestHssUnknownScheme)
     AllOf(Field(&HssConnection::MultimediaAuthRequest::impi, IMPI),
           Field(&HssConnection::MultimediaAuthRequest::impu, IMPU),
           Field(&HssConnection::MultimediaAuthRequest::scheme, SCHEME_DIGEST)),
+    _,
     _))
     .WillOnce(InvokeArgument<0>(ByRef(answer)));
 
@@ -797,6 +801,7 @@ TEST_F(HTTPHandlersTest, ImpiDigestHssAKAReturned)
     AllOf(Field(&HssConnection::MultimediaAuthRequest::impi, IMPI),
           Field(&HssConnection::MultimediaAuthRequest::impu, IMPU),
           Field(&HssConnection::MultimediaAuthRequest::scheme, SCHEME_DIGEST)),
+    _,
     _))
     .WillOnce(InvokeArgument<0>(ByRef(answer)));
 
@@ -835,6 +840,7 @@ TEST_F(HTTPHandlersTest, ImpiAvEmptyQoP)
     AllOf(Field(&HssConnection::MultimediaAuthRequest::impi, IMPI),
           Field(&HssConnection::MultimediaAuthRequest::impu, IMPU),
           Field(&HssConnection::MultimediaAuthRequest::scheme, SCHEME_UNKNOWN)),
+    _,
     _))
     .WillOnce(InvokeArgument<0>(ByRef(answer)));
 
@@ -893,6 +899,7 @@ TEST_F(HTTPHandlersTest, ImpiAKA)
     AllOf(Field(&HssConnection::MultimediaAuthRequest::impi, IMPI),
           Field(&HssConnection::MultimediaAuthRequest::impu, IMPU),
           Field(&HssConnection::MultimediaAuthRequest::scheme, SCHEME_AKA)),
+    _,
     _))
     .WillOnce(InvokeArgument<0>(ByRef(answer)));
 
@@ -935,6 +942,7 @@ TEST_F(HTTPHandlersTest, ImpiAKAv2)
     AllOf(Field(&HssConnection::MultimediaAuthRequest::impi, IMPI),
           Field(&HssConnection::MultimediaAuthRequest::impu, IMPU),
           Field(&HssConnection::MultimediaAuthRequest::scheme, SCHEME_AKAV2)),
+    _,
     _))
     .WillOnce(InvokeArgument<0>(ByRef(answer)));
 
@@ -1009,6 +1017,7 @@ TEST_F(HTTPHandlersTest, ImpiRegStatusServerName)
     AllOf(Field(&HssConnection::UserAuthRequest::impi, IMPI),
           Field(&HssConnection::UserAuthRequest::impu, IMPU),
           Field(&HssConnection::UserAuthRequest::visited_network, DEST_REALM)),
+    _,
     _))
     .WillOnce(InvokeArgument<0>(ByRef(answer)));
 
@@ -1044,6 +1053,7 @@ TEST_F(HTTPHandlersTest, ImpiRegStatusCapabilities)
     AllOf(Field(&HssConnection::UserAuthRequest::impi, IMPI),
           Field(&HssConnection::UserAuthRequest::impu, IMPU),
           Field(&HssConnection::UserAuthRequest::visited_network, DEST_REALM)),
+    _,
     _))
     .WillOnce(InvokeArgument<0>(ByRef(answer)));
 
@@ -1079,6 +1089,7 @@ TEST_F(HTTPHandlersTest, ImpiRegStatusCapabilitiesWithServerName)
     AllOf(Field(&HssConnection::UserAuthRequest::impi, IMPI),
           Field(&HssConnection::UserAuthRequest::impu, IMPU),
           Field(&HssConnection::UserAuthRequest::visited_network, DEST_REALM)),
+    _,
     _))
     .WillOnce(InvokeArgument<0>(ByRef(answer)));
 
@@ -1117,6 +1128,7 @@ TEST_F(HTTPHandlersTest, ImpiRegStatusPassesHealthCheck)
     AllOf(Field(&HssConnection::UserAuthRequest::impi, IMPI),
           Field(&HssConnection::UserAuthRequest::impu, IMPU),
           Field(&HssConnection::UserAuthRequest::visited_network, DEST_REALM)),
+    _,
     _))
     .WillOnce(InvokeArgument<0>(ByRef(answer)));
 
@@ -1155,6 +1167,7 @@ TEST_F(HTTPHandlersTest, ImpiRegStatusOptParams)
           Field(&HssConnection::UserAuthRequest::impu, IMPU),
           Field(&HssConnection::UserAuthRequest::visited_network, VISITED_NETWORK),
           Field(&HssConnection::UserAuthRequest::authorization_type, AUTH_TYPE_DEREG)),
+    _,
     _))
     .WillOnce(InvokeArgument<0>(ByRef(answer)));
 
@@ -1217,7 +1230,7 @@ TEST_F(HTTPHandlersTest, LocationInfoMainline)
                                       "");
 
   // Check the contents of the LIR
-  EXPECT_CALL(*_hss, send_location_info_request(_, Field(&HssConnection::LocationInfoRequest::impu, IMPU), _))
+  EXPECT_CALL(*_hss, send_location_info_request(_, Field(&HssConnection::LocationInfoRequest::impu, IMPU), _, _))
     .WillOnce(InvokeArgument<0>(ByRef(answer)));
 
   // Expect a 200
@@ -1249,7 +1262,7 @@ TEST_F(HTTPHandlersTest, LocationInfoServerCapabilitiesNoServerName)
                                       "");
 
   // Check the contents of the LIR
-  EXPECT_CALL(*_hss, send_location_info_request(_, Field(&HssConnection::LocationInfoRequest::impu, IMPU), _))
+  EXPECT_CALL(*_hss, send_location_info_request(_, Field(&HssConnection::LocationInfoRequest::impu, IMPU), _, _))
     .WillOnce(InvokeArgument<0>(ByRef(answer)));
 
   // Expect a 200
@@ -1281,7 +1294,7 @@ TEST_F(HTTPHandlersTest, LocationInfoServerCapabilitiesWithServerName)
                                       "");
 
   // Check the contents of the LIR
-  EXPECT_CALL(*_hss, send_location_info_request(_, Field(&HssConnection::LocationInfoRequest::impu, IMPU), _))
+  EXPECT_CALL(*_hss, send_location_info_request(_, Field(&HssConnection::LocationInfoRequest::impu, IMPU), _, _))
     .WillOnce(InvokeArgument<0>(ByRef(answer)));
 
   // Expect a 200
@@ -1313,7 +1326,7 @@ TEST_F(HTTPHandlersTest, LocationInfoWithWildcard)
                                       WILDCARD);
 
   // Check the contents of the LIR
-  EXPECT_CALL(*_hss, send_location_info_request(_, Field(&HssConnection::LocationInfoRequest::impu, IMPU), _))
+  EXPECT_CALL(*_hss, send_location_info_request(_, Field(&HssConnection::LocationInfoRequest::impu, IMPU), _, _))
     .WillOnce(InvokeArgument<0>(ByRef(answer)));
 
   // Expect a 200
@@ -1349,6 +1362,7 @@ TEST_F(HTTPHandlersTest, LocationInfoOptParams)
     AllOf(Field(&HssConnection::LocationInfoRequest::impu, IMPU),
           Field(&HssConnection::LocationInfoRequest::originating, "true"),
           Field(&HssConnection::LocationInfoRequest::authorization_type, AUTH_TYPE_CAPAB)),
+    _,
     _))
     .WillOnce(InvokeArgument<0>(ByRef(answer)));
 
@@ -1495,6 +1509,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataInitialReg)
           Field(&HssConnection::ServerAssignmentRequest::impu, IMPU),
           Field(&HssConnection::ServerAssignmentRequest::server_name, SERVER_NAME),
           Field(&HssConnection::ServerAssignmentRequest::type, Cx::ServerAssignmentType::REGISTRATION)),
+    _,
     _))
     .WillOnce(InvokeArgument<0>(ByRef(answer)));
 
@@ -1545,6 +1560,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataInitialRegNoServerName)
           Field(&HssConnection::ServerAssignmentRequest::impu, IMPU),
           Field(&HssConnection::ServerAssignmentRequest::server_name, DEFAULT_SERVER_NAME),
           Field(&HssConnection::ServerAssignmentRequest::type, Cx::ServerAssignmentType::REGISTRATION)),
+    _,
     _))
     .WillOnce(InvokeArgument<0>(ByRef(answer)));
 
@@ -1595,6 +1611,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataInitialRegCacheGetNotFound)
           Field(&HssConnection::ServerAssignmentRequest::impu, IMPU),
           Field(&HssConnection::ServerAssignmentRequest::server_name, DEFAULT_SERVER_NAME),
           Field(&HssConnection::ServerAssignmentRequest::type, Cx::ServerAssignmentType::REGISTRATION)),
+    _,
     _))
     .WillOnce(InvokeArgument<0>(ByRef(answer)));
 
@@ -1666,6 +1683,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataInitialRegCachePutError)
           Field(&HssConnection::ServerAssignmentRequest::impu, IMPU),
           Field(&HssConnection::ServerAssignmentRequest::server_name, SERVER_NAME),
           Field(&HssConnection::ServerAssignmentRequest::type, Cx::ServerAssignmentType::REGISTRATION)),
+    _,
     _))
     .WillOnce(InvokeArgument<0>(ByRef(answer)));
 
@@ -1716,6 +1734,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataReReg)
           Field(&HssConnection::ServerAssignmentRequest::impu, IMPU),
           Field(&HssConnection::ServerAssignmentRequest::server_name, SERVER_NAME),
           Field(&HssConnection::ServerAssignmentRequest::type, Cx::ServerAssignmentType::RE_REGISTRATION)),
+    _,
     _))
     .WillOnce(InvokeArgument<0>(ByRef(answer)));
 
@@ -1768,6 +1787,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataReRegNoCache)
           Field(&HssConnection::ServerAssignmentRequest::impu, IMPU),
           Field(&HssConnection::ServerAssignmentRequest::server_name, SERVER_NAME),
           Field(&HssConnection::ServerAssignmentRequest::type, Cx::ServerAssignmentType::RE_REGISTRATION)),
+    _,
     _))
     .WillOnce(InvokeArgument<0>(ByRef(answer)));
 
@@ -1849,6 +1869,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataReRegNewBinding)
           Field(&HssConnection::ServerAssignmentRequest::impu, IMPU),
           Field(&HssConnection::ServerAssignmentRequest::server_name, SERVER_NAME),
           Field(&HssConnection::ServerAssignmentRequest::type, Cx::ServerAssignmentType::REGISTRATION)),
+    _,
     _))
     .WillOnce(InvokeArgument<0>(ByRef(answer)));
 
@@ -1900,6 +1921,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataRegIncludesBarring)
           Field(&HssConnection::ServerAssignmentRequest::impu, IMPU),
           Field(&HssConnection::ServerAssignmentRequest::server_name, SERVER_NAME),
           Field(&HssConnection::ServerAssignmentRequest::type, Cx::ServerAssignmentType::REGISTRATION)),
+    _,
     _))
     .WillOnce(InvokeArgument<0>(ByRef(answer)));
 
@@ -1949,6 +1971,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataCallWildcardWithSAR)
   EXPECT_CALL(*_hss, send_server_assignment_request(_,
     AllOf(Field(&HssConnection::ServerAssignmentRequest::impu, IMPU),
           Field(&HssConnection::ServerAssignmentRequest::type, Cx::ServerAssignmentType::UNREGISTERED_USER)),
+    _,
     _))
     .WillOnce(InvokeArgument<0>(ByRef(answer)));
 
@@ -1996,6 +2019,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataCallNewWildcard)
     AllOf(Field(&HssConnection::ServerAssignmentRequest::impu, IMPU),
           Field(&HssConnection::ServerAssignmentRequest::type, Cx::ServerAssignmentType::UNREGISTERED_USER),
           Field(&HssConnection::ServerAssignmentRequest::wildcard_impu, WILDCARD)),
+    _,
     _))
     .WillOnce(InvokeArgument<0>(ByRef(answer)));
 
@@ -2044,6 +2068,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataCallNewWildcardNotFound)
     AllOf(Field(&HssConnection::ServerAssignmentRequest::impu, IMPU),
           Field(&HssConnection::ServerAssignmentRequest::type, Cx::ServerAssignmentType::UNREGISTERED_USER),
           Field(&HssConnection::ServerAssignmentRequest::wildcard_impu, WILDCARD)),
+    _,
     _))
     .WillOnce(InvokeArgument<0>(ByRef(answer)));
 
@@ -2069,6 +2094,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataCallNewWildcardNotFound)
     AllOf(Field(&HssConnection::ServerAssignmentRequest::impu, IMPU),
           Field(&HssConnection::ServerAssignmentRequest::type, Cx::ServerAssignmentType::UNREGISTERED_USER),
           Field(&HssConnection::ServerAssignmentRequest::wildcard_impu, NEW_WILDCARD)),
+    _,
     _))
     .WillOnce(InvokeArgument<0>(ByRef(answer2)));
 
@@ -2109,6 +2135,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataCallWildcardLoop)
     AllOf(Field(&HssConnection::ServerAssignmentRequest::impu, IMPU),
           Field(&HssConnection::ServerAssignmentRequest::type, Cx::ServerAssignmentType::UNREGISTERED_USER),
           Field(&HssConnection::ServerAssignmentRequest::wildcard_impu, WILDCARD)),
+    _,
     _))
     .WillOnce(InvokeArgument<0>(ByRef(answer)));
 
@@ -2229,6 +2256,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataCallNewUnregisteredService)
           Field(&HssConnection::ServerAssignmentRequest::impu, IMPU),
           Field(&HssConnection::ServerAssignmentRequest::server_name, SERVER_NAME),
           Field(&HssConnection::ServerAssignmentRequest::type, Cx::ServerAssignmentType::UNREGISTERED_USER)),
+    _,
     _))
     .WillOnce(InvokeArgument<0>(ByRef(answer)));
 
@@ -2277,6 +2305,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataDeregUser)
           Field(&HssConnection::ServerAssignmentRequest::impu, IMPU),
           Field(&HssConnection::ServerAssignmentRequest::server_name, SERVER_NAME),
           Field(&HssConnection::ServerAssignmentRequest::type, Cx::ServerAssignmentType::USER_DEREGISTRATION)),
+    _,
     _))
     .WillOnce(InvokeArgument<0>(ByRef(answer)));
 
@@ -2326,6 +2355,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataDeregTimeout)
           Field(&HssConnection::ServerAssignmentRequest::impu, IMPU),
           Field(&HssConnection::ServerAssignmentRequest::server_name, SERVER_NAME),
           Field(&HssConnection::ServerAssignmentRequest::type, Cx::ServerAssignmentType::TIMEOUT_DEREGISTRATION)),
+    _,
     _))
     .WillOnce(InvokeArgument<0>(ByRef(answer)));
 
@@ -2375,6 +2405,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataDeregAdmin)
           Field(&HssConnection::ServerAssignmentRequest::impu, IMPU),
           Field(&HssConnection::ServerAssignmentRequest::server_name, SERVER_NAME),
           Field(&HssConnection::ServerAssignmentRequest::type, Cx::ServerAssignmentType::ADMINISTRATIVE_DEREGISTRATION)),
+    _,
     _))
     .WillOnce(InvokeArgument<0>(ByRef(answer)));
 
@@ -2425,6 +2456,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataDeregNoIMPI)
           Field(&HssConnection::ServerAssignmentRequest::impu, IMPU),
           Field(&HssConnection::ServerAssignmentRequest::server_name, SERVER_NAME),
           Field(&HssConnection::ServerAssignmentRequest::type, Cx::ServerAssignmentType::ADMINISTRATIVE_DEREGISTRATION)),
+    _,
     _))
     .WillOnce(InvokeArgument<0>(ByRef(answer)));
 
@@ -2474,6 +2506,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataDeregCacheError)
           Field(&HssConnection::ServerAssignmentRequest::impu, IMPU),
           Field(&HssConnection::ServerAssignmentRequest::server_name, SERVER_NAME),
           Field(&HssConnection::ServerAssignmentRequest::type, Cx::ServerAssignmentType::ADMINISTRATIVE_DEREGISTRATION)),
+    _,
     _))
     .WillOnce(InvokeArgument<0>(ByRef(answer)));
 
@@ -2523,6 +2556,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataDeregCacheNotFound)
           Field(&HssConnection::ServerAssignmentRequest::impu, IMPU),
           Field(&HssConnection::ServerAssignmentRequest::server_name, SERVER_NAME),
           Field(&HssConnection::ServerAssignmentRequest::type, Cx::ServerAssignmentType::ADMINISTRATIVE_DEREGISTRATION)),
+    _,
     _))
     .WillOnce(InvokeArgument<0>(ByRef(answer)));
 
@@ -2572,6 +2606,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataDeregUnregSub)
           Field(&HssConnection::ServerAssignmentRequest::impu, IMPU),
           Field(&HssConnection::ServerAssignmentRequest::server_name, SERVER_NAME),
           Field(&HssConnection::ServerAssignmentRequest::type, Cx::ServerAssignmentType::ADMINISTRATIVE_DEREGISTRATION)),
+    _,
     _))
     .WillOnce(InvokeArgument<0>(ByRef(answer)));
 
@@ -2623,6 +2658,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataDeregAuthFailedRegistered)
           Field(&HssConnection::ServerAssignmentRequest::impu, IMPU),
           Field(&HssConnection::ServerAssignmentRequest::server_name, DEFAULT_SERVER_NAME),
           Field(&HssConnection::ServerAssignmentRequest::type, Cx::ServerAssignmentType::AUTHENTICATION_FAILURE)),
+    _,
     _))
     .WillOnce(InvokeArgument<0>(ByRef(answer)));
 
@@ -2666,6 +2702,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataDeregAuthFailedNotRegistered)
           Field(&HssConnection::ServerAssignmentRequest::impu, IMPU),
           Field(&HssConnection::ServerAssignmentRequest::server_name, DEFAULT_SERVER_NAME),
           Field(&HssConnection::ServerAssignmentRequest::type, Cx::ServerAssignmentType::AUTHENTICATION_FAILURE)),
+    _,
     _))
     .WillOnce(InvokeArgument<0>(ByRef(answer)));
 
@@ -2709,6 +2746,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataDeregAuthTimeout)
           Field(&HssConnection::ServerAssignmentRequest::impu, IMPU),
           Field(&HssConnection::ServerAssignmentRequest::server_name, DEFAULT_SERVER_NAME),
           Field(&HssConnection::ServerAssignmentRequest::type, Cx::ServerAssignmentType::AUTHENTICATION_TIMEOUT)),
+    _,
     _))
     .WillOnce(InvokeArgument<0>(ByRef(answer)));
 
@@ -2775,6 +2813,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataInvalidXML)
           Field(&HssConnection::ServerAssignmentRequest::impu, IMPU),
           Field(&HssConnection::ServerAssignmentRequest::server_name, DEFAULT_SERVER_NAME),
           Field(&HssConnection::ServerAssignmentRequest::type, Cx::ServerAssignmentType::REGISTRATION)),
+    _,
     _))
     .WillOnce(InvokeArgument<0>(ByRef(answer)));
 
@@ -2855,6 +2894,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataHssNotFound)
           Field(&HssConnection::ServerAssignmentRequest::impu, IMPU),
           Field(&HssConnection::ServerAssignmentRequest::server_name, SERVER_NAME),
           Field(&HssConnection::ServerAssignmentRequest::type, Cx::ServerAssignmentType::REGISTRATION)),
+    _,
     _))
     .WillOnce(InvokeArgument<0>(ByRef(answer)));
 
@@ -2893,6 +2933,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataHssUnavailable)
           Field(&HssConnection::ServerAssignmentRequest::impu, IMPU),
           Field(&HssConnection::ServerAssignmentRequest::server_name, SERVER_NAME),
           Field(&HssConnection::ServerAssignmentRequest::type, Cx::ServerAssignmentType::REGISTRATION)),
+    _,
     _))
     .WillOnce(InvokeArgument<0>(ByRef(answer)));
 
@@ -2931,6 +2972,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataHssUnknownError)
           Field(&HssConnection::ServerAssignmentRequest::impu, IMPU),
           Field(&HssConnection::ServerAssignmentRequest::server_name, SERVER_NAME),
           Field(&HssConnection::ServerAssignmentRequest::type, Cx::ServerAssignmentType::REGISTRATION)),
+    _,
     _))
     .WillOnce(InvokeArgument<0>(ByRef(answer)));
 

--- a/src/ut/http_handlers_test.cpp
+++ b/src/ut/http_handlers_test.cpp
@@ -1420,7 +1420,7 @@ TEST_F(HTTPHandlersTest, ImpuReadRegDataMainline)
   irs->set_ims_sub_xml(IMPU_IMS_SUBSCRIPTION);
   irs->set_reg_state(RegistrationState::REGISTERED);
 
-  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, IMPU, FAKE_TRAIL_ID))
+  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, IMPU, FAKE_TRAIL_ID, _))
     .WillOnce(InvokeArgument<0>(irs));
 
   // HTTP response is sent straight back - no state is changed.
@@ -1445,7 +1445,7 @@ TEST_F(HTTPHandlersTest, ImpuReadRegDataCacheGetNotFound)
   ImpuReadRegDataTask* task = new ImpuReadRegDataTask(req, &cfg, FAKE_TRAIL_ID);
 
   // Set up the cache to hit an error
-  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, IMPU, FAKE_TRAIL_ID))
+  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, IMPU, FAKE_TRAIL_ID, _))
     .WillOnce(InvokeArgument<1>(Store::Status::NOT_FOUND));
 
   // 404 error expected
@@ -1493,7 +1493,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataInitialReg)
   irs->set_charging_addresses(NO_CHARGING_ADDRESSES);
 
   // Set up the cache to return our IRS
-  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, IMPU, FAKE_TRAIL_ID))
+  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, IMPU, FAKE_TRAIL_ID, _))
     .WillOnce(InvokeArgument<0>(irs));
 
   // Create an SAA with which the mock hss will respond to our SAR
@@ -1518,7 +1518,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataInitialReg)
     AllOf(Property(&ImplicitRegistrationSet::get_reg_state, RegistrationState::REGISTERED),
           Property(&ImplicitRegistrationSet::get_ttl, 7200),
           Property(&ImplicitRegistrationSet::get_associated_impis, IMPI_IN_VECTOR)),
-    FAKE_TRAIL_ID))
+    FAKE_TRAIL_ID, _))
     .WillOnce(DoAll(InvokeArgument<1>(), InvokeArgument<0>()));
 
   // Expect 200 response
@@ -1544,7 +1544,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataInitialRegNoServerName)
   irs->set_charging_addresses(NO_CHARGING_ADDRESSES);
 
   // Set up the cache to return our IRS
-  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, IMPU, FAKE_TRAIL_ID))
+  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, IMPU, FAKE_TRAIL_ID, _))
     .WillOnce(InvokeArgument<0>(irs));
 
   // Create an SAA with which the mock hss will respond to our SAR
@@ -1568,7 +1568,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataInitialRegNoServerName)
   EXPECT_CALL(*_cache, put_implicit_registration_set(_, _, _,
     AllOf(Property(&ImplicitRegistrationSet::get_reg_state, RegistrationState::REGISTERED),
           Property(&ImplicitRegistrationSet::get_ttl, 7200)),
-    FAKE_TRAIL_ID))
+    FAKE_TRAIL_ID, _))
     .WillOnce(DoAll(InvokeArgument<1>(), InvokeArgument<0>()));
 
   // Expect 200 response
@@ -1590,7 +1590,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataInitialRegCacheGetNotFound)
   ImpuRegDataTask* task = new ImpuRegDataTask(req, &cfg, FAKE_TRAIL_ID);
 
   // Set up the cache to return NOT_FOUND
-  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, IMPU, FAKE_TRAIL_ID))
+  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, IMPU, FAKE_TRAIL_ID, _))
     .WillOnce(InvokeArgument<1>(Store::Status::NOT_FOUND));
 
   // Create IRS to be returned from the cache whenthe above is not found
@@ -1621,7 +1621,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataInitialRegCacheGetNotFound)
   EXPECT_CALL(*_cache, put_implicit_registration_set(_, _, _,
     AllOf(Property(&ImplicitRegistrationSet::get_reg_state, RegistrationState::REGISTERED),
           Property(&ImplicitRegistrationSet::get_ttl, 7200)),
-    FAKE_TRAIL_ID))
+    FAKE_TRAIL_ID, _))
     .WillOnce(DoAll(InvokeArgument<1>(), InvokeArgument<0>()));
 
   // Expect 200 response
@@ -1641,7 +1641,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataInitialRegCacheGetError)
   ImpuRegDataTask* task = new ImpuRegDataTask(req, &cfg, FAKE_TRAIL_ID);
 
   // Set up the cache to hit an error
-  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, IMPU, FAKE_TRAIL_ID))
+  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, IMPU, FAKE_TRAIL_ID, _))
     .WillOnce(InvokeArgument<1>(Store::Status::ERROR));
 
   // 504 error expected
@@ -1667,7 +1667,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataInitialRegCachePutError)
   irs->set_charging_addresses(NO_CHARGING_ADDRESSES);
 
   // Set up the cache to return our IRS
-  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, IMPU, FAKE_TRAIL_ID))
+  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, IMPU, FAKE_TRAIL_ID, _))
     .WillOnce(InvokeArgument<0>(irs));
 
   // Create an SAA with which the mock hss will respond to our SAR
@@ -1691,7 +1691,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataInitialRegCachePutError)
   EXPECT_CALL(*_cache, put_implicit_registration_set(_, _, _,
     AllOf(Property(&ImplicitRegistrationSet::get_reg_state, RegistrationState::REGISTERED),
           Property(&ImplicitRegistrationSet::get_ttl, 7200)),
-    FAKE_TRAIL_ID))
+    FAKE_TRAIL_ID, _))
     .WillOnce(InvokeArgument<2>(Store::Status::ERROR));
 
   // Expect 503 response
@@ -1718,7 +1718,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataReReg)
   irs->add_associated_impi(IMPI);
 
   // Set up the cache to return our IRS
-  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, IMPU, FAKE_TRAIL_ID))
+  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, IMPU, FAKE_TRAIL_ID, _))
     .WillOnce(InvokeArgument<0>(irs));
 
   // Create an SAA with which the mock hss will respond to our SAR
@@ -1742,7 +1742,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataReReg)
   EXPECT_CALL(*_cache, put_implicit_registration_set(_, _, _,
     AllOf(Property(&ImplicitRegistrationSet::get_reg_state, RegistrationState::REGISTERED),
           Property(&ImplicitRegistrationSet::get_ttl, 7200)),
-    FAKE_TRAIL_ID))
+    FAKE_TRAIL_ID, _))
     .WillOnce(DoAll(InvokeArgument<1>(), InvokeArgument<0>()));
 
   // Expect 200 response
@@ -1771,7 +1771,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataReRegNoCache)
   irs->set_ttl(7200);
 
   // Set up the cache to return our IRS
-  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, IMPU, FAKE_TRAIL_ID))
+  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, IMPU, FAKE_TRAIL_ID, _))
     .WillOnce(InvokeArgument<0>(irs));
 
   // Create an SAA with which the mock hss will respond to our SAR
@@ -1795,7 +1795,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataReRegNoCache)
   EXPECT_CALL(*_cache, put_implicit_registration_set(_, _, _,
     AllOf(Property(&ImplicitRegistrationSet::get_reg_state, RegistrationState::REGISTERED),
           Property(&ImplicitRegistrationSet::get_ttl, 7200)),
-    FAKE_TRAIL_ID))
+    FAKE_TRAIL_ID, _))
     .WillOnce(DoAll(InvokeArgument<1>(), InvokeArgument<0>()));
 
   // Expect 200 response
@@ -1824,7 +1824,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataReRegCached)
   irs->add_associated_impi(IMPI);
 
   // Set up the cache to return our IRS
-  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, IMPU, FAKE_TRAIL_ID))
+  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, IMPU, FAKE_TRAIL_ID, _))
     .WillOnce(InvokeArgument<0>(irs));
 
   // No SAR is made, and not new data added to cache
@@ -1852,7 +1852,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataReRegNewBinding)
   irs->set_charging_addresses(NO_CHARGING_ADDRESSES);
 
   // Set up the cache to return our IRS
-  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, IMPU, FAKE_TRAIL_ID))
+  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, IMPU, FAKE_TRAIL_ID, _))
     .WillOnce(InvokeArgument<0>(irs));
 
   // Create an SAA with which the mock hss will respond to our SAR
@@ -1877,7 +1877,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataReRegNewBinding)
   EXPECT_CALL(*_cache, put_implicit_registration_set(_, _, _,
     AllOf(Property(&ImplicitRegistrationSet::get_reg_state, RegistrationState::REGISTERED),
           Property(&ImplicitRegistrationSet::get_ttl, 7200)),
-    FAKE_TRAIL_ID))
+    FAKE_TRAIL_ID, _))
     .WillOnce(DoAll(InvokeArgument<1>(), InvokeArgument<0>()));
 
   // Expect 200 response
@@ -1905,7 +1905,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataRegIncludesBarring)
   irs->set_charging_addresses(NO_CHARGING_ADDRESSES);
 
   // Set up the cache to return our IRS
-  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, IMPU, FAKE_TRAIL_ID))
+  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, IMPU, FAKE_TRAIL_ID, _))
     .WillOnce(InvokeArgument<0>(irs));
 
   // Create an SAA with which the mock hss will respond to our SAR
@@ -1929,7 +1929,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataRegIncludesBarring)
   EXPECT_CALL(*_cache, put_implicit_registration_set(_, _, _,
     AllOf(Property(&ImplicitRegistrationSet::get_reg_state, RegistrationState::REGISTERED),
           Property(&ImplicitRegistrationSet::get_ttl, 7200)),
-    FAKE_TRAIL_ID))
+    FAKE_TRAIL_ID, _))
     .WillOnce(DoAll(InvokeArgument<1>(), InvokeArgument<0>()));
 
   // Expect 200 response
@@ -1955,7 +1955,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataCallWildcardWithSAR)
   irs->set_reg_state(RegistrationState::NOT_REGISTERED);
 
   // Set up the cache to return our IRS
-  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, IMPU, FAKE_TRAIL_ID))
+  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, IMPU, FAKE_TRAIL_ID, _))
     .WillOnce(InvokeArgument<0>(irs));
 
   // Create an SAA with which the mock hss will respond to our SAR
@@ -1980,7 +1980,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataCallWildcardWithSAR)
   FakeImplicitRegistrationSet* irs2 = new FakeImplicitRegistrationSet(IMPU);
   irs2->set_reg_state(RegistrationState::REGISTERED);
 
-  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, WILDCARD, FAKE_TRAIL_ID))
+  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, WILDCARD, FAKE_TRAIL_ID, _))
     .WillOnce(InvokeArgument<0>(irs2));
 
   // Expect 200 response
@@ -2002,7 +2002,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataCallNewWildcard)
   irs->set_reg_state(RegistrationState::NOT_REGISTERED);
 
   // Set up the cache to return our IRS
-  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, WILDCARD, FAKE_TRAIL_ID))
+  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, WILDCARD, FAKE_TRAIL_ID, _))
     .WillOnce(InvokeArgument<0>(irs));
 
   // Create an SAA with which the mock hss will respond to our SAR
@@ -2028,7 +2028,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataCallNewWildcard)
   FakeImplicitRegistrationSet* irs2 = new FakeImplicitRegistrationSet(IMPU);
   irs2->set_reg_state(RegistrationState::REGISTERED);
 
-  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, NEW_WILDCARD, FAKE_TRAIL_ID))
+  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, NEW_WILDCARD, FAKE_TRAIL_ID, _))
     .WillOnce(InvokeArgument<0>(irs2));
 
   // Expect 200 response
@@ -2051,7 +2051,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataCallNewWildcardNotFound)
   irs->set_reg_state(RegistrationState::NOT_REGISTERED);
 
   // Set up the cache to return our IRS
-  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, WILDCARD, FAKE_TRAIL_ID))
+  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, WILDCARD, FAKE_TRAIL_ID, _))
     .WillOnce(InvokeArgument<0>(irs));
 
   // Create an SAA with which the mock hss will respond to our SAR
@@ -2074,7 +2074,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataCallNewWildcardNotFound)
 
   // We now expect another cache lookup for the new wildcard impu, which will
   // return NOT_FOUND
-  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, NEW_WILDCARD, FAKE_TRAIL_ID))
+  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, NEW_WILDCARD, FAKE_TRAIL_ID, _))
     .WillOnce(InvokeArgument<1>(Store::Status::NOT_FOUND));
 
   // Create IRS to be returned from the cache when we fail to find the above
@@ -2118,7 +2118,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataCallWildcardLoop)
   irs->set_reg_state(RegistrationState::NOT_REGISTERED);
 
   // Set up the cache to return our IRS
-  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, WILDCARD, FAKE_TRAIL_ID))
+  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, WILDCARD, FAKE_TRAIL_ID, _))
     .WillOnce(InvokeArgument<0>(irs));
 
   // Create an SAA with which the mock hss will respond to our SAR
@@ -2161,7 +2161,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataCallMainline)
   irs->add_associated_impi(IMPI);
 
   // Set up the cache to return our IRS
-  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, IMPU, FAKE_TRAIL_ID))
+  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, IMPU, FAKE_TRAIL_ID, _))
     .WillOnce(InvokeArgument<0>(irs));
 
   // Check the response
@@ -2188,7 +2188,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataCallWildcard)
   irs->add_associated_impi(IMPI);
 
   // Set up the cache to return our IRS
-  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, WILDCARD, FAKE_TRAIL_ID))
+  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, WILDCARD, FAKE_TRAIL_ID, _))
     .WillOnce(InvokeArgument<0>(irs));
 
   // Check the response
@@ -2215,7 +2215,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataCallUnregisteredService)
   irs->add_associated_impi(IMPI);
 
   // Set up the cache to return our IRS
-  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, IMPU, FAKE_TRAIL_ID))
+  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, IMPU, FAKE_TRAIL_ID, _))
     .WillOnce(InvokeArgument<0>(irs));
 
   // Check the response
@@ -2236,7 +2236,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataCallNewUnregisteredService)
   ImpuRegDataTask* task = new ImpuRegDataTask(req, &cfg, FAKE_TRAIL_ID);
 
   // Get NOT_FOUND from the cache
-  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, IMPU, FAKE_TRAIL_ID))
+  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, IMPU, FAKE_TRAIL_ID, _))
     .WillOnce(InvokeArgument<1>(Store::Status::NOT_FOUND));
 
   // Create IRS to be returned from the cache when we fail to find the above
@@ -2264,7 +2264,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataCallNewUnregisteredService)
   EXPECT_CALL(*_cache, put_implicit_registration_set(_, _, _,
     AllOf(Property(&ImplicitRegistrationSet::get_reg_state, RegistrationState::UNREGISTERED),
           Property(&ImplicitRegistrationSet::get_ttl, 7200)),
-    FAKE_TRAIL_ID))
+    FAKE_TRAIL_ID, _))
     .WillOnce(DoAll(InvokeArgument<1>(), InvokeArgument<0>()));
 
   // Check the response
@@ -2291,7 +2291,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataDeregUser)
   irs->add_associated_impi(IMPI);
 
   // Lookup use in cache
-  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, IMPU, FAKE_TRAIL_ID))
+  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, IMPU, FAKE_TRAIL_ID, _))
     .WillOnce(InvokeArgument<0>(irs));
 
   // Then send SAR, which gets SUCCESS back
@@ -2314,8 +2314,9 @@ TEST_F(HTTPHandlersTest, ImpuRegDataDeregUser)
   // that's how the cache knows what to delete)
   EXPECT_CALL(*_cache, delete_implicit_registration_set(_, _, _,
     Property(&ImplicitRegistrationSet::get_ims_sub_xml, IMPU_IMS_SUBSCRIPTION),
-    FAKE_TRAIL_ID))
+    FAKE_TRAIL_ID, _))
     .WillOnce(DoAll(InvokeArgument<1>(), InvokeArgument<0>()));
+
 
   // Check the response
   EXPECT_CALL(*_httpstack, send_reply(_, 200, _));
@@ -2341,7 +2342,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataDeregTimeout)
   irs->add_associated_impi(IMPI);
 
   // Lookup use in cache
-  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, IMPU, FAKE_TRAIL_ID))
+  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, IMPU, FAKE_TRAIL_ID, _))
     .WillOnce(InvokeArgument<0>(irs));
 
   // Then send SAR, which gets SUCCESS back
@@ -2364,7 +2365,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataDeregTimeout)
   // that's how the cache knows what to delete)
   EXPECT_CALL(*_cache, delete_implicit_registration_set(_, _, _,
     Property(&ImplicitRegistrationSet::get_ims_sub_xml, IMPU_IMS_SUBSCRIPTION),
-    FAKE_TRAIL_ID))
+    FAKE_TRAIL_ID, _))
     .WillOnce(DoAll(InvokeArgument<1>(), InvokeArgument<0>()));
 
   // Check the response
@@ -2391,7 +2392,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataDeregAdmin)
   irs->add_associated_impi(IMPI);
 
   // Lookup use in cache
-  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, IMPU, FAKE_TRAIL_ID))
+  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, IMPU, FAKE_TRAIL_ID, _))
     .WillOnce(InvokeArgument<0>(irs));
 
   // Then send SAR, which gets SUCCESS back
@@ -2414,7 +2415,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataDeregAdmin)
   // that's how the cache knows what to delete)
   EXPECT_CALL(*_cache, delete_implicit_registration_set(_, _, _,
     Property(&ImplicitRegistrationSet::get_ims_sub_xml, IMPU_IMS_SUBSCRIPTION),
-    FAKE_TRAIL_ID))
+    FAKE_TRAIL_ID, _))
     .WillOnce(DoAll(InvokeArgument<1>(), InvokeArgument<0>()));
 
   // Check the response
@@ -2442,7 +2443,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataDeregNoIMPI)
   irs->add_associated_impi(IMPI);
 
   // Lookup use in cache
-  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, IMPU, FAKE_TRAIL_ID))
+  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, IMPU, FAKE_TRAIL_ID, _))
     .WillOnce(InvokeArgument<0>(irs));
 
   // Then send SAR, which gets SUCCESS back
@@ -2465,7 +2466,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataDeregNoIMPI)
   // that's how the cache knows what to delete)
   EXPECT_CALL(*_cache, delete_implicit_registration_set(_, _, _,
     Property(&ImplicitRegistrationSet::get_ims_sub_xml, IMPU_IMS_SUBSCRIPTION),
-    FAKE_TRAIL_ID))
+    FAKE_TRAIL_ID, _))
     .WillOnce(DoAll(InvokeArgument<1>(), InvokeArgument<0>()));
 
   // Check the response
@@ -2492,7 +2493,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataDeregCacheError)
   irs->add_associated_impi(IMPI);
 
   // Lookup use in cache
-  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, IMPU, FAKE_TRAIL_ID))
+  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, IMPU, FAKE_TRAIL_ID, _))
     .WillOnce(InvokeArgument<0>(irs));
 
   // Then send SAR, which gets SUCCESS back
@@ -2515,7 +2516,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataDeregCacheError)
   // that's how the cache knows what to delete)
   EXPECT_CALL(*_cache, delete_implicit_registration_set(_, _, _,
     Property(&ImplicitRegistrationSet::get_ims_sub_xml, IMPU_IMS_SUBSCRIPTION),
-    FAKE_TRAIL_ID))
+    FAKE_TRAIL_ID, _))
     .WillOnce(InvokeArgument<2>(Store::Status::ERROR));
 
   // Check the response
@@ -2542,7 +2543,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataDeregCacheNotFound)
   irs->add_associated_impi(IMPI);
 
   // Lookup use in cache
-  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, IMPU, FAKE_TRAIL_ID))
+  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, IMPU, FAKE_TRAIL_ID, _))
     .WillOnce(InvokeArgument<0>(irs));
 
   // Then send SAR, which gets SUCCESS back
@@ -2565,7 +2566,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataDeregCacheNotFound)
   // that's how the cache knows what to delete)
   EXPECT_CALL(*_cache, delete_implicit_registration_set(_, _, _,
     Property(&ImplicitRegistrationSet::get_ims_sub_xml, IMPU_IMS_SUBSCRIPTION),
-    FAKE_TRAIL_ID))
+    FAKE_TRAIL_ID, _))
     .WillOnce(InvokeArgument<2>(Store::Status::NOT_FOUND));
 
   // Check the response
@@ -2592,7 +2593,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataDeregUnregSub)
   irs->add_associated_impi(IMPI);
 
   // Lookup irs in cache
-  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, IMPU, FAKE_TRAIL_ID))
+  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, IMPU, FAKE_TRAIL_ID, _))
     .WillOnce(InvokeArgument<0>(irs));
 
   // Then send SAR, which gets SUCCESS back
@@ -2615,7 +2616,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataDeregUnregSub)
   // that's how the cache knows what to delete)
   EXPECT_CALL(*_cache, delete_implicit_registration_set(_, _, _,
     Property(&ImplicitRegistrationSet::get_ims_sub_xml, IMPU_IMS_SUBSCRIPTION),
-    FAKE_TRAIL_ID))
+    FAKE_TRAIL_ID, _))
     .WillOnce(DoAll(InvokeArgument<1>(), InvokeArgument<0>()));
 
   // Check the response
@@ -2644,7 +2645,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataDeregAuthFailedRegistered)
   irs->add_associated_impi(IMPI);
 
   // Expect a cache lookup will return IRS in state REGISTERED
-  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, IMPU, FAKE_TRAIL_ID))
+  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, IMPU, FAKE_TRAIL_ID, _))
     .WillOnce(InvokeArgument<0>(irs));
 
   // Then send an auth failure SAR, which gets SUCCESS back
@@ -2688,7 +2689,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataDeregAuthFailedNotRegistered)
   irs->add_associated_impi(IMPI);
 
   // Expect a cache lookup will return IRS in state NOT_REGISTERED
-  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, IMPU, FAKE_TRAIL_ID))
+  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, IMPU, FAKE_TRAIL_ID, _))
     .WillOnce(InvokeArgument<0>(irs));
 
   // Then send an auth failure SAR, which gets SUCCESS back
@@ -2732,7 +2733,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataDeregAuthTimeout)
   irs->add_associated_impi(IMPI);
 
   // Expect a cache lookup will return IRS in state NOT_REGISTERED
-  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, IMPU, FAKE_TRAIL_ID))
+  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, IMPU, FAKE_TRAIL_ID, _))
     .WillOnce(InvokeArgument<0>(irs));
 
   // Then send an auth timeout SAR, which gets SUCCESS back
@@ -2775,7 +2776,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataDeregInvalid)
   irs->add_associated_impi(IMPI);
 
   // Expect a cache lookup will return IRS in state NOT_REGISTERED
-  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, IMPU, FAKE_TRAIL_ID))
+  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, IMPU, FAKE_TRAIL_ID, _))
     .WillOnce(InvokeArgument<0>(irs));
 
   // No SAR, just a 400 Bad Request
@@ -2795,7 +2796,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataInvalidXML)
   ImpuRegDataTask* task = new ImpuRegDataTask(req, &cfg, FAKE_TRAIL_ID);
 
   // Cache doesn't find anything, and so creates an empty IRS
-  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, IMPU, FAKE_TRAIL_ID))
+  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, IMPU, FAKE_TRAIL_ID, _))
     .WillOnce(InvokeArgument<1>(Store::Status::NOT_FOUND));
 
   FakeImplicitRegistrationSet* irs = new FakeImplicitRegistrationSet(IMPU);
@@ -2883,7 +2884,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataHssNotFound)
   irs->add_associated_impi(IMPI);
 
   // Expect a cache lookup will return IRS in state NOT_REGISTERED
-  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, IMPU, FAKE_TRAIL_ID))
+  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, IMPU, FAKE_TRAIL_ID, _))
     .WillOnce(InvokeArgument<0>(irs));
 
   // Then send a SAR, which gets a NOT_FOUND error
@@ -2922,7 +2923,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataHssUnavailable)
   irs->add_associated_impi(IMPI);
 
   // Expect a cache lookup will return IRS in state NOT_REGISTERED
-  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, IMPU, FAKE_TRAIL_ID))
+  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, IMPU, FAKE_TRAIL_ID, _))
     .WillOnce(InvokeArgument<0>(irs));
 
   // Then send a SAR, which gets a SERVER_UNAVAILABLE error
@@ -2961,7 +2962,7 @@ TEST_F(HTTPHandlersTest, ImpuRegDataHssUnknownError)
   irs->add_associated_impi(IMPI);
 
   // Expect a cache lookup will return IRS in state NOT_REGISTERED
-  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, IMPU, FAKE_TRAIL_ID))
+  EXPECT_CALL(*_cache, get_implicit_registration_set_for_impu(_, _, IMPU, FAKE_TRAIL_ID, _))
     .WillOnce(InvokeArgument<0>(irs));
 
   // Then send a SAR, which gets a NOT_FOUND error

--- a/src/ut/memcachedcache_test.cpp
+++ b/src/ut/memcachedcache_test.cpp
@@ -739,6 +739,7 @@ TEST_F(MemcachedCacheTest, GetIrsForImpis)
   Store::Status status =
     _memcached_cache->get_implicit_registration_sets_for_impis({IMPI},
                                                                0L,
+                                                               nullptr,
                                                                irss);
 
 
@@ -758,6 +759,7 @@ TEST_F(MemcachedCacheTest, GetIrsForImpisNotFound)
   Store::Status status =
     _memcached_cache->get_implicit_registration_sets_for_impis({IMPI},
                                                                0L,
+                                                               nullptr,
                                                                irss);
 
 
@@ -789,6 +791,7 @@ TEST_F(MemcachedCacheTest, GetIrsForImpuLocalStore)
   Store::Status status =
     _memcached_cache->get_implicit_registration_set_for_impu(IMPU,
                                                              0L,
+                                                             nullptr,
                                                              irs);
 
   ASSERT_EQ(Store::Status::OK, status);
@@ -804,6 +807,7 @@ TEST_F(MemcachedCacheTest, GetIrsForImpuNotFound)
   Store::Status status =
     _memcached_cache->get_implicit_registration_set_for_impu(IMPU,
                                                              0L,
+                                                             nullptr,
                                                              irs);
 
   ASSERT_EQ(Store::Status::NOT_FOUND, status);
@@ -841,6 +845,7 @@ TEST_F(MemcachedCacheTest, GetIrsForImpuLocalStoreViaAssocImpu)
   Store::Status status =
     _memcached_cache->get_implicit_registration_set_for_impu(ASSOC_IMPU,
                                                              0L,
+                                                             nullptr,
                                                              irs);
 
   ASSERT_EQ(Store::Status::OK, status);
@@ -880,6 +885,7 @@ TEST_F(MemcachedCacheTest, GetIrsForImpuLocalStoreViaAssocImpuWithoutImpu)
   Store::Status status =
     _memcached_cache->get_implicit_registration_set_for_impu(ASSOC_IMPU,
                                                              0L,
+                                                             nullptr,
                                                              irs);
 
   ASSERT_EQ(Store::Status::NOT_FOUND, status);
@@ -904,6 +910,7 @@ TEST_F(MemcachedCacheTest, GetIrsForImpuLocalStoreViaAssocImpuMissingDefault)
   Store::Status status =
     _memcached_cache->get_implicit_registration_set_for_impu(ASSOC_IMPU,
                                                              0L,
+                                                             nullptr,
                                                              irs);
 
   ASSERT_EQ(Store::Status::NOT_FOUND, status);
@@ -943,6 +950,7 @@ TEST_F(MemcachedCacheTest, GetIrsForImpuLocalStoreViaAssocImpuToAssocImpu)
   Store::Status status =
     _memcached_cache->get_implicit_registration_set_for_impu(ASSOC_IMPU,
                                                              0L,
+                                                             nullptr,
                                                              irs);
 
   ASSERT_EQ(Store::Status::NOT_FOUND, status);
@@ -973,6 +981,7 @@ TEST_F(MemcachedCacheTest, GetIrsForImpuRemoteStore)
   Store::Status status =
     _memcached_cache->get_implicit_registration_set_for_impu(IMPU,
                                                              0L,
+                                                             nullptr,
                                                              irs);
 
   ASSERT_EQ(Store::Status::OK, status);
@@ -1003,6 +1012,7 @@ TEST_F(MemcachedCacheTest, GetIrsForImpuSecondRemoteStore)
   Store::Status status =
     _memcached_cache->get_implicit_registration_set_for_impu(IMPU,
                                                              0L,
+                                                             nullptr,
                                                              irs);
 
   ASSERT_EQ(Store::Status::OK, status);
@@ -1035,6 +1045,7 @@ TEST_F(MemcachedCacheTest, GetIrsForImpuBothRemoteStores)
   Store::Status status =
     _memcached_cache->get_implicit_registration_set_for_impu(IMPU,
                                                              0L,
+                                                             nullptr,
                                                              irs);
 
   ASSERT_EQ(Store::Status::OK, status);
@@ -1053,7 +1064,7 @@ TEST_F(MemcachedCacheTest, PutIrs)
   irs->set_reg_state(RegistrationState::REGISTERED);
 
   EXPECT_CALL(*_mock_progress_cb, progress_callback());
-  Store::Status status = _memcached_cache->put_implicit_registration_set(irs, _progress_callback, 0L);
+  Store::Status status = _memcached_cache->put_implicit_registration_set(irs, _progress_callback, 0L, nullptr);
   EXPECT_EQ(Store::Status::OK, status);
 
   delete irs;
@@ -1090,12 +1101,12 @@ TEST_F(MemcachedCacheTest, PutIrsWithExistingUnrefreshed)
 
   ImplicitRegistrationSet* irs;
 
-  _memcached_cache->get_implicit_registration_set_for_impu(IMPU, 0L, irs);
+  _memcached_cache->get_implicit_registration_set_for_impu(IMPU, 0L, nullptr, irs);
 
   irs->add_associated_impi(IMPI);
 
   EXPECT_CALL(*_mock_progress_cb, progress_callback());
-  Store::Status status = _memcached_cache->put_implicit_registration_set(irs, _progress_callback, 0L);
+  Store::Status status = _memcached_cache->put_implicit_registration_set(irs, _progress_callback, 0L, nullptr);
   EXPECT_EQ(Store::Status::OK, status);
 
   delete irs;
@@ -1122,7 +1133,7 @@ TEST_F(MemcachedCacheTest, PutIrsWithExistingNotRefreshedConflictAssociated)
 
   ImplicitRegistrationSet* irs;
 
-  _memcached_cache->get_implicit_registration_set_for_impu(IMPU, 0L, irs);
+  _memcached_cache->get_implicit_registration_set_for_impu(IMPU, 0L, nullptr, irs);
 
   irs->set_ims_sub_xml(SERVICE_PROFILE_3);
 
@@ -1138,7 +1149,7 @@ TEST_F(MemcachedCacheTest, PutIrsWithExistingNotRefreshedConflictAssociated)
 
   // Errors don't trigger the progress_callback
   EXPECT_EQ(Store::Status::ERROR,
-            _memcached_cache->put_implicit_registration_set(irs, _progress_callback, 0L));
+            _memcached_cache->put_implicit_registration_set(irs, _progress_callback, 0L, nullptr));
 
   delete irs;
 }
@@ -1164,7 +1175,7 @@ TEST_F(MemcachedCacheTest, PutIrsWithExistingRefreshedConflictAssociated)
 
   ImplicitRegistrationSet* irs;
 
-  _memcached_cache->get_implicit_registration_set_for_impu(IMPU, 0L, irs);
+  _memcached_cache->get_implicit_registration_set_for_impu(IMPU, 0L, nullptr, irs);
 
   irs->set_ttl(2);
   irs->set_ims_sub_xml(SERVICE_PROFILE_3);
@@ -1184,7 +1195,7 @@ TEST_F(MemcachedCacheTest, PutIrsWithExistingRefreshedConflictAssociated)
   }
 
   EXPECT_CALL(*_mock_progress_cb, progress_callback());
-  Store::Status status = _memcached_cache->put_implicit_registration_set(irs, _progress_callback, 0L);
+  Store::Status status = _memcached_cache->put_implicit_registration_set(irs, _progress_callback, 0L, nullptr);
   EXPECT_EQ(Store::Status::OK, status);
 
   delete irs;
@@ -1213,16 +1224,17 @@ TEST_F(MemcachedCacheTest, AddNewIrsUnregistered)
   reg_irs->set_ims_sub_xml(SERVICE_PROFILE);
 
   EXPECT_CALL(*_mock_progress_cb, progress_callback()).Times(2);
-  Store::Status status = _memcached_cache->put_implicit_registration_set(reg_irs, _progress_callback, 0L);
+  Store::Status status = _memcached_cache->put_implicit_registration_set(reg_irs, _progress_callback, 0L, nullptr);
   EXPECT_EQ(Store::Status::OK, status);
 
-  status = _memcached_cache->put_implicit_registration_set(unreg_irs, _progress_callback, 0L);
+  status = _memcached_cache->put_implicit_registration_set(unreg_irs, _progress_callback, 0L, nullptr);
   EXPECT_EQ(Store::Status::OK, status);
 
   // Now, get the data from the store and check that the reg state is REGISTERED
   ImplicitRegistrationSet* stored_irs = nullptr;
   status = _memcached_cache->get_implicit_registration_set_for_impu(IMPU,
                                                                     0L,
+                                                                    nullptr,
                                                                     stored_irs);
   ASSERT_EQ(Store::Status::OK, status);
   ASSERT_NE(nullptr, stored_irs);
@@ -1247,7 +1259,7 @@ TEST_F(MemcachedCacheTest, PutIrsRemoteError)
 
   // Expect that we still report success, but that we log the error
   EXPECT_CALL(*_mock_progress_cb, progress_callback());
-  Store::Status status = _memcached_cache->put_implicit_registration_set(irs, _progress_callback, 0L);
+  Store::Status status = _memcached_cache->put_implicit_registration_set(irs, _progress_callback, 0L, nullptr);
   EXPECT_EQ(Store::Status::OK, status);
 
   EXPECT_TRUE(log.contains("Failed to perform operation to remote store with error 4"));
@@ -1264,7 +1276,7 @@ TEST_F(MemcachedCacheTest, PutIrsUnchanged)
 
   // Expect that we still report success and call the progress callback
   EXPECT_CALL(*_mock_progress_cb, progress_callback());
-  Store::Status status = _memcached_cache->put_implicit_registration_set(mirs, _progress_callback, 0L);
+  Store::Status status = _memcached_cache->put_implicit_registration_set(mirs, _progress_callback, 0L, nullptr);
   EXPECT_EQ(Store::Status::OK, status);
 
   delete mirs;
@@ -1359,7 +1371,7 @@ TEST_F(MemcachedCacheTest, PutIrsWithExistingRefreshed)
 
   ImplicitRegistrationSet* irs;
 
-  _memcached_cache->get_implicit_registration_set_for_impu(IMPU, 0L, irs);
+  _memcached_cache->get_implicit_registration_set_for_impu(IMPU, 0L, nullptr, irs);
 
   irs->set_ttl(2);
   irs->set_ims_sub_xml(SERVICE_PROFILE_3);
@@ -1369,7 +1381,7 @@ TEST_F(MemcachedCacheTest, PutIrsWithExistingRefreshed)
   irs->add_associated_impi(IMPI_3);
 
   EXPECT_CALL(*_mock_progress_cb, progress_callback());
-  Store::Status status = _memcached_cache->put_implicit_registration_set(irs, _progress_callback, 0L);
+  Store::Status status = _memcached_cache->put_implicit_registration_set(irs, _progress_callback, 0L, nullptr);
   EXPECT_EQ(Store::Status::OK, status);
 
   delete irs;
@@ -1385,7 +1397,7 @@ TEST_F(MemcachedCacheTest, DeleteIrsNotAdded)
   irs->set_reg_state(RegistrationState::REGISTERED);
 
   EXPECT_CALL(*_mock_progress_cb, progress_callback());
-  Store::Status status = _memcached_cache->delete_implicit_registration_set(irs, _progress_callback, 0L);
+  Store::Status status = _memcached_cache->delete_implicit_registration_set(irs, _progress_callback, 0L, nullptr);
   EXPECT_EQ(Store::Status::OK, status);
 
   delete irs;
@@ -1410,12 +1422,12 @@ TEST_F(MemcachedCacheTest, DeleteIrsAddedRemote)
 
   ImplicitRegistrationSet* irs;
 
-  _memcached_cache->get_implicit_registration_set_for_impu(IMPU, 0L, irs);
+  _memcached_cache->get_implicit_registration_set_for_impu(IMPU, 0L, nullptr, irs);
 
   std::vector<ImplicitRegistrationSet*> irss = {irs};
 
   EXPECT_CALL(*_mock_progress_cb, progress_callback());
-  Store::Status status = _memcached_cache->delete_implicit_registration_set(irs, _progress_callback, 0L);
+  Store::Status status = _memcached_cache->delete_implicit_registration_set(irs, _progress_callback, 0L, nullptr);
   EXPECT_EQ(Store::Status::OK, status);
 
   delete irs;
@@ -1440,7 +1452,7 @@ TEST_F(MemcachedCacheTest, DeleteIrsAddedLocalStoreFail)
 
   ImplicitRegistrationSet* irs;
 
-  _memcached_cache->get_implicit_registration_set_for_impu(IMPU, 0L, irs);
+  _memcached_cache->get_implicit_registration_set_for_impu(IMPU, 0L, nullptr, irs);
 
   std::vector<ImplicitRegistrationSet*> irss = {irs};
 
@@ -1448,7 +1460,7 @@ TEST_F(MemcachedCacheTest, DeleteIrsAddedLocalStoreFail)
 
   // The progress_callback is not called on error
   EXPECT_EQ(Store::Status::ERROR,
-            _memcached_cache->delete_implicit_registration_sets(irss, _progress_callback, 0L));
+            _memcached_cache->delete_implicit_registration_sets(irss, _progress_callback, 0L, nullptr));
 
   delete irs;
 }
@@ -1472,10 +1484,10 @@ TEST_F(MemcachedCacheTest, DeleteIrss)
 
   ImplicitRegistrationSet* irs;
 
-  _memcached_cache->get_implicit_registration_set_for_impu(IMPU, 0L, irs);
+  _memcached_cache->get_implicit_registration_set_for_impu(IMPU, 0L, nullptr, irs);
 
   EXPECT_CALL(*_mock_progress_cb, progress_callback());
-  Store::Status status = _memcached_cache->delete_implicit_registration_set(irs, _progress_callback, 0L);
+  Store::Status status = _memcached_cache->delete_implicit_registration_set(irs, _progress_callback, 0L, nullptr);
   EXPECT_EQ(Store::Status::OK, status);
 
   delete irs;
@@ -1503,6 +1515,7 @@ TEST_F(MemcachedCacheTest, GetIrsForImpus)
   Store::Status status =
     _memcached_cache->get_implicit_registration_sets_for_impus({IMPU},
                                                                0L,
+                                                               nullptr,
                                                                irss);
 
   EXPECT_EQ(Store::Status::OK, status);
@@ -1521,6 +1534,7 @@ TEST_F(MemcachedCacheTest, GetImsSubscriptionNotFound)
   Store::Status status =
     _memcached_cache->get_ims_subscription(IMPI,
                                            0L,
+                                           nullptr,
                                            subscription);
 
   EXPECT_EQ(Store::Status::NOT_FOUND, status);
@@ -1556,6 +1570,7 @@ TEST_F(MemcachedCacheTest, GetImsSubscriptionLocal)
   Store::Status status =
     _memcached_cache->get_ims_subscription(IMPI,
                                            0L,
+                                           nullptr,
                                            subscription);
 
   EXPECT_EQ(Store::Status::OK, status);
@@ -1593,6 +1608,7 @@ TEST_F(MemcachedCacheTest, GetImsSubscriptionRemote)
   Store::Status status =
     _memcached_cache->get_ims_subscription(IMPI,
                                            0L,
+                                           nullptr,
                                            subscription);
 
   EXPECT_EQ(Store::Status::OK, status);
@@ -1629,6 +1645,7 @@ TEST_F(MemcachedCacheTest, PutImsSubscription)
 
   _memcached_cache->get_ims_subscription(IMPI,
                                          0L,
+                                         nullptr,
                                          subscription);
 
   subscription->set_charging_addrs(CHARGING_ADDRESSES_2);
@@ -1638,7 +1655,8 @@ TEST_F(MemcachedCacheTest, PutImsSubscription)
   Store::Status status =
     _memcached_cache->put_ims_subscription(subscription,
                                            _progress_callback,
-                                           0L);
+                                           0L,
+                                           nullptr);
 
   EXPECT_EQ(Store::Status::OK, status);
 
@@ -1685,7 +1703,7 @@ TEST_F(MemcachedCacheMockStoreTest, UpdateIrsImpiMappingsDataContention)
 
   // The get fails with NOT_FOUND
   EXPECT_CALL(*_mock_store, get_impi_mapping(_, _, _)).WillOnce(Return(Store::Status::NOT_FOUND));
-  Store::Status status = _memcached_cache->update_irs_impi_mappings(mirs, 0L, _mock_store);
+  Store::Status status = _memcached_cache->update_irs_impi_mappings(mirs, 0L, _mock_store, nullptr);
   EXPECT_EQ(Store::Status::OK, status);
 
   delete mirs;
@@ -1709,7 +1727,7 @@ TEST_F(MemcachedCacheMockStoreTest, UpdateIrsImpiMappingsDataContentionError)
 
   // The get fails with ERROR
   EXPECT_CALL(*_mock_store, get_impi_mapping(_, _, _)).WillOnce(Return(Store::Status::ERROR));
-  Store::Status status = _memcached_cache->update_irs_impi_mappings(mirs, 0L, _mock_store);
+  Store::Status status = _memcached_cache->update_irs_impi_mappings(mirs, 0L, _mock_store, nullptr);
   EXPECT_EQ(Store::Status::ERROR, status);
 
   delete mirs;

--- a/src/ut/mockhsscacheprocessor.hpp
+++ b/src/ut/mockhsscacheprocessor.hpp
@@ -24,57 +24,65 @@ public:
   MOCK_METHOD0(create_implicit_registration_set,
                ImplicitRegistrationSet*());
 
-  MOCK_METHOD4(get_implicit_registration_set_for_impu,
+  MOCK_METHOD5(get_implicit_registration_set_for_impu,
                void(irs_success_callback success_cb,
                     failure_callback failure_cb,
                     std::string impu,
-                    SAS::TrailId trail));
+                    SAS::TrailId trail,
+                    Utils::StopWatch* stopwatch));
 
-  MOCK_METHOD4(get_implicit_registration_sets_for_impis,
+  MOCK_METHOD5(get_implicit_registration_sets_for_impis,
                void(irs_vector_success_callback success_cb,
                     failure_callback failure_cb,
                     std::vector<std::string> impis,
-                    SAS::TrailId trail));
+                    SAS::TrailId trail,
+                    Utils::StopWatch* stopwatch));
 
-  MOCK_METHOD4(get_implicit_registration_sets_for_impus,
+  MOCK_METHOD5(get_implicit_registration_sets_for_impus,
                void(irs_vector_success_callback success_cb,
                     failure_callback failure_cb,
                     std::vector<std::string> impus,
-                    SAS::TrailId trail));
+                    SAS::TrailId trail,
+                    Utils::StopWatch* stopwatch));
 
-  MOCK_METHOD5(put_implicit_registration_set,
+  MOCK_METHOD6(put_implicit_registration_set,
                void(void_success_cb success_cb,
                     progress_callback progress_cb,
                     failure_callback failure_cb,
                     ImplicitRegistrationSet* irs,
-                    SAS::TrailId trail));
+                    SAS::TrailId trail,
+                    Utils::StopWatch* stopwatch));
 
-  MOCK_METHOD5(delete_implicit_registration_set,
+  MOCK_METHOD6(delete_implicit_registration_set,
                void(void_success_cb success_cb,
                     progress_callback progress_cb,
                     failure_callback failure_cb,
                     ImplicitRegistrationSet* irs,
-                    SAS::TrailId trail));
+                    SAS::TrailId trail,
+                    Utils::StopWatch* stopwatch));
 
-  MOCK_METHOD5(delete_implicit_registration_sets,
+  MOCK_METHOD6(delete_implicit_registration_sets,
                void(void_success_cb success_cb,
                     progress_callback progress_cb,
                     failure_callback failure_cb,
                     std::vector<ImplicitRegistrationSet*> irss,
-                    SAS::TrailId trail));
+                    SAS::TrailId trail,
+                    Utils::StopWatch* stopwatch));
 
-  MOCK_METHOD4(get_ims_subscription,
+  MOCK_METHOD5(get_ims_subscription,
                void(ims_sub_success_cb success_cb,
                     failure_callback failure_cb,
                     std::string impi,
-                    SAS::TrailId trail));
+                    SAS::TrailId trail,
+                    Utils::StopWatch* stopwatch));
 
-  MOCK_METHOD5(put_ims_subscription,
+  MOCK_METHOD6(put_ims_subscription,
                void(void_success_cb success_cb,
                     progress_callback progress_cb,
                     failure_callback failure_cb,
                     ImsSubscription* subscription,
-                    SAS::TrailId trail));
+                    SAS::TrailId trail,
+                    Utils::StopWatch* stopwatch));
 
 };
 

--- a/src/ut/mockhssconnection.hpp
+++ b/src/ut/mockhssconnection.hpp
@@ -21,17 +21,29 @@ public:
   MockHssConnection();
   virtual ~MockHssConnection();
 
-  MOCK_METHOD3(send_multimedia_auth_request,
-               void(::HssConnection::maa_cb cb, ::HssConnection::MultimediaAuthRequest req, SAS::TrailId trail));
+  MOCK_METHOD4(send_multimedia_auth_request,
+               void(::HssConnection::maa_cb cb,
+                    ::HssConnection::MultimediaAuthRequest req,
+                    SAS::TrailId trail,
+                    Utils::StopWatch* stopwatch));
 
-  MOCK_METHOD3(send_user_auth_request,
-               void(::HssConnection::uaa_cb cb, ::HssConnection::UserAuthRequest req, SAS::TrailId trail));
+  MOCK_METHOD4(send_user_auth_request,
+               void(::HssConnection::uaa_cb cb,
+                    ::HssConnection::UserAuthRequest req,
+                    SAS::TrailId trail,
+                    Utils::StopWatch* stopwatch));
 
-  MOCK_METHOD3(send_location_info_request,
-               void(::HssConnection::lia_cb cb, ::HssConnection::LocationInfoRequest req, SAS::TrailId trail));
+  MOCK_METHOD4(send_location_info_request,
+               void(::HssConnection::lia_cb cb,
+                    ::HssConnection::LocationInfoRequest req,
+                    SAS::TrailId trail,
+                    Utils::StopWatch* stopwatch));
 
-  MOCK_METHOD3(send_server_assignment_request,
-               void(::HssConnection::saa_cb cb, ::HssConnection::ServerAssignmentRequest req, SAS::TrailId trail));
+  MOCK_METHOD4(send_server_assignment_request,
+               void(::HssConnection::saa_cb cb,
+                    ::HssConnection::ServerAssignmentRequest req,
+                    SAS::TrailId trail,
+                    Utils::StopWatch* stopwatch));
 };
 
 #endif

--- a/src/ut/mockimpustore.hpp
+++ b/src/ut/mockimpustore.hpp
@@ -24,7 +24,7 @@ public:
   MOCK_METHOD2(set_impu_without_cas, Store::Status(Impu* impu, SAS::TrailId trail));
   MOCK_METHOD2(add_impu, Store::Status(Impu* impu, SAS::TrailId trail));
   MOCK_METHOD2(set_impu, Store::Status(Impu* impu, SAS::TrailId trail));
-  MOCK_METHOD2(get_impu, Impu*(const std::string& impu, SAS::TrailId trail));
+  MOCK_METHOD3(get_impu, Store::Status(const std::string& impu, Impu*& out_impu, SAS::TrailId trail));
   MOCK_METHOD2(delete_impu, Store::Status(Impu* impu, SAS::TrailId trail));
   MOCK_METHOD2(set_impi_mapping, Store::Status(ImpiMapping* mapping, SAS::TrailId trail));
   MOCK_METHOD3(get_impi_mapping, Store::Status(const std::string impi, ImpiMapping*& out_mapping, SAS::TrailId trail));


### PR DESCRIPTION
This PR adds the ability for Homestead to pause the StopWatch on an HTTPRequest when it's performing network I/O.

To achieve this, we've had to pass the StopWatch through the `HssCacheProcessor` and `HssConnection` interfaces.

The Diameter side already tracks Diameter latency, so we just subtract this from our total latency.


The memcached side doesn't, and threading complicates it further. We use the `IOHook`s in cpp-common to register hooks that the `MemcachedStore` will call into when it starts and stops network operations.

These hooks are stored in thread_local data, and are removed when they are deleted. So we must be careful to add the hook before doing any ImpuStore operations, and remove it after we're done.

We also need to be careful not to register any hooks after we've called into any of the `progress_cb` callbacks, as the HttpHandler may have destroyed the StopWatch in response. For this reason, the `perform()` method has been tweaked to only pass the StopWatch to the action for the local store, and not the remotes.
