### PR TITLE
[Reviewer: Richard] Add some virtual destructors where they're missing

### DIFF
--- a/include/diameter_hss_connection.h
+++ b/include/diameter_hss_connection.h
@@ -102,6 +102,8 @@ private:
       _stopwatch(stopwatch)
     {};
 
+    virtual ~DiameterTransaction() {};
+
   protected:
     StatsFlags _stat_updates;
     callback_t _response_clbk;
@@ -129,6 +131,7 @@ private:
     using DiameterTransaction::DiameterTransaction;
 
     virtual MultimediaAuthAnswer create_answer(Diameter::Message& rsp) override;
+    virtual ~MarDiameterTransaction() {};
   };
 
   class UarDiameterTransaction : public DiameterTransaction<UserAuthAnswer>
@@ -138,6 +141,7 @@ private:
     using DiameterTransaction::DiameterTransaction;
 
     virtual UserAuthAnswer create_answer(Diameter::Message& rsp) override;
+    virtual ~UarDiameterTransaction() {};
   };
 
   class LirDiameterTransaction : public DiameterTransaction<LocationInfoAnswer>
@@ -147,6 +151,7 @@ private:
     using DiameterTransaction::DiameterTransaction;
 
     virtual LocationInfoAnswer create_answer(Diameter::Message& rsp) override;
+    virtual ~LirDiameterTransaction() {};
   };
 
   class SarDiameterTransaction : public DiameterTransaction<ServerAssignmentAnswer>
@@ -156,6 +161,7 @@ private:
     using DiameterTransaction::DiameterTransaction;
 
     virtual ServerAssignmentAnswer create_answer(Diameter::Message& rsp) override;
+    virtual ~SarDiameterTransaction() {};
   };
 };
 

--- a/include/hsprov_hss_connection.h
+++ b/include/hsprov_hss_connection.h
@@ -63,6 +63,8 @@ public:
       _stats_manager(stats_manager)
     {};
 
+    virtual ~HsProvTransaction() {};
+
   protected:
     callback_t _response_clbk;
     StatisticsManager* _stats_manager;
@@ -92,6 +94,7 @@ public:
     using HsProvTransaction::HsProvTransaction;
 
     virtual MultimediaAuthAnswer create_answer(CassandraStore::Operation* op) override;
+    virtual ~MarHsProvTransaction() {};
   };
 
   class LirHsProvTransaction : public HsProvTransaction<LocationInfoAnswer>
@@ -101,6 +104,7 @@ public:
     using HsProvTransaction::HsProvTransaction;
 
     virtual LocationInfoAnswer create_answer(CassandraStore::Operation* op) override;
+    virtual ~LirHsProvTransaction() {};
   };
 
   class SarHsProvTransaction : public HsProvTransaction<ServerAssignmentAnswer>
@@ -110,6 +114,7 @@ public:
     using HsProvTransaction::HsProvTransaction;
 
     virtual ServerAssignmentAnswer create_answer(CassandraStore::Operation* op) override;
+    virtual ~SarHsProvTransaction() {};
   };
 
 private:

--- a/include/http_handlers.h
+++ b/include/http_handlers.h
@@ -51,6 +51,8 @@ public:
     HttpStackUtils::Task(req, trail)
   {};
 
+  virtual ~HssCacheTask() {};
+
   static void configure_hss_connection(HssConnection::HssConnection* hss,
                                        std::string server_name);
   static void configure_cache(HssCacheProcessor* cache);
@@ -122,6 +124,7 @@ public:
     ImpiTask(req, cfg, trail)
   {}
 
+  virtual ~ImpiDigestTask() {};
   bool parse_request();
   void send_reply(const DigestAuthVector& av);
   void send_reply(const AKAAuthVector& av);
@@ -137,6 +140,7 @@ public:
     ImpiTask(req, cfg, trail)
   {}
 
+  virtual ~ImpiAvTask() {};
   bool parse_request();
   void send_reply(const DigestAuthVector& av);
   void send_reply(const AKAAuthVector& av);
@@ -156,6 +160,7 @@ public:
     HssCacheTask(req, trail), _cfg(cfg), _impi(), _impu(), _visited_network(), _authorization_type(), _emergency()
   {}
 
+  virtual ~ImpiRegistrationStatusTask() {};
   void run();
   void on_uar_response(const HssConnection::UserAuthAnswer& uaa);
 
@@ -180,6 +185,7 @@ public:
     HssCacheTask(req, trail), _cfg(cfg), _impu(), _originating(), _authorization_type()
   {}
 
+  virtual ~ImpuLocationInfoTask() {};
   void run();
   void on_lir_response(const HssConnection::LocationInfoAnswer& lia);
 


### PR DESCRIPTION
As I mentioned on Friday, I spotted some subclasses that didn't have virtual destructors. Figured we should add them so that we don't get tripped up by them in the future. (I've checked that all the classes in `http_handlers.h` and `diameter_handlers.h` now have them.)