### PR TITLE
[Reviewer: AJH] Integrate Homestead with the new sas.json file

### DIFF
--- a/debian/homestead.init.d
+++ b/debian/homestead.init.d
@@ -69,7 +69,6 @@ setup_environment()
 get_settings()
 {
         # Set up defaults and then pull in any overrides.
-        sas_server=0.0.0.0
         hss_hostname=0.0.0.0
         signaling_dns_server=127.0.0.1
         scscf=5054
@@ -180,7 +179,7 @@ get_daemon_args()
                      --access-log=$log_directory
                      --log-file=$log_directory
                      --log-level=$log_level
-                     --sas=$sas_server,$NAME@$public_hostname"
+                     --sas=$NAME@$public_hostname"
 
         [ "$http_blacklist_duration" = "" ]     || DAEMON_ARGS="$DAEMON_ARGS --http-blacklist-duration=$http_blacklist_duration"
         [ "$diameter_blacklist_duration" = "" ] || DAEMON_ARGS="$DAEMON_ARGS --diameter-blacklist-duration=$diameter_blacklist_duration"

--- a/homestead.root/usr/share/clearwater/infrastructure/scripts/reload/sas_json/homestead_reload
+++ b/homestead.root/usr/share/clearwater/infrastructure/scripts/reload/sas_json/homestead_reload
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# @file homestead_reload
+#
+# Copyright (C) Metaswitch Networks 2018
+# If license terms are provided to you in a COPYING file in the root directory
+# of the source code repository by which you are accessing this code, then
+# the license outlined in that COPYING file applies to your use.
+# Otherwise no rights are granted except for those provided to you by
+# Metaswitch Networks in a separate written agreement.
+
+service homestead reload

--- a/src/Makefile
+++ b/src/Makefile
@@ -119,6 +119,7 @@ COMMON_LDFLAGS := -L../usr/lib \
                   -levent \
                   -lcares \
                   -lboost_regex \
+                  -lboost_thread \
                   -lboost_system \
                   -lpthread \
                   -lcurl \

--- a/src/Makefile
+++ b/src/Makefile
@@ -45,6 +45,7 @@ COMMON_SOURCES := a_record_resolver.cpp \
                   namespace_hop.cpp \
                   realmmanager.cpp \
                   saslogger.cpp \
+                  sasservice.cpp \
                   signalhandler.cpp \
                   sproutconnection.cpp \
                   statistic.cpp \

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -46,6 +46,7 @@
 #include "snmp_agent.h"
 #include "namespace_hop.h"
 #include "utils.h"
+#include "sasservice.h"
 
 struct options
 {
@@ -79,7 +80,6 @@ struct options
   int log_level;
   int cache_threads;
   int cassandra_threads;
-  std::string sas_server;
   std::string sas_system_name;
   int diameter_timeout_ms;
   int target_latency_us;
@@ -223,10 +223,8 @@ void usage(void)
        "                            String to use to specify AKA SIP-Auth-Scheme (default: Digest-AKAv1-MD5)\n"
        " -a, --access-log <directory>\n"
        "                            Generate access logs in specified directory\n"
-       "     --sas <hostname>,<system name>\n"
-       "                            Use specified host as Service Assurance Server and specified\n"
-       "                            system name to identify this system to SAS.  If this option isn't\n"
-       "                            specified SAS is disabled\n"
+       "     --sas <system name>\n"
+       "                            Use specifiedsystem name to identify this system to SAS.\n"
        "     --diameter-timeout-ms  Length of time (in ms) before timing out a Diameter request to the HSS\n"
        "     --target-latency-us <usecs>\n"
        "                            Target latency above which throttling applies (default: 100000)\n"
@@ -441,14 +439,11 @@ int init_options(int argc, char**argv, struct options& options)
         std::vector<std::string> sas_options;
         Utils::split_string(std::string(optarg), ',', sas_options, 0, false);
 
-        if ((sas_options.size() == 2) &&
-            !sas_options[0].empty() &&
-            !sas_options[1].empty())
+        if ((sas_options.size() == 1) &&
+            !sas_options[0].empty())
         {
-          options.sas_server = sas_options[0];
-          options.sas_system_name = sas_options[1];
-          TRC_INFO("SAS set to %s", options.sas_server.c_str());
-          TRC_INFO("System name is set to %s", options.sas_system_name.c_str());
+          options.sas_system_name = sas_options[0];
+          TRC_INFO("SAS system name is set to %s", options.sas_system_name.c_str());
         }
         else
         {
@@ -725,7 +720,6 @@ int main(int argc, char**argv)
   options.sprout_http_name = "sprout-http-name.unknown";
   options.log_to_file = false;
   options.log_level = 0;
-  options.sas_server = "0.0.0.0";
   options.sas_system_name = "";
   options.diameter_timeout_ms = 200;
   options.target_latency_us = 100000;
@@ -804,12 +798,6 @@ int main(int argc, char**argv)
     access_logger = new AccessLogger(options.access_log_directory);
   }
 
-  if (options.sas_server == "0.0.0.0")
-  {
-    TRC_WARNING("SAS server option was invalid or not configured - SAS is disabled");
-    CL_HOMESTEAD_INVALID_SAS_OPTION.log();
-  }
-
   // Create a DNS resolver and a SIP specific resolver.
   int af = AF_INET;
   struct in6_addr dummy_addr;
@@ -819,10 +807,13 @@ int main(int argc, char**argv)
     af = AF_INET6;
   }
 
+  // Initialise the SasService, to read the SAS config to pass into SAS::Init
+  SasService* sas_service = new SasService();
+
   SAS::init(options.sas_system_name,
             "homestead",
             SASEvent::CURRENT_RESOURCE_BUNDLE,
-            options.sas_server,
+            sas_service->get_single_sas_server(),
             sas_write,
             options.sas_signaling_if ? create_connection_in_signaling_namespace
                                      : create_connection_in_management_namespace);
@@ -1275,6 +1266,7 @@ int main(int argc, char**argv)
   delete memcached_cache; memcached_cache = nullptr;
   delete load_monitor; load_monitor = NULL;
 
+  delete sas_service; sas_service = NULL;
   SAS::term();
 
   // Delete Homestead's alarm objects

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,10 +29,6 @@
 #include "hsprov_hss_connection.h"
 #include "hsprov_store.h"
 #include "hss_cache_processor.h"
-#include "saslogger.h"
-#include "sas.h"
-#include "sasevent.h"
-#include "saslogger.h"
 #include "sproutconnection.h"
 #include "diameterresolver.h"
 #include "realmmanager.h"
@@ -436,19 +432,8 @@ int init_options(int argc, char**argv, struct options& options)
 
     case SAS_CONFIG:
       {
-        std::vector<std::string> sas_options;
-        Utils::split_string(std::string(optarg), ',', sas_options, 0, false);
-
-        if ((sas_options.size() == 1) &&
-            !sas_options[0].empty())
-        {
-          options.sas_system_name = sas_options[0];
-          TRC_INFO("SAS system name is set to %s", options.sas_system_name.c_str());
-        }
-        else
-        {
-          TRC_WARNING("Invalid --sas option: %s", optarg);
-        }
+        options.sas_system_name = std::string(optarg);
+        TRC_INFO("SAS system name is set to %s", options.sas_system_name.c_str());
       }
       break;
 
@@ -808,15 +793,7 @@ int main(int argc, char**argv)
   }
 
   // Initialise the SasService, to read the SAS config to pass into SAS::Init
-  SasService* sas_service = new SasService();
-
-  SAS::init(options.sas_system_name,
-            "homestead",
-            SASEvent::CURRENT_RESOURCE_BUNDLE,
-            sas_service->get_single_sas_server(),
-            sas_write,
-            options.sas_signaling_if ? create_connection_in_signaling_namespace
-                                     : create_connection_in_management_namespace);
+  SasService* sas_service = new SasService(options.sas_system_name, "homestead", options.sas_signaling_if);
 
   // Set up the statistics (Homestead specific and Diameter)
   snmp_setup("homestead");
@@ -1267,7 +1244,6 @@ int main(int argc, char**argv)
   delete load_monitor; load_monitor = NULL;
 
   delete sas_service; sas_service = NULL;
-  SAS::term();
 
   // Delete Homestead's alarm objects
   delete astaire_comm_monitor;


### PR DESCRIPTION
This removes the reading/passing of the `sas_server` shared_config parameter from Homestead, instead using the new SasService module (associated PR: https://github.com/Metaswitch/cpp-common/pull/770)