### PR TITLE
[Reviewer: Chris] Start signal handlers so we listen for SIGHUP

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -795,6 +795,9 @@ int main(int argc, char**argv)
     }
   }
 
+  // Start the signal handlers to handle signals - e.g. SIGHUP
+  start_signal_handlers();
+
   AccessLogger* access_logger = NULL;
   if (options.access_log_enabled)
   {


### PR DESCRIPTION
If we don't do this, then `sudo service homestead reload` doesn't trigger us to
reload the dns.json file.

I've tested that this works in EC2 by doing:

```
[dime-1]ubuntu:~$ sudo service homestead reload
[dime-1]ubuntu:~$ tail /var/log/homestead/homestead_current.txt
20-03-2018 11:04:47.843 UTC [7f068096f700] Status static_dns_cache.cpp:95: Loading static DNS records from /etc/clearwater/dns.json
20-03-2018 11:04:47.843 UTC [7f068096f700] Status static_dns_cache.cpp:241: Loaded 0 static DNS records from /etc/clearwater/dns.jso
```

This matches what we do in Sprout - https://github.com/Metaswitch/sprout/blob/dev/src/main.cpp#L1805-L1806