### PR TITLE
[Reviewer: Seb] Remove reference to retrieving all subscribers

### DIFF
--- a/docs/ManagementHttpAPI.md
+++ b/docs/ManagementHttpAPI.md
@@ -11,25 +11,3 @@ Responses:
   * 200 if successful, with an XML body as defined in the link above.
   * 502 if Homestead has been unable to contact the HSS.
   * 503 if Homestead is currently overloaded.
-
----
-
-    /impu/
-
-Make a GET request to this URL to list subscribers this Homestead knows about.
-
-Responses:
-
-  * 200 if successful, with a JSON body containing subscribers' public identities (max 1000). The subscribers are returned in an arbitrary order, and if more than 1000 subscribers are present then an arbitrary selection of them are returned. If no subscribers are present then the list of `impus` is empty.
-  
-  ```
-  {
-    "impus": [
-      "sip:bob@example.com",
-      "sip:alice@example.com",
-      "sip:caleb@example.com"
-    ]
-  }
-  ```
-  
-  * 500 if Homestead has been unable to contact Cassandra.


### PR DESCRIPTION
Seb,

As part of the memcached work, we removed the API to list all subscribers which Homestead knows about, as that's not practical on memcached.

This corrects the docs in that area.