### PR TITLE
[Reviewer: Richard] Add memcached queue stats

### DIFF
--- a/include/hss_cache_processor.h
+++ b/include/hss_cache_processor.h
@@ -34,7 +34,8 @@ public:
   // Starts the threadpool with the required number of threads
   bool start_threads(int num_threads,
                      ExceptionHandler* exception_handler,
-                     unsigned int max_queue);
+                     unsigned int max_queue,
+                     SNMP::EventAccumulatorByScopeTable* queue_size_table);
 
   // Stops the threadpool
   void stop();

--- a/src/Makefile
+++ b/src/Makefile
@@ -58,6 +58,7 @@ homestead_SOURCES := ${COMMON_SOURCES} \
                      main.cpp \
                      snmp_counter_table.cpp \
                      snmp_event_accumulator_table.cpp \
+                     snmp_event_accumulator_by_scope_table.cpp \
                      event_statistic_accumulator.cpp \
                      snmp_cx_counter_table.cpp
 

--- a/src/hss_cache_processor.cpp
+++ b/src/hss_cache_processor.cpp
@@ -25,13 +25,15 @@ HssCacheProcessor::HssCacheProcessor(HssCache* cache) :
 
 bool HssCacheProcessor::start_threads(int num_threads,
                                       ExceptionHandler* exception_handler,
-                                      unsigned int max_queue)
+                                      unsigned int max_queue,
+                                      SNMP::EventAccumulatorByScopeTable* queue_size_table)
 {
   TRC_INFO("Starting threadpool with %d threads", num_threads);
   _thread_pool = new FunctorThreadPool(num_threads,
                                        exception_handler,
                                        exception_callback,
-                                       max_queue);
+                                       max_queue,
+                                       queue_size_table);
 
   return _thread_pool->start();
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -839,8 +839,8 @@ int main(int argc, char**argv)
                                                                          ".1.2.826.0.1.1578918.9.5.14");
   SNMP::CxCounterTable* rtr_results_table = SNMP::CxCounterTable::create("cx_rtr_results",
                                                                          ".1.2.826.0.1.1578918.9.5.15");
-  SNMP::EventAccumulatorByScopeTable* memcached_queue_size_table =
-    SNMP::EventAccumulatorByScopeTable::create("memcached_queue_size",
+  SNMP::EventAccumulatorByScopeTable* cache_queue_size_table =
+    SNMP::EventAccumulatorByScopeTable::create("cache_queue_size",
                                                ".1.2.826.0.1.1578918.9.5.16");
 
   // Must happen after all SNMP tables have been registered.
@@ -914,7 +914,7 @@ int main(int argc, char**argv)
   bool started = cache_processor->start_threads(options.cache_threads,
                                                 exception_handler,
                                                 0,
-                                                memcached_queue_size_table);
+                                                cache_queue_size_table);
   if (!started)
   {
     CL_HOMESTEAD_CACHE_INIT_FAIL.log();
@@ -1246,7 +1246,7 @@ int main(int argc, char**argv)
   delete lir_results_table; lir_results_table = NULL;
   delete ppr_results_table; ppr_results_table = NULL;
   delete rtr_results_table; rtr_results_table = NULL;
-  delete memcached_queue_size_table; memcached_queue_size_table = NULL;
+  delete cache_queue_size_table; cache_queue_size_table = NULL;
 
   delete http_stack_sig; http_stack_sig = NULL;
   delete http_stack_mgmt; http_stack_mgmt = NULL;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -840,7 +840,7 @@ int main(int argc, char**argv)
   SNMP::CxCounterTable* rtr_results_table = SNMP::CxCounterTable::create("cx_rtr_results",
                                                                          ".1.2.826.0.1.1578918.9.5.15");
   SNMP::EventAccumulatorByScopeTable* memcached_queue_size_table =
-    SNMP::EventAccumulatorByScopeTable::create("H_memcached_queue_size",
+    SNMP::EventAccumulatorByScopeTable::create("memcached_queue_size",
                                                ".1.2.826.0.1.1578918.9.5.16");
 
   // Must happen after all SNMP tables have been registered.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -839,6 +839,10 @@ int main(int argc, char**argv)
                                                                          ".1.2.826.0.1.1578918.9.5.14");
   SNMP::CxCounterTable* rtr_results_table = SNMP::CxCounterTable::create("cx_rtr_results",
                                                                          ".1.2.826.0.1.1578918.9.5.15");
+  SNMP::EventAccumulatorByScopeTable* memcached_queue_size_table =
+    SNMP::EventAccumulatorByScopeTable::create("H_memcached_queue_size",
+                                               ".1.2.826.0.1.1578918.9.5.16");
+
   // Must happen after all SNMP tables have been registered.
   init_snmp_handler_threads("homestead");
 
@@ -909,7 +913,8 @@ int main(int argc, char**argv)
   HssCacheTask::configure_cache(cache_processor);
   bool started = cache_processor->start_threads(options.cache_threads,
                                                 exception_handler,
-                                                0);
+                                                0,
+                                                memcached_queue_size_table);
   if (!started)
   {
     CL_HOMESTEAD_CACHE_INIT_FAIL.log();
@@ -1241,6 +1246,7 @@ int main(int argc, char**argv)
   delete lir_results_table; lir_results_table = NULL;
   delete ppr_results_table; ppr_results_table = NULL;
   delete rtr_results_table; rtr_results_table = NULL;
+  delete memcached_queue_size_table; memcached_queue_size_table = NULL;
 
   delete http_stack_sig; http_stack_sig = NULL;
   delete http_stack_mgmt; http_stack_mgmt = NULL;


### PR DESCRIPTION
_As discussed, we think we need this stat to help us diagnose issues, and it's a generally useful stat to track._

This PR adds a new stat to hometsead to track the size of the memcached thread pool's queue. It uses the same structure as the queue size that we track in Sprout.

`make full_test` passes, and I've live tested that we're reporting it correctly.