### PR TITLE
Return large value for timeout if entry not found

### DIFF
--- a/homestead.root/usr/share/clearwater/bin/check_cx_health.py
+++ b/homestead.root/usr/share/clearwater/bin/check_cx_health.py
@@ -143,8 +143,8 @@ def count_timeouts(table_segment_head):
         _log.debug("Got value {} for timeout OID {}.2.0".format(timeouts[0], table_segment_head))
         return int(timeouts[0])
     else:
-        _log.debug("Timeout OID {}.2.0 entry is empty, possibly homestead process is dead".format(table_segment_head))
         # return a large value as all connections may have timed out.
+        _log.debug("Timeout OID {}.2.0 entry is empty, possibly homestead process is dead".format(table_segment_head))
         return 100
 
 # Perform a single check of the statistics to determine whether the Cx Diameter

--- a/homestead.root/usr/share/clearwater/bin/check_cx_health.py
+++ b/homestead.root/usr/share/clearwater/bin/check_cx_health.py
@@ -139,9 +139,13 @@ def count_timeouts(table_segment_head):
 
     # timeouts are always at element ".2.0" below the table segment head
     timeouts = ss.get(netsnmp.VarList(netsnmp.Varbind(table_segment_head + ".2.0")))
-    _log.debug("Got value {} for timeout OID {}.2.0".format(timeouts[0], table_segment_head))
-
-    return int(timeouts[0])
+    if timeouts[0]:
+        _log.debug("Got value {} for timeout OID {}.2.0".format(timeouts[0], table_segment_head))
+        return int(timeouts[0])
+    else:
+        _log.debug("Timeout OID {}.2.0 entry is empty, possibly homestead process is dead".format(table_segment_head))
+        # return a large value as all connections may have timed out.
+        return 100
 
 # Perform a single check of the statistics to determine whether the Cx Diameter
 # stack might be broken.


### PR DESCRIPTION
The table lookup for timeouts may come back as not found for various reasons, e.g. when homestead process is killed. In such case, return a timeout value that's almost guaranteed to be higher than fault tolerance, as it's indicative that all connection attempts may have failed. 

Live tested by stopping homestead and running the script. It will have an error count of 400, and decides "All requests failing? True" if there isn't any successful connection at the same time. 