### PR TITLE
[Reviewer: CJR] Homestead - Disable Clientside SAS Compression

### DIFF
--- a/src/diameter_handlers.cpp
+++ b/src/diameter_handlers.cpp
@@ -414,7 +414,7 @@ void PushProfileTask::on_get_ims_sub_success(ImsSubscription* ims_sub)
     {
       TRC_ERROR("No SIP URI in Implicit Registration Set");
       SAS::Event event(this->trail(), SASEvent::NO_SIP_URI_IN_IRS, 0);
-      event.add_compressed_param(_ims_subscription, &SASEvent::PROFILE_SERVICE_PROFILE);
+      event.add_var_param(_ims_subscription);
       SAS::report_event(event);
     }
 
@@ -450,13 +450,13 @@ void PushProfileTask::on_get_ims_sub_success(ImsSubscription* ims_sub)
   {
     // Add the impu and XMl to the SAS event
     put_cache_event.add_var_param(new_default_id);
-    put_cache_event.add_compressed_param(_ims_subscription, &SASEvent::PROFILE_SERVICE_PROFILE);
+    put_cache_event.add_var_param(_ims_subscription);
   }
   else
   {
     // Put an empty string for the impu, and note that the XML is unchanged
     put_cache_event.add_var_param("");
-    put_cache_event.add_compressed_param("IMS subscription unchanged", &SASEvent::PROFILE_SERVICE_PROFILE);
+    put_cache_event.add_var_param("IMS subscription unchanged");
   }
 
   // We now may have to update the charging addresses

--- a/src/http_handlers.cpp
+++ b/src/http_handlers.cpp
@@ -803,7 +803,7 @@ void ImpuRegDataTask::on_get_reg_data_success(ImplicitRegistrationSet* irs)
   ChargingAddresses charging_addrs = _irs->get_charging_addresses();
 
   SAS::Event event(this->trail(), SASEvent::CACHE_GET_REG_DATA_SUCCESS, 0);
-  event.add_compressed_param(service_profile, &SASEvent::PROFILE_SERVICE_PROFILE);
+  event.add_var_param(service_profile);
   event.add_static_param(reg_state);
   std::string associated_impis_str = boost::algorithm::join(associated_impis, ", ");
   event.add_var_param(associated_impis_str);
@@ -1049,7 +1049,7 @@ void ImpuRegDataTask::send_reply()
     else
     {
       SAS::Event event(this->trail(), SASEvent::REG_DATA_HSS_INVALID, 0);
-      event.add_compressed_param(_irs->get_ims_sub_xml(), &SASEvent::PROFILE_SERVICE_PROFILE);
+      event.add_var_param(_irs->get_ims_sub_xml());
       SAS::report_event(event);
     }
   }
@@ -1112,7 +1112,7 @@ void ImpuRegDataTask::put_in_cache()
         // LCOV_EXCL_START - This is essentially tested in the PPR UTs
         TRC_ERROR("No SIP URI in Implicit Registration Set");
         SAS::Event event(this->trail(), SASEvent::NO_SIP_URI_IN_IRS, 0);
-        event.add_compressed_param(_irs->get_ims_sub_xml(), &SASEvent::PROFILE_SERVICE_PROFILE);
+        event.add_var_param(_irs->get_ims_sub_xml());
         SAS::report_event(event);
         // LCOV_EXCL_STOP
       }
@@ -1122,7 +1122,7 @@ void ImpuRegDataTask::put_in_cache()
       SAS::Event event(this->trail(), SASEvent::CACHE_PUT_REG_DATA, 0);
       std::string public_ids_str = boost::algorithm::join(public_ids, ", ");
       event.add_var_param(public_ids_str);
-      event.add_compressed_param(_irs->get_ims_sub_xml(), &SASEvent::PROFILE_SERVICE_PROFILE);
+      event.add_var_param(_irs->get_ims_sub_xml());
       event.add_static_param(_irs->get_reg_state());
       std::string associated_private_ids_str = boost::algorithm::join(_irs->get_associated_impis(), ", ");
       event.add_var_param(associated_private_ids_str);


### PR DESCRIPTION
Changed all instances of `add_compressed_param `to `add_var_param`