### PR TITLE
check_cx_health should wait for the process to be stable before reporting the error.

### DIFF
--- a/homestead.root/usr/share/clearwater/bin/check_cx_health
+++ b/homestead.root/usr/share/clearwater/bin/check_cx_health
@@ -6,7 +6,9 @@
 # Otherwise no rights are granted except for those provided to you by
 # Metaswitch Networks in a separate written agreement.
 
-set -ue
+# We must not `set -e` here because we check the return codes of commands
+# explicitly
+set -u
 
 . /etc/clearwater/config
 


### PR DESCRIPTION
This is a fix for: https://github.com/Metaswitch/clearwater-issues/issues/3638

We must not `set -e`, because we want to intercept the non-zero exit code that the python script returns and then possibly ignore it.

I think that we do the checks this way round so that we can report that we're ignoring the error because the process is not yet stable, so the fix I've gone for is just to ensure that we don't `set -e` at the start.

I've had a look through the other scripts that use the `monit_stability` script, and none of the others use `set -e` so I think this is the complete fix.

I've tested that this works by:

1) On a node with the original script, replacing the python call in `check_cx_health` with a call to a function that just returns 3, and verifying that I see restarts within the 20s grace period

2) Patched the script with this change, and verified that I no longer see restarts within the 20s grace period.