### PR TITLE
[Reviewer: Richard] Tweak to StopWatchGetImpuForImpuGR test

### DIFF
--- a/src/ut/memcachedcache_test.cpp
+++ b/src/ut/memcachedcache_test.cpp
@@ -1697,18 +1697,24 @@ private:
   MemcachedCache* _memcached_cache;
 
   // These allow us to advance time as a side effect of a mock function call
+  // They all actually pause for 5ms too, to avoid some double counting in
+  // the MemcachedCache (which we don't care about in production, as we'd rather
+  // over-count than under-count)
   static void advance_time_10_ms()
   {
+    usleep(5000);
     cwtest_advance_time_ms(10);
   }
 
   static void advance_time_25_ms()
   {
+    usleep(5000);
     cwtest_advance_time_ms(25);
   }
 
   static void advance_time_50_ms()
   {
+    usleep(5000);
     cwtest_advance_time_ms(50);
   }
 };


### PR DESCRIPTION
Just add in a small real pause each time a mock call advances time to avoid some
double-counting of time spent by our stopwatch

We don't care that we may potentially be silghtly over-counting the latency, as we schedule some work and then immediately pause the stopwatch.

However, our UTs looks for a specific time, so they are stricter about this.

Sending to you as you reviewed originally. I think we should merge this into dev/master, but shout if you disagree