### PR TITLE
[Reviewer: Adam] Fix logging

### DIFF
--- a/src/diameter_hss_connection.cpp
+++ b/src/diameter_hss_connection.cpp
@@ -50,7 +50,7 @@ void DiameterHssConnection::DiameterTransaction<T>::increment_results(int32_t re
 template <class AnswerType>
 void DiameterHssConnection::DiameterTransaction<AnswerType>::on_timeout()
 {
-  TRC_WARNING("Translating Diameter timeout to ResultCode::SERVER_UNAVAILABLE");
+  TRC_INFO("Diameter timeout - translating to ResultCode::SERVER_UNAVAILABLE");
 
   update_latency_stats();
 
@@ -149,7 +149,6 @@ MultimediaAuthAnswer DiameterHssConnection::MarDiameterTransaction::create_answe
   }
   else if (result_code == DIAMETER_UNABLE_TO_DELIVER)
   {
-    TRC_WARNING("Translating DIAMETER_UNABLE_TO_DELIVER to ResultCode::SERVER_UNAVAILABLE");
     rc = SERVER_UNAVAILABLE;
   }
   else if (experimental_result == DIAMETER_ERROR_USER_UNKNOWN &&
@@ -227,7 +226,6 @@ UserAuthAnswer DiameterHssConnection::UarDiameterTransaction::create_answer(Diam
   }
   else if (result_code == DIAMETER_UNABLE_TO_DELIVER)
   {
-    TRC_WARNING("Translating DIAMETER_UNABLE_TO_DELIVER to ResultCode::SERVER_UNAVAILABLE");
     rc = ResultCode::SERVER_UNAVAILABLE;
   }
   else
@@ -293,7 +291,6 @@ LocationInfoAnswer DiameterHssConnection::LirDiameterTransaction::create_answer(
   }
   else if (result_code == DIAMETER_UNABLE_TO_DELIVER)
   {
-    TRC_WARNING("Translating DIAMETER_UNABLE_TO_DELIVER to ResultCode::SERVER_UNAVAILABLE");
     rc = ResultCode::SERVER_UNAVAILABLE;
   }
   else
@@ -341,7 +338,6 @@ ServerAssignmentAnswer DiameterHssConnection::SarDiameterTransaction::create_ans
   }
   else if (result_code == DIAMETER_UNABLE_TO_DELIVER)
   {
-    TRC_WARNING("Translating DIAMETER_UNABLE_TO_DELIVER to ResultCode::SERVER_UNAVAILABLE");
     rc = ResultCode::SERVER_UNAVAILABLE;
   }
   else if ((experimental_result == DIAMETER_ERROR_USER_UNKNOWN) &&

--- a/src/http_handlers.cpp
+++ b/src/http_handlers.cpp
@@ -155,7 +155,7 @@ void ImpiTask::on_mar_response(const HssConnection::MultimediaAuthAnswer& maa)
   }
   else if (rc == HssConnection::ResultCode::TIMEOUT)
   {
-    TRC_ERROR("Timeout error at HSS when attempting MAR - reject with 504");
+    TRC_INFO("Timeout error at HSS when attempting MAR - reject with 504");
 
     // We also record a penalty for the purposes of overload control
     record_penalty();
@@ -410,7 +410,7 @@ void ImpiRegistrationStatusTask::on_uar_response(const HssConnection::UserAuthAn
   }
   else if (rc == HssConnection::ResultCode::TIMEOUT)
   {
-    TRC_ERROR("Timeout error at HSS when attempting UAR - reject with 504");
+    TRC_INFO("Timeout error at HSS when attempting UAR - reject with 504");
 
     // We also record a penalty for the purposes of overload control
     record_penalty();
@@ -526,7 +526,7 @@ void ImpuLocationInfoTask::on_lir_response(const HssConnection::LocationInfoAnsw
   }
   else if (rc == HssConnection::ResultCode::TIMEOUT)
   {
-    TRC_ERROR("Timeout error at HSS when attempting LIR - reject with 504");
+    TRC_INFO("Timeout error at HSS when attempting LIR - reject with 504");
 
     // We also record a penalty for the purposes of overload control
     record_penalty();
@@ -849,7 +849,7 @@ void ImpuRegDataTask::on_get_reg_data_failure(Store::Status rc)
   else
   {
     // Send a 504 in all other cases (the request won't be retried)
-    TRC_ERROR("Cache query failed with rc %d - reject with 504", rc);
+    TRC_DEBUG("Cache query failed with rc %d - reject with 504", rc);
     SAS::Event event(this->trail(), SASEvent::CACHE_GET_REG_DATA_FAIL, 0);
     SAS::report_event(event);
     send_http_reply(HTTP_GATEWAY_TIMEOUT);
@@ -1238,7 +1238,7 @@ void ImpuRegDataTask::on_sar_response(const HssConnection::ServerAssignmentAnswe
   }
   else if (rc == HssConnection::ResultCode::TIMEOUT)
   {
-    TRC_ERROR("Timeout error at HSS when attempting SAR - reject with 504");
+    TRC_INFO("Timeout error at HSS when attempting SAR - reject with 504");
 
     // We also record a penalty for the purposes of overload control
     record_penalty();


### PR DESCRIPTION
As per https://github.com/Metaswitch/clearwater-issues/issues/3710, a bunch of extra logging added as part of the EC2 testing was accidentally left in. This PR just downgrades/removes those as they're per-call logs.

`make` and `make full_test` both pass.